### PR TITLE
Unified pipeline requirements

### DIFF
--- a/garden_ai/app/pipeline.py
+++ b/garden_ai/app/pipeline.py
@@ -201,8 +201,7 @@ def create(
         with open(out_file, "w") as f:
             f.write(contents)
         with open(out_dir / "requirements.txt", "w") as f:
-            lines = ["## Please specify all pipeline dependencies here"]
-            f.write(lines)
+            f.write("## Please specify all pipeline dependencies here\n")
 
         print(f"Generated pipeline scaffolding in {out_dir}.")
 

--- a/garden_ai/app/pipeline.py
+++ b/garden_ai/app/pipeline.py
@@ -8,9 +8,10 @@ from typing import List, Optional
 import jinja2
 import rich
 import typer
-from garden_ai import GardenClient, Pipeline, step
 from rich import print
 from rich.prompt import Prompt
+
+from garden_ai import GardenClient, Pipeline, step
 
 logger = logging.getLogger()
 
@@ -199,7 +200,11 @@ def create(
         contents = template_pipeline(shortname, pipeline)
         with open(out_file, "w") as f:
             f.write(contents)
-        print(f"Wrote to {out_file}.")
+        with open(out_dir / "requirements.txt", "w") as f:
+            lines = ["## Please specify all pipeline dependencies here"]
+            f.write(lines)
+
+        print(f"Generated pipeline scaffolding in {out_dir}.")
 
     if verbose:
         client.put_local_pipeline(pipeline)

--- a/garden_ai/mlmodel.py
+++ b/garden_ai/mlmodel.py
@@ -74,10 +74,9 @@ def upload_model(
 def Model(model_full_name: str) -> mlflow.pyfunc.PyFuncModel:
     """Load a registered model from Garden-AI's (MLflow) tracking server.
 
-    Tip: for large models, using this as a "default argument" in a ``@step``-decorated
-    function will trigger the download as soon as the pipeline is initialized,
-    _before_ any calls to the pipeline. (Usage elsewhere should be fine, but
-    the pipeline won't be able to download the model until is actually called)
+    Tip: This is meant to be used as a "default argument" in a
+    ``@step``-decorated function. This allows the pipeline to download the model
+    as soon as the steps are initialized, _before_ any calls to the pipeline.
 
     Example:
     --------

--- a/garden_ai/mlmodel.py
+++ b/garden_ai/mlmodel.py
@@ -1,3 +1,4 @@
+import pathlib
 import pickle
 from functools import lru_cache
 from typing import List
@@ -105,4 +106,7 @@ def Model(model_full_name: str) -> mlflow.pyfunc.PyFuncModel:
     to use this function as a default value for some keyword argument.
     """
     model_uri = f"models:/{model_full_name}"
-    return load_model(model_uri=model_uri, suppress_warnings=False, dst_path=None)
+    local_store = pathlib.Path("~/.garden/mlflow").expanduser()
+    local_store.mkdir(parents=True, exist_ok=True)
+    # don't clutter the user's current directory with mystery mlflow directories
+    return load_model(model_uri=model_uri, suppress_warnings=True, dst_path=local_store)

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import pathlib
 from datetime import datetime
 from functools import reduce
 from inspect import signature
@@ -53,6 +54,7 @@ class Pipeline:
     version: str = "0.0.1"
     year: str = Field(default_factory=lambda: str(datetime.now().year))
     tags: List[str] = Field(default_factory=list, unique_items=True)
+    requirements_file: pathlib.Path
 
     def _composed_steps(*args, **kwargs):
         """ "This method intentionally left blank"
@@ -76,6 +78,13 @@ class Pipeline:
             logger.error(e)
             raise
         return steps
+
+    @validator("requirements_file")
+    def check_exists(cls, req_file):
+        req_file = pathlib.Path(req_file)
+        if not req_file.exists():
+            raise ValueError(f"Could not find {req_file}.")
+        return req_file
 
     def register(self):
         """register this Pipeline's complete Step composition as a funcx function

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -143,7 +143,10 @@ class Pipeline:
         self.conda_dependencies = list(set(self.conda_dependencies))
         self.pip_dependencies = validate_pip_lines(list(set(self.pip_dependencies)))
 
-        if len(set(py_versions[k] for k in py_versions if py_versions[k])) > 1:
+        distinct_py_versions = set(
+            py_versions[k] for k in py_versions if py_versions[k]
+        )
+        if len(distinct_py_versions) > 1:
             logger.warning(
                 "Found multiple python versions specified across this"
                 f"pipeline's dependencies: {py_versions}. {self.python_version} "

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -23,7 +23,12 @@ from garden_ai.datacite import (
     Types,
 )
 from garden_ai.steps import DataclassConfig, Step
-from garden_ai.utils import garden_json_encoder, read_conda_deps, safe_compose
+from garden_ai.utils import (
+    garden_json_encoder,
+    read_conda_deps,
+    safe_compose,
+    validate_pip_lines,
+)
 
 logger = logging.getLogger()
 
@@ -136,7 +141,7 @@ class Pipeline:
 
         self.python_version = py_versions["pipeline"] or py_versions["system"]
         self.conda_dependencies = list(set(self.conda_dependencies))
-        self.pip_dependencies = list(set(self.pip_dependencies))
+        self.pip_dependencies = validate_pip_lines(list(set(self.pip_dependencies)))
 
         if len(set(py_versions[k] for k in py_versions if py_versions[k])) > 1:
             logger.warning(

--- a/garden_ai/steps.py
+++ b/garden_ai/steps.py
@@ -165,17 +165,9 @@ class Step:
                 uri = model.metadata.get_model_info().model_uri
                 deps_file = str(get_model_dependencies(uri, format="conda"))
                 python_version, conda_deps, pip_deps = read_conda_deps(deps_file)
-                # hack: user-dependencies like `examol @ git+https://github.com/exalearn/ExaMol.git`,
-                # which are not on pypi, should be read _before_ a line saying
-                # `examol==0.0.1` so pip won't worry that it's not on pypi, otherwise
-                # pip will claim it could not be installed.
-                #
-                # fortunately, mlflow generates the pip section of the conda.yaml files
-                # in the exact opposite order to what we'd want, so we can just reverse
-                # that list.
                 self.python_version = python_version
                 self.conda_dependencies += conda_deps
-                self.pip_dependencies += reversed(pip_deps)
+                self.pip_dependencies += pip_deps
 
         return
 

--- a/garden_ai/steps.py
+++ b/garden_ai/steps.py
@@ -7,6 +7,8 @@ from inspect import Parameter, Signature, signature
 from typing import Callable, Dict, List, Optional
 from uuid import UUID, uuid4
 
+import dparse
+from mlflow.pyfunc import PyFuncModel, get_model_dependencies
 from pydantic import Field, validator
 from pydantic.dataclasses import dataclass
 from typing_extensions import get_type_hints
@@ -122,6 +124,7 @@ class Step:
     input_info: Optional[str] = Field(None)
     output_info: Optional[str] = Field(None)
     uuid: UUID = Field(default_factory=uuid4)
+    _model_dependencies: Field(default_factory=list)
 
     def __post_init_post_parse__(self):
         # like __post_init__, but called after pydantic validation
@@ -138,11 +141,34 @@ class Step:
             self.input_info = str(input_hints)
         if self.output_info is None:
             self.output_info = f"return: {return_hint}"
+        self._infer_model_deps()
         return
 
     def __call__(self, *args, **kwargs):
         # keep it simple: just pass input the underlying callable.
         return self.func(*args, **kwargs)
+
+    def _infer_model_deps(self):
+        """
+        If this step's function has Model as a default argument, like
+        ``func(*args, model=Model(...))``, extract the dependencies for that model
+        and track them as step-level dependencies.
+        """
+        sig = signature(self.func)
+        for param in sig.parameters.values():
+            if isinstance(param.default, PyFuncModel):
+                model = param.default
+                uri = model.get_model_info().model_uri
+                deps_file = get_model_dependencies(uri, format="conda")
+                with open(deps_file, "r") as f:
+                    contents = f.read()
+                    parsed = dparse.parse(
+                        contents, path=deps_file, resolve=True
+                    ).serialize()
+                    deps = [d["line"] for d in parsed["dependencies"]]
+                    deps.extend(d["line"] for d in parsed["resolved_dependencies"])
+                self._model_dependencies += deps
+        return
 
     @validator("func")
     def has_annotations(cls, f: Callable):
@@ -217,23 +243,24 @@ def inference_step(model_uri: str, **kwargs):
 
     Example:
     --------
-    ```python
-    @inference_step(model_uri="models:/my-model/my-version")
-    def my_step(data: pd.DataFrame) -> MyResultType:
-        pass  # NOTE: leave the function body empty
+        ```python
+        @inference_step(model_uri="models:/my-model/my-version")
+        def my_step(data: pd.DataFrame) -> MyResultType:
+            pass  # NOTE: leave the function body empty
 
-    ## equivalent to:
-
-    def my_step(data: MyDataType) -> MyResultType:
-        model = garden_ai.Model("models:/my-model/my-version")
-        return model.predict(data)
-    ```
+        ## equivalent to:
+        @step
+        def my_step(
+            data: MyDataType,
+            model=garden_ai.Model("me@uni.edu-my-model/version"),
+        ) -> MyResultType:
+            return model.predict(data)
+        ```
     """
 
     def wrapper(f: Callable):
         @wraps(f)  # make sure we aren't losing signature info
-        def boilerplate(*args, **_kwargs):
-            model = Model(model_uri)
+        def boilerplate(*args, model=Model(model_uri), **_kwargs):
             return model.predict(*args)
 
         return step(boilerplate)

--- a/garden_ai/templates/pipeline
+++ b/garden_ai/templates/pipeline
@@ -1,19 +1,25 @@
 ## THIS FILE WAS AUTOMATICALLY GENERATED ##
-from garden_ai import Pipeline, step, Model
+from garden_ai import GardenClient, Model, Pipeline, step
 import typing
 
+_ = GardenClient()
 ##################################### STEPS #####################################
 """
 Brief notes on steps (see docs for more detail):
 
-    - any python callable can be made into a step by decorating it with `@step`.
-    - the callable MUST have valid type-hints for all arguments and return type.
-    - these type-hints are used to verify that the steps can be composed in a pipeline.
-    - steps also extract metadata from the callable, like `description` or
-        `output_info` from the callable's docstring or return annotation,
-        respectively.
-    - don't use `Any` or `None` in step annotations. If a step is indeed general enough to
-        accept or return any python object, prefer `object` as the annotation.
+    - you may define your pipeline using as many or as few @steps as you like.
+
+    - Any python function or callable can be made into a step by decorating it
+        with `@step`, like below.
+
+    - these functions will be composed in the pipeline (i.e. calling the pipeline
+        is equivalent to calling each step in order).
+
+    - the steps MUST have valid type-hints for all positional arguments and
+        return types.
+      - don't use `Any` or `None` in step annotations
+      - these type-hints are used to verify that steps are compatible when
+          composing (no checking at runtime)
 """
 
 # example step using the decorator:
@@ -24,18 +30,20 @@ def preprocessing_step(input_data: object) -> object:
     pass
 
 
-# metadata can also be manually specified with kwargs
-@step(input_info=..., authors=...)
+@step()
 def another_step(data: object) -> object:
     # TODO
     pass
 
 
 @step
-def run_inference(arg: object, model = Model("YOUR MODEL's URI HERE")) -> object:
+def run_inference(
+    input_arg: object,
+    model=Model("YOUR MODEL's NAME HERE"),
+) -> object:
     pass
 
-# steps will be composed in order by the pipeline below
+# the step functions will be composed in order by the pipeline:
 ALL_STEPS = (
     preprocessing_step,
     another_step,
@@ -45,6 +53,7 @@ ALL_STEPS = (
 ################################### PIPELINE ####################################
 
 {{ shortname }} = Pipeline(
+    requirements_file="./requirements.txt",
     title="{{ pipeline.title }}",
     steps=ALL_STEPS,
     authors={{ pipeline.authors }},
@@ -52,6 +61,6 @@ ALL_STEPS = (
     description="{{ pipeline.description }}",
     version="{{ pipeline.version }}",
     year={{ pipeline.year }},
-    tags= {{ pipeline.tags }},
+    tags={{ pipeline.tags }},
     uuid="{{ pipeline.uuid }}",  # WARNING: DO NOT EDIT UUID
 )

--- a/poetry.lock
+++ b/poetry.lock
@@ -714,7 +714,7 @@ files = [
 name = "dparse"
 version = "0.6.2"
 description = "A parser for Python dependency files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.5"
 files = [
@@ -724,6 +724,7 @@ files = [
 
 [package.dependencies]
 packaging = "*"
+pyyaml = {version = "*", optional = true, markers = "extra == \"conda\""}
 toml = "*"
 
 [package.extras]
@@ -2370,7 +2371,6 @@ files = [
     {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win_amd64.whl", hash = "sha256:d000f258cf42fec2b1bbf2863c61d7b8918d31ffee905da62dede869254d3b8a"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:045e0626baf1c52e5527bd5db361bc83180faaba2ff586e763d3d5982a876a9e"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_12_6_arm64.whl", hash = "sha256:721bc4ba4525f53f6a611ec0967bdcee61b31df5a56801281027a3a6d1c2daf5"},
-    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:41d0f1fa4c6830176eef5b276af04c89320ea616655d01327d5ce65e50575c94"},
     {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4b3a93bb9bc662fc1f99c5c3ea8e623d8b23ad22f861eb6fce9377ac07ad6072"},
     {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_12_0_arm64.whl", hash = "sha256:a234a20ae07e8469da311e182e70ef6b199d0fbeb6c6cc2901204dd87fb867e8"},
     {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:15910ef4f3e537eea7fe45f8a5d19997479940d9196f357152a09031c5be59f3"},
@@ -2829,30 +2829,40 @@ python-versions = ">=3.7"
 files = [
     {file = "SQLAlchemy-2.0.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6987f658389ad8bb6257db91551e7fde3e904974eef6f323856260907ef311d7"},
     {file = "SQLAlchemy-2.0.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bfcadfb8f0a9d26a76a5e2488cedd2e7cf8e70fe76d58aeb1c85eb83b33cbc5c"},
+    {file = "SQLAlchemy-2.0.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d653962da384a1d99795dbd8aac4a7516071b2f2984ed2aa25545fae670b808"},
     {file = "SQLAlchemy-2.0.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:edc16c8e24605d0a7925afaf99dbcbdc3f98a2cdda4622f1ea34482cb3b91940"},
+    {file = "SQLAlchemy-2.0.6-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:3be54b3825512b3de5698ae04bf4aad6ea60442ac0f6b91ee4b8fa4db5c2dccd"},
     {file = "SQLAlchemy-2.0.6-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1df00f280fcf7628379c6838d47ac6abd2319848cb02984af313de9243994db8"},
     {file = "SQLAlchemy-2.0.6-cp310-cp310-win32.whl", hash = "sha256:ff10ad2d74a9a79c2984a2c709943e5362a1c898d8f3414815ea57515ae80c84"},
     {file = "SQLAlchemy-2.0.6-cp310-cp310-win_amd64.whl", hash = "sha256:ca147d9cde38b481085408e1d4277ee834cb88bcc31bc01933bc6513340071bc"},
     {file = "SQLAlchemy-2.0.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2ad44f45526411bebbf427cf858955a35f3a6bfd7db8f4314b12da4c0d1a4fd2"},
     {file = "SQLAlchemy-2.0.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5c35175b74cbcfe9af077bd13e87cfab13239e075c0e1e920095082f9377f0ed"},
+    {file = "SQLAlchemy-2.0.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20f36bff3b6c9fa94e40114fda4dc5048d40fd665390f5547b456a28e8059ee8"},
     {file = "SQLAlchemy-2.0.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61abff42e44e5daf17372cb8baa90e970dc647fc5f747e2caa9f9768acf17be8"},
+    {file = "SQLAlchemy-2.0.6-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:48824b989a0e4340cd099dd4539702ddb1a5ce449f8a7355124e40a4935a95fa"},
     {file = "SQLAlchemy-2.0.6-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f47709c98544384d390aed34046f0573df5725d22861c0cd0a5c151bc22eedff"},
     {file = "SQLAlchemy-2.0.6-cp311-cp311-win32.whl", hash = "sha256:bfce790746d059af6d0bc68b578ba20d50a63c71a3db16edce7aa8eccdd73796"},
     {file = "SQLAlchemy-2.0.6-cp311-cp311-win_amd64.whl", hash = "sha256:82691d3539023c3cee5ae055c47bf873728cd6b33bfaa7b916bea5a99b92f700"},
     {file = "SQLAlchemy-2.0.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d7bd001a40997f0c9a9ac10a57663a9397959966a5a365bb24a4d1a17aa60175"},
+    {file = "SQLAlchemy-2.0.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3625a52fae744cff6f9beb6ed0775468b9eb7e6e8f6730676dfc49aa77d98b4e"},
     {file = "SQLAlchemy-2.0.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac6274dd530b684cca8cbb774e348afac6846f15d1694a56954413be6e2e8dcd"},
+    {file = "SQLAlchemy-2.0.6-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:db91fe985f2264ab49b3450ab7e2a59c34f7eaf3bf283d6b9e2f9ee02b29e533"},
     {file = "SQLAlchemy-2.0.6-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:47e96be3e8c9c0f2c71ec87599be4bb8409d61841b66964a36b2447bec510b3b"},
     {file = "SQLAlchemy-2.0.6-cp37-cp37m-win32.whl", hash = "sha256:709f1ecb5dcea59f36fa0f485e09e41ff313b2d62c83a6f99b36870b0d6e42fa"},
     {file = "SQLAlchemy-2.0.6-cp37-cp37m-win_amd64.whl", hash = "sha256:e0e270a4f5b42c67362d9c6af648cb86f6a00b20767553cfd734c914e1e2a5e0"},
     {file = "SQLAlchemy-2.0.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bea2c1341abe9bc6f30071b8ada1a3c44f24ec0fe1b9418e9c1112ed32057c9e"},
     {file = "SQLAlchemy-2.0.6-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:81d4fc8f5c966677a3a2f39eb8e496442269d8c7d285b28145f7745fcc089d63"},
+    {file = "SQLAlchemy-2.0.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7be0e6a4061d28b66ca4b4eb24558dd8c6386d3bcd2d6d7ef247be27cf1281b"},
     {file = "SQLAlchemy-2.0.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed714b864349704a7a719ec7199eec3f9cd15c190ecf6e10c34b5a0c549c5c18"},
+    {file = "SQLAlchemy-2.0.6-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:c76caced0c8e9129810895f71954c72f478e30bea7d0bba7130bade396be5048"},
     {file = "SQLAlchemy-2.0.6-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:4100c80070a66b042f1010b29b29a88d1d151c27a5e522c95ec07518b361a7a3"},
     {file = "SQLAlchemy-2.0.6-cp38-cp38-win32.whl", hash = "sha256:9310666251385e4374c6f0bae6d69e62bc422021298ceb8669bf6ff56957ff37"},
     {file = "SQLAlchemy-2.0.6-cp38-cp38-win_amd64.whl", hash = "sha256:5b067b2eaf3d97a49f3f6217981efa7b45d5726c2142f103712b020dd250fd98"},
     {file = "SQLAlchemy-2.0.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1fd154847f2c77128e16757e3fd2028151aa8208dd3b9a5978918ea786a15312"},
     {file = "SQLAlchemy-2.0.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7635cd38e3ea8522729b14451157104fce2117c44e7ba6a14684ed153d71b567"},
+    {file = "SQLAlchemy-2.0.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:483712fce53e2f7ec95ed7d106cd463f9fc122c28a7df4aaf2bc873d0d2a901f"},
     {file = "SQLAlchemy-2.0.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:778db814cc21eff200c8bd42b4ffe976fa3378d10fb84d2c164d3c6a30bb38ee"},
+    {file = "SQLAlchemy-2.0.6-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2c4c64f321080c83a3f0eed11cc9b73fe2a574f6b8339c402861274165c24cf6"},
     {file = "SQLAlchemy-2.0.6-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:bfde1d7cf8b9aa6bbd0d53946cd508d76db7689afd442e2289642cdc8908b7b7"},
     {file = "SQLAlchemy-2.0.6-cp39-cp39-win32.whl", hash = "sha256:8ef7c56c74f4420b2c4a148d2531ba7f99b946cbf438a2bbcb2435fb4938a08d"},
     {file = "SQLAlchemy-2.0.6-cp39-cp39-win_amd64.whl", hash = "sha256:224c817e880359d344a462fc4dd94a233804f371aa290b024b6b976a2f5ade36"},
@@ -2954,7 +2964,7 @@ files = [
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 files = [
@@ -3018,6 +3028,18 @@ all = ["colorama (>=0.4.3,<0.5.0)", "rich (>=10.11.0,<13.0.0)", "shellingham (>=
 dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
 doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "pillow (>=9.3.0,<10.0.0)"]
 test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.910)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<13.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.8"
+description = "Typing stubs for PyYAML"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-PyYAML-6.0.12.8.tar.gz", hash = "sha256:19304869a89d49af00be681e7b267414df213f4eb89634c4495fa62e8f942b9f"},
+    {file = "types_PyYAML-6.0.12.8-py3-none-any.whl", hash = "sha256:5314a4b2580999b2ea06b2e5f9a7763d860d6e09cdf21c0e9561daa9cbd60178"},
+]
 
 [[package]]
 name = "types-requests"
@@ -3224,4 +3246,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "29cad99c0e4665e6cbd623132b68a9417adf6d1e7a6a92cadd7ff45ad07463d5"
+content-hash = "0796e8e623c7ea488b0abffa8fa7b4b237121c10edbd20a45e0acd74b49f65cd"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3246,4 +3246,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "0796e8e623c7ea488b0abffa8fa7b4b237121c10edbd20a45e0acd74b49f65cd"
+content-hash = "0c0278029403e03ff059ffde783397e171054eee5d59a1a9430f5ab79eb6128d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ mlflow = "2.2.1"
 # Specifying a recent version of it helps avoid install issues on M1 Macs
 numba = "^0.56"
 boto3 = "^1.26.77"
+dparse = {extras = ["conda"], version = "^0.6.2"}
 
 [tool.poetry.scripts]
 garden-ai = "garden_ai.app.main:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ mlflow = "2.2.1"
 numba = "^0.56"
 boto3 = "^1.26.77"
 dparse = {extras = ["conda"], version = "^0.6.2"}
+pyyaml = "^6.0"
 
 [tool.poetry.scripts]
 garden-ai = "garden_ai.app.main:app"
@@ -38,6 +39,7 @@ flake8 = "^5.0.4"
 mypy = "^0.981"
 types-requests = "^2.20.0"
 safety = "^2.3.1"
+types-pyyaml = "^6.0.12.8"
 
 
 [tool.poetry.group.develop.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ numba = "^0.56"
 boto3 = "^1.26.77"
 dparse = {extras = ["conda"], version = "^0.6.2"}
 pyyaml = "^6.0"
+packaging = "^23.0"
 
 [tool.poetry.scripts]
 garden-ai = "garden_ai.app.main:app"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,10 @@
 import pytest
 
-from garden_ai.utils import extract_email_from_globus_jwt
+from garden_ai.utils import (
+    extract_email_from_globus_jwt,
+    validate_pip_lines,
+    InvalidRequirement,
+)
 
 
 def test_extract_email_from_globus_jwt_happy_path(identity_jwt):
@@ -13,3 +17,29 @@ def test_extract_email_from_globus_jwt_malformed(identity_jwt):
     malformed_jwt = ".".join(jwt_segments)
     with pytest.raises(Exception):
         extract_email_from_globus_jwt(malformed_jwt)
+
+
+def test_validate_pip_lines():
+    # Valid requirements
+    valid_lines = [
+        "numpy==1.21.2",
+        "pandas>=1.3.3",
+        "scipy!=1.7.2",
+        "matplotlib",
+        "package @ https://github.com/user/package/archive/v1.0.0.tar.gz",
+    ]
+
+    result = validate_pip_lines(valid_lines)
+    assert result == [
+        "package@ https://github.com/user/package/archive/v1.0.0.tar.gz",
+        "numpy==1.21.2",
+        "pandas>=1.3.3",
+        "scipy!=1.7.2",
+        "matplotlib",
+    ]
+    with pytest.raises(InvalidRequirement):
+        invalid_lines = [
+            "numpy --hash=sha256:abc",
+            "https://github.com/user/package/archive/v1.0.0.tar.gz",
+        ]
+        result = validate_pip_lines(valid_lines + invalid_lines)


### PR DESCRIPTION
Addresses #65, aiming at a smooth hand off to #39 

## Overview

This PR adds the following behavior to the initialization of pipeline/step objects:

steps now extract model-specific dependencies from any models referenced in a default argument, e.g. `@step`-decorated function like `def my_step(*arg, model=garden_ai.Model('...')): pass` will have recorded the dependencies listed in the mlflow model's conda.yml in `my_step.model_conda_dependencies` and/or `my_step.pip_dependencies`, per the `conda.yml`. Steps also track the python version for the model in `my_step.python_version`, if one is specified by the requirements file for the model.

pipelines collect any of their step-level dependencies in `pipeline.conda_dependencies` and/or or `pipeline.pip_dependencies`, as appropriate. Pipelines also include any pipeline-level dependencies found in `pipeline.requirements_file`, depending on the extension of `pipeline.requirements_file`. 

Pipelines also have a `pipeline.python_version` attribute for the container spec, which is either set explicitly in the constructor or inferred from `sys.version_info`. If versions conflict a warning is logged, but no exceptions are thrown.


## Discussion
- for #39 : 
  `ContainerSpec(..., pip=pipeline.pip_dependencies, conda=pipeline.conda_dependencies, python_version=pipeline.python_version)`

## Testing
unit tests included, plus some manual testing (and debugging) with Logan's real model with a real non-pypi dependency 
<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--84.org.readthedocs.build/en/84/

<!-- readthedocs-preview garden-ai end -->