### PR TITLE
Upload model from CLI

### DIFF
--- a/garden_ai/app/main.py
+++ b/garden_ai/app/main.py
@@ -2,6 +2,7 @@ import logging
 import typer
 from garden_ai.app.garden import garden_app
 from garden_ai.app.pipeline import pipeline_app
+from garden_ai.app.model import model_app
 
 logger = logging.getLogger()
 
@@ -11,6 +12,7 @@ app = typer.Typer(no_args_is_help=True)
 # nb: subcommands are mini typer apps in their own right
 app.add_typer(garden_app)
 app.add_typer(pipeline_app)
+app.add_typer(model_app)
 
 
 @app.callback()

--- a/garden_ai/app/model.py
+++ b/garden_ai/app/model.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+from typing import Optional, List
+
+from garden_ai.client import GardenClient
+
+import typer
+import rich
+
+model_app = typer.Typer(name="model", no_args_is_help=True)
+
+
+@model_app.callback()
+def pipeline():
+    """
+    sub-commands for managing machine learning models
+    """
+    pass
+
+
+@model_app.command(no_args_is_help=True)
+def register(
+    name: str = typer.Argument(
+        None,
+        help=("The name of your model"),
+    ),
+    model_path: Path = typer.Argument(
+        None,
+        dir_okay=False,
+        file_okay=True,
+        writable=True,
+        readable=True,
+        resolve_path=True,
+        help=("The path to your model on your filesystem"),
+    ),
+    flavor: str = typer.Argument(
+        "sklearn",
+        help=(
+            "What ML library did you make the model with? "
+            "Currently we just support sklearn."
+        ),
+    ),
+    extra_pip_requirements: Optional[List[str]] = typer.Option(
+        None,
+        help=(
+            "Additonal package requirmeents. Add multiple like "
+            '--extra_pip_requirements "torch=1.3.1" --extra_pip_requirements "pandas<=1.5.0"'
+        ),
+    ),
+):
+    """Register a model in Garden. Outputs a full model identifier that you can reference in a Pipeline."""
+    if flavor != "sklearn":
+        rich.print("Sorry jk, we only support sklearn.")
+
+    client = GardenClient()
+    full_model_name = client.log_model(str(model_path), name, extra_pip_requirements)
+    rich.print(
+        f"Successfully uploaded your model! The full name to include in your pipeline is '{full_model_name}'"
+    )

--- a/garden_ai/app/model.py
+++ b/garden_ai/app/model.py
@@ -10,7 +10,7 @@ model_app = typer.Typer(name="model", no_args_is_help=True)
 
 
 @model_app.callback()
-def pipeline():
+def model():
     """
     sub-commands for managing machine learning models
     """
@@ -20,11 +20,11 @@ def pipeline():
 @model_app.command(no_args_is_help=True)
 def register(
     name: str = typer.Argument(
-        None,
+        ...,
         help=("The name of your model"),
     ),
     model_path: Path = typer.Argument(
-        None,
+        ...,
         dir_okay=False,
         file_okay=True,
         writable=True,
@@ -41,6 +41,8 @@ def register(
     ),
     extra_pip_requirements: Optional[List[str]] = typer.Option(
         None,
+        "--extra-pip-requirements",
+        "-r",
         help=(
             "Additonal package requirmeents. Add multiple like "
             '--extra_pip_requirements "torch=1.3.1" --extra_pip_requirements "pandas<=1.5.0"'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 import sys
+import os
 from typing import Tuple, Union, Any
 from collections import namedtuple
 
@@ -242,6 +243,9 @@ def test_upload_model(mocker, tmp_path):
     model_dir_path.mkdir(parents=True, exist_ok=True)
     model_path = model_dir_path / "model.pkl"
     model_path.write_text("abcd")
+
+    # Prevents ML Flow from creating directory in /tests
+    os.environ["MLFLOW_TRACKING_URI"] = str(tmp_path)
 
     MLFlowVersionResponse = namedtuple("MLFlowVersionResponse", "version")
     versions_response = [MLFlowVersionResponse("1"), MLFlowVersionResponse("0")]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,5 @@
 import sys
 import os
-from typing import Tuple, Union, Any
 from collections import namedtuple
 from typing import Any, List, Tuple, Union
 


### PR DESCRIPTION
Builds on #68. Closes #38.

Adds a `garden model register` command that allows users to upload a model from the CLI.

## Limitations
- The backend is currently set up such that the client interacts with S3 directly. So only users who can read/write directly to the artifact bucket can use this. (So basically, only usable by Garden developers at the moment.)

<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--70.org.readthedocs.build/en/70/

<!-- readthedocs-preview garden-ai end -->