### PR TITLE
Tensor & PyTorch support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 /.dir-locals.el
 /.DS_Store
 /.github/.DS_Store
+.vscode/settings.json

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -16,7 +16,7 @@ If you have it, we recommend installing the CLI with `pipx`_.::
 
 You should then be able to see the following: ::
 
-    $ garden create --help
+    $ garden-ai garden create --help
 
     Usage: garden create [OPTIONS] [DIRECTORY]
 
@@ -73,7 +73,7 @@ which you can paste in your terminal window. This will generate credentials in
 your home directory, so you shouldn't need to repeat this step as the same user
 on the same computer. Here's what that might look like: ::
 
-    $ garden create --title=...  # etc
+    $ garden-ai garden create --title=...  # etc
 
     Authenticating with Globus in your default web browser:
 

--- a/garden_ai/app/model.py
+++ b/garden_ai/app/model.py
@@ -36,7 +36,7 @@ def register(
         "sklearn",
         help=(
             "What ML library did you make the model with? "
-            "Currently we just support sklearn."
+            "Currently we support the following flavors 'sklearn', 'tensorflow', and 'pytorch'."
         ),
     ),
     extra_pip_requirements: Optional[List[str]] = typer.Option(
@@ -45,16 +45,20 @@ def register(
         "-r",
         help=(
             "Additonal package requirmeents. Add multiple like "
-            '--extra_pip_requirements "torch=1.3.1" --extra_pip_requirements "pandas<=1.5.0"'
+            '--extra-pip-requirements "torch=1.3.1" --extra-pip-requirements "pandas<=1.5.0"'
         ),
     ),
 ):
     """Register a model in Garden. Outputs a full model identifier that you can reference in a Pipeline."""
-    if flavor != "sklearn":
-        rich.print("Sorry jk, we only support sklearn.")
+    if flavor not in ["sklearn", "tensorflow", "pytorch"]:
+        rich.print(
+            f"Sorry, we only support 'sklearn', 'tensorflow', and 'pytorch'. The {flavor} is not yet supported."
+        )
 
     client = GardenClient()
-    full_model_name = client.log_model(str(model_path), name, extra_pip_requirements)
+    full_model_name = client.log_model(
+        str(model_path), name, flavor, extra_pip_requirements
+    )
     rich.print(
         f"Successfully uploaded your model! The full name to include in your pipeline is '{full_model_name}'"
     )

--- a/garden_ai/app/model.py
+++ b/garden_ai/app/model.py
@@ -25,7 +25,7 @@ def register(
     ),
     model_path: Path = typer.Argument(
         ...,
-        dir_okay=False,
+        dir_okay=True,
         file_okay=True,
         writable=True,
         readable=True,
@@ -51,7 +51,7 @@ def register(
 ):
     """Register a model in Garden. Outputs a full model identifier that you can reference in a Pipeline."""
     if flavor not in ["sklearn", "tensorflow", "pytorch"]:
-        rich.print(
+        raise typer.BadParameter(
             f"Sorry, we only support 'sklearn', 'tensorflow', and 'pytorch'. The {flavor} flavor is not yet supported."
         )
 

--- a/garden_ai/app/model.py
+++ b/garden_ai/app/model.py
@@ -25,6 +25,7 @@ def register(
     ),
     model_path: Path = typer.Argument(
         ...,
+        exists=True,
         dir_okay=True,
         file_okay=True,
         writable=True,

--- a/garden_ai/app/model.py
+++ b/garden_ai/app/model.py
@@ -52,7 +52,7 @@ def register(
     """Register a model in Garden. Outputs a full model identifier that you can reference in a Pipeline."""
     if flavor not in ["sklearn", "tensorflow", "pytorch"]:
         rich.print(
-            f"Sorry, we only support 'sklearn', 'tensorflow', and 'pytorch'. The {flavor} is not yet supported."
+            f"Sorry, we only support 'sklearn', 'tensorflow', and 'pytorch'. The {flavor} flavor is not yet supported."
         )
 
     client = GardenClient()

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -225,11 +225,19 @@ class GardenClient:
         return Pipeline(**data)
 
     def log_model(
-        self, model_path: str, model_name: str, extra_pip_requirements: List[str] = None
+        self,
+        model_path: str,
+        model_name: str,
+        flavor: str,
+        extra_pip_requirements: List[str] = None,
     ) -> str:
         email = self._get_user_email()
         full_model_name = upload_model(
-            model_path, model_name, email, extra_pip_requirements=extra_pip_requirements
+            model_path,
+            model_name,
+            email,
+            flavor,
+            extra_pip_requirements=extra_pip_requirements,
         )
         return full_model_name
 

--- a/garden_ai/mlmodel.py
+++ b/garden_ai/mlmodel.py
@@ -16,6 +16,7 @@ def upload_model(
     model_path: str,
     model_name: str,
     user_email: str,
+    flavor: str,  # TODO may not be needed? or may decide which mlflow package to use
     extra_pip_requirements: List[str] = None,
 ) -> str:
     """Upload a model to Garden-AI's MLflow model registry.
@@ -28,6 +29,8 @@ def upload_model(
         The name under which to register the uploaded model.
     user_email : str
         The email address of the user uploading the model.
+    flavor : str
+        The library the model was made with, e.g. ``sklearn`` or ``tensorflow``.
     extra_pip_requirements : List[str], optional
         A list of additional pip requirements needed to load and/or run the model.
         Defaults to None.

--- a/tests/integrations/test_mlflow.py
+++ b/tests/integrations/test_mlflow.py
@@ -20,8 +20,48 @@ def toy_sklearn_model():
     return sk_model
 
 
+@pytest.fixture
+def toy_tensorflow_model():
+    # import tensorflow
+    import tensorflow as tf  # type: ignore
+
+    tf_model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Dense(units=10, input_shape=[8]),
+            tf.keras.layers.Dense(units=1),
+        ]
+    )
+    tf_model.compile(loss="mse", optimizer=tf.keras.optimizers.RMSprop(0.001))
+    return tf_model
+
+
+@pytest.fixture
+def toy_pytorch_model():
+    # import torch
+    import torch.nn as nn
+
+    pytorch_model = nn.Sequential(nn.Linear(8, 10), nn.ReLU(), nn.Linear(10, 1))
+    return pytorch_model
+
+
+@pytest.fixture
+def toy_model(request, toy_sklearn_model, toy_tensorflow_model, toy_pytorch_model):
+    model_type = request.param
+    if model_type == "sklearn":
+        return (toy_sklearn_model, model_type)
+    elif model_type == "tensorflow":
+        return (toy_tensorflow_model, model_type)
+    elif model_type == "pytorch":
+        return (toy_pytorch_model, model_type)
+    else:
+        raise ValueError(f"Unknown model_type: {model_type}")
+
+
 @pytest.mark.integration
-def test_mlflow_register(tmp_path, toy_sklearn_model):
+@pytest.mark.parametrize(
+    "toy_model", ["sklearn", "tensorflow", "pytorch"], indirect=True
+)
+def test_mlflow_register(tmp_path, toy_model):
     # as if model.pkl already existed on disk
     import pickle
 
@@ -31,14 +71,17 @@ def test_mlflow_register(tmp_path, toy_sklearn_model):
     # model_path.parent.mkdir(exist_ok=True)
 
     with open(model_path, "wb") as f_out:
-        pickle.dump(toy_sklearn_model, f_out)
+        pickle.dump(toy_model[0], f_out)
 
     # simulate `$ garden-ai model register test-model-name tmp_path/model.pkl`
     name = "test-model-name"
+    flavor = toy_model[1]
     extra_pip_requirements = None
     # actually register the model
     client = GardenClient()
-    full_model_name = client.log_model(str(model_path), name, extra_pip_requirements)
+    full_model_name = client.log_model(
+        str(model_path), name, flavor, extra_pip_requirements
+    )
 
     # all mlflow models will have a 'predict' method
     downloaded_model = Model(full_model_name)

--- a/tests/integrations/test_mlflow.py
+++ b/tests/integrations/test_mlflow.py
@@ -21,61 +21,69 @@ def toy_sklearn_model():
 
 
 @pytest.fixture
-def toy_tensorflow_model():
-    # import tensorflow
-    import tensorflow as tf  # type: ignore
-
-    tf_model = tf.keras.Sequential(
-        [
-            tf.keras.layers.Dense(units=10, input_shape=[8]),
-            tf.keras.layers.Dense(units=1),
-        ]
-    )
-    tf_model.compile(loss="mse", optimizer=tf.keras.optimizers.RMSprop(0.001))
-    return tf_model
-
-
-@pytest.fixture
 def toy_pytorch_model():
-    # import torch
-    import torch.nn as nn
+    import torch
 
-    pytorch_model = nn.Sequential(nn.Linear(8, 10), nn.ReLU(), nn.Linear(10, 1))
-    return pytorch_model
+    pt_model = torch.nn.Linear(6, 1)
+    loss_function = torch.nn.L1Loss()
+    optimizer = torch.optim.Adam(pt_model.parameters(), lr=1e-4)
 
+    X = torch.randn(6)
+    y = torch.randn(1)
 
-@pytest.fixture
-def toy_model(request, toy_sklearn_model, toy_tensorflow_model, toy_pytorch_model):
-    model_type = request.param
-    if model_type == "sklearn":
-        return (toy_sklearn_model, model_type)
-    elif model_type == "tensorflow":
-        return (toy_tensorflow_model, model_type)
-    elif model_type == "pytorch":
-        return (toy_pytorch_model, model_type)
-    else:
-        raise ValueError(f"Unknown model_type: {model_type}")
+    epochs = 5
+    for epoch in range(epochs):
+        optimizer.zero_grad()
+        outputs = pt_model(X)
+
+        loss = loss_function(outputs, y)
+        loss.backward()
+
+        optimizer.step()
+    return pt_model
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize(
-    "toy_model", ["sklearn", "tensorflow", "pytorch"], indirect=True
-)
-def test_mlflow_register(tmp_path, toy_model):
+def test_mlflow_sklearn_register(tmp_path, toy_sklearn_model):
     # as if model.pkl already existed on disk
     import pickle
 
     tmp_path.mkdir(exist_ok=True)
     model_path = tmp_path / "model.pkl"
     model_path.touch()
+    flavor = "sklearn"
     # model_path.parent.mkdir(exist_ok=True)
 
     with open(model_path, "wb") as f_out:
-        pickle.dump(toy_model[0], f_out)
+        pickle.dump(toy_sklearn_model, f_out)
 
     # simulate `$ garden-ai model register test-model-name tmp_path/model.pkl`
-    name = "test-model-name"
-    flavor = toy_model[1]
+    name = "sk-test-model-name"
+    extra_pip_requirements = None
+    # actually register the model
+    client = GardenClient()
+    full_model_name = client.log_model(
+        str(model_path), name, flavor, extra_pip_requirements
+    )
+
+    # all mlflow models will have a 'predict' method
+    downloaded_model = Model(full_model_name)
+    assert hasattr(downloaded_model, "predict")
+
+
+@pytest.mark.integration
+def test_mlflow_pytorch_register(tmp_path, toy_pytorch_model):
+    # as if model.pkl already existed on disk
+    import torch
+
+    tmp_path.mkdir(exist_ok=True)
+    model_path = tmp_path / "pytorchtest.pth"
+    torch.save(toy_pytorch_model, model_path, _use_new_zipfile_serialization=False)
+    flavor = "pytorch"
+    # model_path.parent.mkdir(exist_ok=True)
+
+    # simulate `$ garden-ai model register test-model-name tmp_path/pytorchtest.pt`
+    name = "pt-test-model-name"
     extra_pip_requirements = None
     # actually register the model
     client = GardenClient()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,7 +89,8 @@ def test_model_upload(mocker):
     args = mock_client.log_model.call_args.args
     assert args[0] == "/Users/will/fake-file.pkl"
     assert args[1] == "unit-test-model"
-    assert args[2] == ["torch==1.13.1", "pandas<=1.5.0"]
+    assert args[2] == "sklearn"
+    assert args[3] == ["torch==1.13.1", "pandas<=1.5.0"]
 
 
 def test_clean_identifier():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -240,6 +240,7 @@ def test_pipeline_authors_are_garden_contributors(
 def test_upload_model(mocker, tmp_path):
     model_name = "test_model"
     user_email = "will@test.com"
+    flavor = "sklearn"
     model_dir_path = tmp_path / "models"
 
     model_dir_path.mkdir(parents=True, exist_ok=True)
@@ -260,7 +261,8 @@ def test_upload_model(mocker, tmp_path):
 
     full_model_name = "will@test.com-test_model/1"
     assert (
-        mlmodel.upload_model(str(model_path), model_name, user_email) == full_model_name
+        mlmodel.upload_model(str(model_path), model_name, user_email, flavor)
+        == full_model_name
     )
 
 


### PR DESCRIPTION
Related Issue: #73 

## Overview

This PR is to provide initial functionality to allow a successful upload of models built in the PyTorch or TensorFlow flavor.
Example CLI arguments:
 - `garden-ai model register Steves-testTF-model ../garden-flavor-test/savedtf/ tensorflow`
 - `garden-ai model register Steves-testPT-model ../garden-flavor-test/pytorchtest1.pt pytorch `

## Discussion

The methods employed include the usage of the base library (pytorch or tensorflow) to enable loading of the serialized object subsequent to using the matching flavor of ML Flow to then log the model to the garden MLFLow URI. 

This PR also has the following changes:
- added .vscode/settings.json to .gitignore
- garden_ai/app/model.py
    - added exists check for model_path typer arguments
    - added dir_okay for model_path typer arguments (needed for tensorflow)
    - updated help text for model path and extra_pip_requirements
    - updated the rich text to raise a typer.BadParameter to allow the CLI to exit rather than sit and require manual abort that existed with the rich text alone
    - added flavor as a parameter
- garden_ai/client.py
    - added flavor parameter to log_model method
- garden_ai/mlmodel.py
    - imported torch and tensorflow needed for loading serialized versions.
    - added code to ignore a cpu vs gpu informational warning from tensorflow; hence the flake ignore of E402 for the import of tensorflow after a line of code
    - added the flavor parameter to ModelUploadException class
    - updated docstring
    - created conditional upload based on model flavor, could look into switch case potentially in the future.
        - also checks that the model is in the proper file/dir required for the flavor
    - updated the `model_full_name` in the Model method to align with the other references in the code to model name so that all match to `full_model_name`.
- test/integrations/test_mlflow.py
    - created a fixture for pytorch toy model
    - created a test that follows the sklearn scaffolding for pytorch but seems to have an issue with downloading the model (to be investigated as noted below in the testing section)
    - if this testing issue for pytorch is rectified, then it should be easy to continue to add testing support for further flavors, but I most likely need assistance to confirm this PR is properly uploading and that there are no further errors introduced in the changes listed above.


## Testing

To test simply apply the same structure above (the CLI args) and have a model saved according to one of the flavors [tensorflow](https://www.tensorflow.org/tutorials/keras/save_and_load#save_the_entire_model) via model.save(model_path) (which requires a directory, unless an HDF5 file) or [pytorch](https://pytorch.org/docs/stable/generated/torch.save.html?highlight=save#torch.save) via torch.save(model_path).

At this time I have reverted the parametrized unit tests which created toy models for the tensorflow and pytorch models; however due to the added complexity and many variables that could go into said models when compared to a serialized toy sklearn model parameterized tests might not be the way to go here. I feel this warrants further discussion on how to best test the full functionality and if models require additional parameters such as signatures and other items identified in the mlflow.flavor.log_model() documentations. 

[pytorch - log_model() docs](https://mlflow.org/docs/latest/python_api/mlflow.tensorflow.html#mlflow.tensorflow.log_model) & [tensorflow - log_model() docs](https://mlflow.org/docs/latest/python_api/mlflow.tensorflow.html#mlflow.tensorflow.log_model)

For now, I have a test for the pytorch model that should work as a template, however there seemed to be issues I could not debug 
Exact error: `RuntimeError: PytorchStreamReader failed reading zip archive: invalid header or archive is corrupted`
(the pytorch model was failing at unzipping, this could be an issue with me attempting to download the Model [via Model(full_model_name)] and should be investigated further - perhaps a new issue created if this failure continues with other models/systems/users to rule out my exact circumstances) Steps to reproduce are to run the pytests for test_mlflow.py sklearn should pass and pytorch should fail.


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--100.org.readthedocs.build/en/100/

<!-- readthedocs-preview garden-ai end -->