### PR TITLE
fix: make `pipeline.requirements_file` optional

### DIFF
--- a/garden_ai/templates/pipeline
+++ b/garden_ai/templates/pipeline
@@ -50,12 +50,15 @@ ALL_STEPS = (
     run_inference,
 )
 
+REQUIREMENTS_FILE = None  # to specify additional dependencies, replace `None`
+                          # with an "/absolute/path/to/requirements.txt"
+
 ################################### PIPELINE ####################################
 
 {{ shortname }} = Pipeline(
-    requirements_file="./requirements.txt",
     title="{{ pipeline.title }}",
     steps=ALL_STEPS,
+    requirements_file=REQUIREMENTS_FILE,
     authors={{ pipeline.authors }},
     contributors={{ pipeline.contributors }},
     description="{{ pipeline.description }}",


### PR DESCRIPTION
small fix in anticipation of #51.

makes pipeline's requirements_file attribute optional, with a default value of `None` (from `"./requirements.txt"`)

updates the pipeline template with instructions for specifying a requirements file, including important note that the path must be an absolute path (a possible future improvement could be to relax this constraint)

updates pipeline validators to handle `None` as a requirements file gracefully

## Overview

Fixes issue where pipelines could not be created by the CLI due to lacking a real requirements file, despite a requirements file not being necessary yet (if at all)

## Discussion

This fix is not a hack; the issue just prompted the realization that this attribute should have been optional all along (was only implemented recently in #65)

## Testing

using `importlib` in a repl to import demo pipeline code programmatically, along the same lines as the snippet @WillEngler sent me when trying to implement the actual behavior in #51 


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--92.org.readthedocs.build/en/92/

<!-- readthedocs-preview garden-ai end -->