### PR TITLE
recreates mlflow download bug as integration test

### DIFF
--- a/garden_ai/templates/pipeline
+++ b/garden_ai/templates/pipeline
@@ -1,6 +1,5 @@
 ## THIS FILE WAS AUTOMATICALLY GENERATED ##
-from garden_ai import Pipeline, step
-from garden_ai.steps import inference_step
+from garden_ai import Pipeline, step, Model
 import typing
 
 ##################################### STEPS #####################################
@@ -13,8 +12,6 @@ Brief notes on steps (see docs for more detail):
     - steps also extract metadata from the callable, like `description` or
         `output_info` from the callable's docstring or return annotation,
         respectively.
-    - "specialized steps" like `@run_inference` are the best way to fetch a model
-        from our model registry for use in a pipeline.
     - don't use `Any` or `None` in step annotations. If a step is indeed general enough to
         accept or return any python object, prefer `object` as the annotation.
 """
@@ -34,10 +31,8 @@ def another_step(data: object) -> object:
     pass
 
 
-# specialized model-specific decorator:
-# pulls a model from the garden mlflow instance and run inference
-@inference_step(model_id=..., version=...)
-def run_inference(arg: object, model: object) -> object:
+@step
+def run_inference(arg: object, model = Model("YOUR MODEL's URI HERE")) -> object:
     pass
 
 # steps will be composed in order by the pipeline below

--- a/tests/integrations/test_mlflow.py
+++ b/tests/integrations/test_mlflow.py
@@ -1,0 +1,45 @@
+import pytest
+
+from garden_ai import GardenClient, Model
+
+
+@pytest.fixture(autouse=True)
+def do_not_set_mlflow_env_variables():
+    """overrides same fixture in ../conftest.py for this module only"""
+    return
+
+
+@pytest.fixture
+def toy_sklearn_model():
+    # import sklearn
+    from sklearn import tree
+    from sklearn.datasets import load_wine
+
+    wine = load_wine()
+    sk_model = tree.DecisionTreeClassifier().fit(wine.data, wine.target)
+    return sk_model
+
+
+@pytest.mark.integration
+def test_mlflow_register(tmp_path, toy_sklearn_model):
+    # as if model.pkl already existed on disk
+    import pickle
+
+    tmp_path.mkdir(exist_ok=True)
+    model_path = tmp_path / "model.pkl"
+    model_path.touch()
+    # model_path.parent.mkdir(exist_ok=True)
+
+    with open(model_path, "wb") as f_out:
+        pickle.dump(toy_sklearn_model, f_out)
+
+    # simulate `$ garden-ai model register test-model-name tmp_path/model.pkl`
+    name = "test-model-name"
+    extra_pip_requirements = None
+    # actually register the model
+    client = GardenClient()
+    full_model_name = client.log_model(str(model_path), name, extra_pip_requirements)
+
+    # all mlflow models will have a 'predict' method
+    downloaded_model = Model(full_model_name)
+    assert hasattr(downloaded_model, "predict")


### PR DESCRIPTION
This is the same bug that I was running into when trying to prep logan's real-world model for the 03/08/23 demo

This is a draft PR until the test passes 

to run just this test:
`$ pytest tests/integrations/test_mlflow.py` 

(note: this currently takes ~30-40 seconds on my laptop because it trains a tiny sklearn model every time)