### PR TITLE
93 lazy download models

### DIFF
--- a/garden_ai/mlmodel.py
+++ b/garden_ai/mlmodel.py
@@ -5,7 +5,7 @@ from typing import List
 
 import mlflow  # type: ignore
 from mlflow.pyfunc import load_model  # type: ignore
-from utils.misc import read_conda_deps
+from garden_ai.utils.misc import read_conda_deps
 
 
 class ModelUploadException(Exception):

--- a/garden_ai/steps.py
+++ b/garden_ai/steps.py
@@ -7,13 +7,11 @@ from inspect import Parameter, Signature, signature
 from typing import Callable, Dict, List, Optional
 from uuid import UUID, uuid4
 
-from mlflow.pyfunc import PyFuncModel, get_model_dependencies  # type: ignore
 from pydantic import Field, validator
 from pydantic.dataclasses import dataclass
 from typing_extensions import get_type_hints
-from garden_ai.utils.misc import read_conda_deps
 
-from garden_ai.mlmodel import Model
+from garden_ai.mlmodel import Model, _Model
 
 logger = logging.getLogger()
 
@@ -160,15 +158,11 @@ class Step:
 
         sig = signature(self.func)
         for param in sig.parameters.values():
-            if isinstance(param.default, PyFuncModel):
+            if isinstance(param.default, _Model):
                 model = param.default
-                uri = model.metadata.get_model_info().model_uri
-                deps_file = str(get_model_dependencies(uri, format="conda"))
-                python_version, conda_deps, pip_deps = read_conda_deps(deps_file)
-                self.python_version = python_version
-                self.conda_dependencies += conda_deps
-                self.pip_dependencies += pip_deps
-
+                self.python_version = model.python_version
+                self.conda_dependencies += model.conda_dependencies
+                self.pip_dependencies += model.pip_dependencies
         return
 
     @validator("func")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,13 @@
 from typing import List
 
-import mlflow  # type: ignore
 import pytest
+from funcx import FuncXClient  # type: ignore
 from globus_sdk import AuthClient, OAuthTokenResponse, SearchClient
 from globus_sdk.tokenstorage import SimpleJSONFileAdapter
 from mlflow.pyfunc import PyFuncModel  # type: ignore
 
 import garden_ai
 from garden_ai import Garden, GardenClient, Pipeline, step
-from funcx import FuncXClient  # type: ignore
 
 
 @pytest.fixture(autouse=True)
@@ -203,17 +202,10 @@ def tmp_conda_yml(tmp_path):
 @pytest.fixture
 def step_with_model(mocker, tmp_conda_yml):
     mock_model = mocker.MagicMock(PyFuncModel)
-    mock_uri = "models:/email@addr.ess-fake-model/fake-version"
-
-    mock_model_info = mocker.Mock(mlflow.models.model.ModelInfo)
-    mock_model_info.model_uri = mock_uri
-
-    mock_model.get_model_info = mocker.Mock()
-    mock_model.get_model_info.return_value = mock_model_info
-
     mocker.patch("garden_ai.mlmodel.load_model").return_value = mock_model
-
-    mocker.patch("garden_ai.steps.get_model_dependencies").return_value = tmp_conda_yml
+    mocker.patch(
+        "garden_ai.mlmodel.mlflow.pyfunc.get_model_dependencies"
+    ).return_value = tmp_conda_yml
 
     @step
     def uses_model_in_default(


### PR DESCRIPTION
Fixes #93 
## Overview

- when we register with funcx and serialize the function object, we also serialize any objects included in the default argument list. 
- This meant that we were accidentally including the entire model implicitly (in the form of a large `mlflow.pyfunc.PyFuncModel` object) when we registered a pipeline containing it.
- Now, the object implicitly serialized (a new `garden_ai.mlmodel._Model` object) is *much* smaller because it waits to load an underlying `mlflow.pyfunc.PyFuncModel` until it's actually necessary to make a prediction -- i.e. the pipeline is actually running.

## Discussion

More details in #93 

## Testing

Just needed to update the fixtures included earlier 


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--95.org.readthedocs.build/en/95/

<!-- readthedocs-preview garden-ai end -->