### PR TITLE
Make a PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+Link to any related issues, companion PRs, or blockers. eg, `Fixes #37`
+
+## Overview
+
+A quick summary of what this PR is meant to do.
+
+## Discussion
+
+Any additional context that you think is important for reviewers or future users/contributors looking at this PR.
+
+## Testing
+
+How did you test this? If a reviewer pulled this branch down and wanted to kick the tires, how would they do so?


### PR DESCRIPTION
Look at this unstructured free text. Am I forgetting important information? What if we had a lightweight PR template that gave a little helpful nudge to PR writers but wasn't too opinionated? That would really be something.

<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--76.org.readthedocs.build/en/76/

<!-- readthedocs-preview garden-ai end -->