### PR TITLE
Add GardenClient method that builds a container with ContainerService

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,1 @@
+# This file exists so that the pipeline in toy_example.py works

--- a/examples/toy_example.py
+++ b/examples/toy_example.py
@@ -1,5 +1,6 @@
 from garden_ai import GardenClient, step, Pipeline, Garden
 from typing import List
+import os
 
 
 client = GardenClient()
@@ -67,18 +68,21 @@ pea_edibility_pipeline = Pipeline(
     title="Concept: a pipeline for soup",
     steps=(split_peas, make_soup, rate_soup),
     authors=pea_garden.authors,
+    requirements_file=os.path.dirname(os.path.abspath(__file__)) + "/requirements.txt",
 )
 
 # the complete pipeline is now also callable by itself
 assert pea_edibility_pipeline([1, 2, 3]) == 10 / 10
 
-pea_garden.pipelines += [pea_edibility_pipeline]
 
-# writes complete metadata.json to current working directory
-client.register_metadata(pea_garden)
+def publish_garden():
+    pea_garden.pipelines += [pea_edibility_pipeline]
 
-# publishes metadata to search index
-result = client.publish_garden(pea_garden, ["public"])
+    # writes complete metadata.json to current working directory
+    client.register_metadata(pea_garden)
 
-# propagates any authors of steps/pipelines as "contributors"
-assert "Sister Constance" in pea_garden.contributors
+    # publishes metadata to search index
+    result = client.publish_garden(pea_garden, ["public"])
+
+    # propagates any authors of steps/pipelines as "contributors"
+    assert "Sister Constance" in pea_garden.contributors

--- a/examples/toy_example.py
+++ b/examples/toy_example.py
@@ -83,6 +83,7 @@ def publish_garden():
 
     # publishes metadata to search index
     result = client.publish_garden(pea_garden, ["public"])
+    print(result)
 
     # propagates any authors of steps/pipelines as "contributors"
     assert "Sister Constance" in pea_garden.contributors

--- a/garden_ai/app/console.py
+++ b/garden_ai/app/console.py
@@ -1,0 +1,3 @@
+from rich.console import Console
+
+console = Console()

--- a/garden_ai/app/pipeline.py
+++ b/garden_ai/app/pipeline.py
@@ -219,7 +219,7 @@ def register():
     client = GardenClient()
     # TODO: Some code that makes a Pipeline object from the pipeline the user specifies.
     # For now, only peas.
-    from examples.toy_example import pea_edibility_pipeline
+    from examples.toy_example import pea_edibility_pipeline  # type: ignore
 
     with console.status(
         "[bold green]Building container. This operation times out after 30 minutes."

--- a/garden_ai/app/pipeline.py
+++ b/garden_ai/app/pipeline.py
@@ -12,6 +12,7 @@ from rich import print
 from rich.prompt import Prompt
 
 from garden_ai import GardenClient, Pipeline, step
+from garden_ai.app.console import console
 
 logger = logging.getLogger()
 
@@ -211,3 +212,17 @@ def create(
         rich.print_json(metadata)
 
     return
+
+
+@pipeline_app.command(no_args_is_help=False)
+def register():
+    client = GardenClient()
+    # TODO: Some code that makes a Pipeline object from the pipeline the user specifies.
+    # For now, only peas.
+    from examples.toy_example import pea_edibility_pipeline
+
+    with console.status(
+        "[bold green]Building container. This operation times out after 30 minutes."
+    ):
+        container_uuid = client.build_container(pea_edibility_pipeline)
+    console.print(f"Created container {container_uuid}")

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -125,9 +125,7 @@ class GardenClient:
         }
         funcx_login_manager = FuncXLoginManager(scope_to_authorizer)
         return FuncXClient(
-            login_manager=funcx_login_manager,
-            do_version_check=False,
-            environment="dev"
+            login_manager=funcx_login_manager, do_version_check=False, environment="dev"
         )
 
     def _do_login_flow(self):

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -312,7 +312,7 @@ class GardenClient:
         else:
             return doi
 
-    def _build_container(self, pipeline: Pipeline) -> str:
+    def build_container(self, pipeline: Pipeline) -> str:
         built_container_uuid = build_container(self.funcx_client, pipeline)
         return built_container_uuid
 

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 import requests
 import typer
-from funcx import FuncXClient  # type: ignore
+from funcx import FuncXClient, ContainerSpec  # type: ignore
 from globus_sdk import (
     AuthAPIError,
     AuthClient,
@@ -33,6 +33,7 @@ from garden_ai.mlflow_bandaid.binary_header_provider import (
 )
 from mlflow.tracking.request_header.registry import _request_header_provider_registry  # type: ignore
 from garden_ai.globus_compute.login_manager import FuncXLoginManager
+from garden_ai.globus_compute.containers import build_container
 from globus_sdk.scopes import AuthScopes, SearchScopes
 
 # garden-dev index
@@ -123,7 +124,11 @@ class GardenClient:
             FuncXClient.FUNCX_SCOPE: self.funcx_authorizer,
         }
         funcx_login_manager = FuncXLoginManager(scope_to_authorizer)
-        return FuncXClient(login_manager=funcx_login_manager, do_version_check=False)
+        return FuncXClient(
+            login_manager=funcx_login_manager,
+            do_version_check=False,
+            environment="dev"
+        )
 
     def _do_login_flow(self):
         self.auth_client.oauth2_start_flow(
@@ -308,6 +313,10 @@ class GardenClient:
             raise
         else:
             return doi
+
+    def _build_container(self, pipeline: Pipeline) -> str:
+        built_container_uuid = build_container(self.funcx_client, pipeline)
+        return built_container_uuid
 
     def register_metadata(self, garden: Garden, out_dir=None):
         """

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 import requests
 import typer
-from funcx import FuncXClient, ContainerSpec  # type: ignore
+from funcx import FuncXClient  # type: ignore
 from globus_sdk import (
     AuthAPIError,
     AuthClient,

--- a/garden_ai/globus_compute/containers.py
+++ b/garden_ai/globus_compute/containers.py
@@ -1,14 +1,12 @@
 from time import sleep
 from enum import Enum
 from rich.console import Console
-import logging
 
 from funcx import FuncXClient, ContainerSpec  # type: ignore
 from globus_sdk import GlobusAPIError
 from garden_ai.pipelines import Pipeline
 
 console = Console()
-logger = logging.getLogger()
 
 
 class ContainerBuildException(Exception):
@@ -61,7 +59,6 @@ def poll_until_container_is_built(funcx_client, container_uuid):
                 raise ContainerBuildException(
                     "Lost connection with Container Service during build"
                 ) from e
-            logger.debug(f"status is {status}")
             # Update the end user twice a minute
             if i % 30 == 0:
                 console.log(f"Current status is {status}")

--- a/garden_ai/globus_compute/containers.py
+++ b/garden_ai/globus_compute/containers.py
@@ -18,10 +18,10 @@ class ContainerBuildException(Exception):
 
 
 class BuildStatus(str, Enum):
-    queued = 'queued'
-    building = 'building'
-    ready = 'ready'
-    failed = 'failed'
+    queued = "queued"
+    building = "building"
+    ready = "ready"
+    failed = "failed"
 
 
 def build_container(funcx_client: FuncXClient, pipeline: Pipeline) -> str:
@@ -36,7 +36,9 @@ def build_container(funcx_client: FuncXClient, pipeline: Pipeline) -> str:
     try:
         container_uuid = funcx_client.build_container(cs)
     except Exception as e:
-        raise ContainerBuildException("Could not submit build request to Container Service") from e
+        raise ContainerBuildException(
+            "Could not submit build request to Container Service"
+        ) from e
 
     poll_until_container_is_built(funcx_client, container_uuid)
     return container_uuid
@@ -49,12 +51,16 @@ def poll_until_container_is_built(funcx_client, container_uuid):
     """
     timeout_at = 1800
     i = 0
-    with console.status("[bold green]Building container. This operation times out after 30 minutes.") as status:
+    with console.status(
+        "[bold green]Building container. This operation times out after 30 minutes."
+    ) as status:
         while i < timeout_at:
             try:
                 status = funcx_client.get_container_build_status(container_uuid)
             except GlobusAPIError as e:
-                raise ContainerBuildException("Lost connection with Container Service during build") from e
+                raise ContainerBuildException(
+                    "Lost connection with Container Service during build"
+                ) from e
             logger.debug(f"status is {status}")
             # Update the end user twice a minute
             if i % 30 == 0:
@@ -64,12 +70,20 @@ def poll_until_container_is_built(funcx_client, container_uuid):
             sleep(5)
             i += 5
         else:
-            raise ContainerBuildException(f"Container Build Timeout after {timeout_at} seconds")
+            raise ContainerBuildException(
+                f"Container Build Timeout after {timeout_at} seconds"
+            )
 
     if status == BuildStatus.failed:
         try:
-            build_result = funcx_client.get_container(container_uuid, container_type="docker")
+            build_result = funcx_client.get_container(
+                container_uuid, container_type="docker"
+            )
         except GlobusAPIError as e:
-            raise ContainerBuildException("ContainerService build failed. Could not retrieve error reason.") from e
-        error_message = build_result['build_stderr']
-        raise ContainerBuildException("ContainerService build failed. Build error message:\n" + error_message)
+            raise ContainerBuildException(
+                "ContainerService build failed. Could not retrieve error reason."
+            ) from e
+        error_message = build_result["build_stderr"]
+        raise ContainerBuildException(
+            "ContainerService build failed. Build error message:\n" + error_message
+        )

--- a/garden_ai/globus_compute/containers.py
+++ b/garden_ai/globus_compute/containers.py
@@ -26,9 +26,9 @@ def build_container(funcx_client: FuncXClient, pipeline: Pipeline) -> str:
     name = str(pipeline.uuid)
     cs = ContainerSpec(
         name=name,
-        pip=[],  # pipeline.pip_requirements,
-        python_version="3.7",  # pipeline.python_version,
-        conda=[],  # pipeline.conda_requirements,
+        pip=pipeline.pip_dependencies,
+        python_version=pipeline.python_version,
+        conda=pipeline.conda_dependencies,
     )
 
     try:

--- a/garden_ai/globus_compute/containers.py
+++ b/garden_ai/globus_compute/containers.py
@@ -1,0 +1,75 @@
+from time import sleep
+from enum import Enum
+from rich.console import Console
+import logging
+
+from funcx import FuncXClient, ContainerSpec  # type: ignore
+from globus_sdk import GlobusAPIError
+from garden_ai.pipelines import Pipeline
+
+console = Console()
+logger = logging.getLogger()
+
+
+class ContainerBuildException(Exception):
+    """Exception raised when a container build request fails"""
+
+    pass
+
+
+class BuildStatus(str, Enum):
+    queued = 'queued'
+    building = 'building'
+    ready = 'ready'
+    failed = 'failed'
+
+
+def build_container(funcx_client: FuncXClient, pipeline: Pipeline) -> str:
+    name = str(pipeline.uuid)
+    cs = ContainerSpec(
+        name=name,
+        pip=[],  # pipeline.pip_requirements,
+        python_version="3.7",  # pipeline.python_version,
+        conda=[],  # pipeline.conda_requirements,
+    )
+
+    try:
+        container_uuid = funcx_client.build_container(cs)
+    except Exception as e:
+        raise ContainerBuildException("Could not submit build request to Container Service") from e
+
+    poll_until_container_is_built(funcx_client, container_uuid)
+    return container_uuid
+
+
+def poll_until_container_is_built(funcx_client, container_uuid):
+    """
+    Given a uuid of a container, blocks until that container is built.
+    Prints a cool status indicator to the console while polling.
+    """
+    timeout_at = 1800
+    i = 0
+    with console.status("[bold green]Building container. This operation times out after 30 minutes.") as status:
+        while i < timeout_at:
+            try:
+                status = funcx_client.get_container_build_status(container_uuid)
+            except GlobusAPIError as e:
+                raise ContainerBuildException("Lost connection with Container Service during build") from e
+            logger.debug(f"status is {status}")
+            # Update the end user twice a minute
+            if i % 30 == 0:
+                console.log(f"Current status is {status}")
+            if status in [BuildStatus.ready, BuildStatus.failed]:
+                break
+            sleep(5)
+            i += 5
+        else:
+            raise ContainerBuildException(f"Container Build Timeout after {timeout_at} seconds")
+
+    if status == BuildStatus.failed:
+        try:
+            build_result = funcx_client.get_container(container_uuid, container_type="docker")
+        except GlobusAPIError as e:
+            raise ContainerBuildException("ContainerService build failed. Could not retrieve error reason.") from e
+        error_message = build_result['build_stderr']
+        raise ContainerBuildException("ContainerService build failed. Build error message:\n" + error_message)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,9 +95,7 @@ def funcx_client(mocker):
     mock_funcx_client.build_container = mocker.Mock(
         return_value="d1fc6d30-be1c-4ac4-a289-d87b27e84357"
     )
-    mock_funcx_client.get_container_build_status = mocker.Mock(
-        return_value="ready"
-    )
+    mock_funcx_client.get_container_build_status = mocker.Mock(return_value="ready")
     return mock_funcx_client
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from mlflow.pyfunc import PyFuncModel  # type: ignore
 
 import garden_ai
 from garden_ai import Garden, GardenClient, Pipeline, step
+from funcx import FuncXClient  # type: ignore
 
 
 @pytest.fixture(autouse=True)
@@ -86,6 +87,18 @@ def garden_client(mocker, mock_authorizer_tuple, mock_keystore, token, identity_
     # Call the Garden constructor
     gc = GardenClient(auth_client=mock_auth_client, search_client=mock_search_client)
     return gc
+
+
+@pytest.fixture
+def funcx_client(mocker):
+    mock_funcx_client = mocker.MagicMock(FuncXClient)
+    mock_funcx_client.build_container = mocker.Mock(
+        return_value="d1fc6d30-be1c-4ac4-a289-d87b27e84357"
+    )
+    mock_funcx_client.get_container_build_status = mocker.Mock(
+        return_value="ready"
+    )
+    return mock_funcx_client
 
 
 @pytest.fixture

--- a/tests/integrations/test_container_build.py
+++ b/tests/integrations/test_container_build.py
@@ -6,4 +6,4 @@ from garden_ai import GardenClient
 @pytest.mark.integration
 def test_container_build(pipeline_toy_example):
     gc = GardenClient()
-    gc._build_container(pipeline_toy_example)
+    gc.build_container(pipeline_toy_example)

--- a/tests/integrations/test_container_build.py
+++ b/tests/integrations/test_container_build.py
@@ -1,0 +1,9 @@
+import pytest
+
+from garden_ai import GardenClient
+
+
+@pytest.mark.integration
+def test_container_build(pipeline_toy_example):
+    gc = GardenClient()
+    gc._build_container(pipeline_toy_example)

--- a/tests/test_globus_compute.py
+++ b/tests/test_globus_compute.py
@@ -1,0 +1,24 @@
+import pytest
+
+from garden_ai.globus_compute.containers import build_container, ContainerBuildException
+
+
+def test_build_container_happy_path(funcx_client, pipeline_toy_example):
+    container_uuid = build_container(funcx_client, pipeline_toy_example)
+    assert container_uuid == "d1fc6d30-be1c-4ac4-a289-d87b27e84357"
+
+
+def test_build_container_where_build_fails(funcx_client, pipeline_toy_example, mocker):
+    funcx_client.get_container_build_status = mocker.Mock(
+        return_value="failed"
+    )
+    with pytest.raises(ContainerBuildException):
+        build_container(funcx_client, pipeline_toy_example)
+
+
+def test_build_container_with_container_request_error(funcx_client, pipeline_toy_example, mocker):
+    mock_exception = mocker.MagicMock(Exception)
+    mocker.patch("garden_ai.globus_compute.containers.GlobusAPIError", new=mock_exception)
+    funcx_client.build_container.side_effect = mock_exception
+    with pytest.raises(ContainerBuildException):
+        build_container(funcx_client, pipeline_toy_example)

--- a/tests/test_globus_compute.py
+++ b/tests/test_globus_compute.py
@@ -17,10 +17,12 @@ def test_build_container_where_build_fails(funcx_client, pipeline_toy_example, m
 def test_build_container_with_container_request_error(
     funcx_client, pipeline_toy_example, mocker
 ):
-    mock_exception = mocker.MagicMock(Exception)
+    class MockException(Exception):
+        pass
+
     mocker.patch(
-        "garden_ai.globus_compute.containers.GlobusAPIError", new=mock_exception
+        "garden_ai.globus_compute.containers.GlobusAPIError", new=MockException
     )
-    funcx_client.build_container.side_effect = mock_exception
+    funcx_client.build_container.side_effect = MockException
     with pytest.raises(ContainerBuildException):
         build_container(funcx_client, pipeline_toy_example)

--- a/tests/test_globus_compute.py
+++ b/tests/test_globus_compute.py
@@ -9,16 +9,18 @@ def test_build_container_happy_path(funcx_client, pipeline_toy_example):
 
 
 def test_build_container_where_build_fails(funcx_client, pipeline_toy_example, mocker):
-    funcx_client.get_container_build_status = mocker.Mock(
-        return_value="failed"
-    )
+    funcx_client.get_container_build_status = mocker.Mock(return_value="failed")
     with pytest.raises(ContainerBuildException):
         build_container(funcx_client, pipeline_toy_example)
 
 
-def test_build_container_with_container_request_error(funcx_client, pipeline_toy_example, mocker):
+def test_build_container_with_container_request_error(
+    funcx_client, pipeline_toy_example, mocker
+):
     mock_exception = mocker.MagicMock(Exception)
-    mocker.patch("garden_ai.globus_compute.containers.GlobusAPIError", new=mock_exception)
+    mocker.patch(
+        "garden_ai.globus_compute.containers.GlobusAPIError", new=mock_exception
+    )
     funcx_client.build_container.side_effect = mock_exception
     with pytest.raises(ContainerBuildException):
         build_container(funcx_client, pipeline_toy_example)


### PR DESCRIPTION
Implements #39 

## Overview

Adds a client method that we can use to build a container in the pipeline registration flow.

## Discussion



## Testing

Added unit tests and an integration test. Also I made a little dummy cli wrapper not included in this PR to check the pretty status indicator. That code isn't in this PR, but here is what the status indicator looks like. (The dots spin around ✨)

<img width="550" alt="Screenshot 2023-03-22 at 1 12 54 PM" src="https://user-images.githubusercontent.com/6283143/226999141-5958f99a-f1b0-406b-93a7-205faa77ff5d.png">


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--89.org.readthedocs.build/en/89/

<!-- readthedocs-preview garden-ai end -->