### PR TITLE
add garden-ai prefix to CLI commands in quickstart.rst

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -16,7 +16,7 @@ If you have it, we recommend installing the CLI with `pipx`_.::
 
 You should then be able to see the following: ::
 
-    $ garden create --help
+    $ garden-ai garden create --help
 
     Usage: garden create [OPTIONS] [DIRECTORY]
 
@@ -73,7 +73,7 @@ which you can paste in your terminal window. This will generate credentials in
 your home directory, so you shouldn't need to repeat this step as the same user
 on the same computer. Here's what that might look like: ::
 
-    $ garden create --title=...  # etc
+    $ garden-ai garden create --title=...  # etc
 
     Authenticating with Globus in your default web browser:
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -18,7 +18,7 @@ You should then be able to see the following: ::
 
     $ garden-ai garden create --help
 
-    Usage: garden create [OPTIONS] [DIRECTORY]
+    Usage: garden-ai garden create [OPTIONS] [DIRECTORY]
 
     Create a new Garden
 


### PR DESCRIPTION
[Fixes #81](https://github.com/Garden-AI/garden/issues/81) 

## Overview

Minor fix to quickstart docs. The prefix ```garden-ai``` was absent from the CLI commands. Changed only in the quickstart docs, the prefix does exist appropriately when referenced in [test_mlflow.py](https://github.com/Garden-AI/garden/blob/main/tests/integrations/test_mlflow.py) and [client.py](https://github.com/Garden-AI/garden/blob/main/garden_ai/client.py).

## Discussion

A simple fix that was discussed was with @WillEngler and @OwenPriceSkelly.

## Testing

Reproducible by following the current [quickstart](https://github.com/Garden-AI/garden/blob/main/docs/quickstart.rst) as written, will not create the intended help command output.

Outcome if quickstart followed in Current state:
![image](https://user-images.githubusercontent.com/45859416/225742447-01f6412c-6cdf-41c5-9b88-4b7a1ec8c816.png)

Outcome if quickstart followed in the proposed state:
![image](https://user-images.githubusercontent.com/45859416/225742694-21fab636-2b9e-48f2-b1c1-8001a23992ac.png)





<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--83.org.readthedocs.build/en/83/

<!-- readthedocs-preview garden-ai end -->