### PR TITLE
Monkeypatch FuncX client to get around clientside serialization bug

### DIFF
--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -32,7 +32,7 @@ from garden_ai.mlflow_bandaid.binary_header_provider import (
     BinaryContentTypeHeaderProvider,
 )
 from mlflow.tracking.request_header.registry import _request_header_provider_registry  # type: ignore
-import garden_ai.funcx_bandaid.serializer_patch  # noqa: F401
+import garden_ai.funcx_bandaid.serializer_patch  # type: ignore # noqa: F401
 from garden_ai.globus_compute.login_manager import FuncXLoginManager
 from garden_ai.globus_compute.containers import build_container
 from garden_ai.globus_compute.remote_functions import register_pipeline

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -32,6 +32,7 @@ from garden_ai.mlflow_bandaid.binary_header_provider import (
     BinaryContentTypeHeaderProvider,
 )
 from mlflow.tracking.request_header.registry import _request_header_provider_registry  # type: ignore
+import garden_ai.funcx_bandaid.serializer_patch
 from garden_ai.globus_compute.login_manager import FuncXLoginManager
 from garden_ai.globus_compute.containers import build_container
 from garden_ai.globus_compute.remote_functions import register_pipeline

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -32,7 +32,7 @@ from garden_ai.mlflow_bandaid.binary_header_provider import (
     BinaryContentTypeHeaderProvider,
 )
 from mlflow.tracking.request_header.registry import _request_header_provider_registry  # type: ignore
-import garden_ai.funcx_bandaid.serializer_patch  # type: ignore # noqa: F401
+import garden_ai.funcx_bandaid.serialization_patch  # type: ignore # noqa: F401
 from garden_ai.globus_compute.login_manager import FuncXLoginManager
 from garden_ai.globus_compute.containers import build_container
 from garden_ai.globus_compute.remote_functions import register_pipeline

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -32,7 +32,7 @@ from garden_ai.mlflow_bandaid.binary_header_provider import (
     BinaryContentTypeHeaderProvider,
 )
 from mlflow.tracking.request_header.registry import _request_header_provider_registry  # type: ignore
-import garden_ai.funcx_bandaid.serializer_patch
+import garden_ai.funcx_bandaid.serializer_patch  # noqa: F401
 from garden_ai.globus_compute.login_manager import FuncXLoginManager
 from garden_ai.globus_compute.containers import build_container
 from garden_ai.globus_compute.remote_functions import register_pipeline

--- a/garden_ai/funcx_bandaid/serialization_patch.py
+++ b/garden_ai/funcx_bandaid/serialization_patch.py
@@ -27,7 +27,7 @@ def serialize(self, *args, **kwargs):
 
 
 @monkeypatch_method(DillCodeTextInspect)
-def serialize(self, *args, **kwargs):
+def serialize(self, *args, **kwargs):  # noqa: F811
     if args[0].__closure__ is not None:
         raise SerializerError("Payload non-local variables ignored by `getsource`.")
     return self.original_func(*args, **kwargs)

--- a/garden_ai/funcx_bandaid/serialization_patch.py
+++ b/garden_ai/funcx_bandaid/serialization_patch.py
@@ -1,0 +1,33 @@
+from funcx.serialize.base import SerializerError
+from funcx.serialize.concretes import DillCodeSource, DillCodeTextInspect
+
+"""
+This is a temporary hack until this PR gets merged: https://github.com/funcx-faas/funcX/pull/1083
+Basically FuncX is using the wrong serialization method by default on our pipeline functions.
+The PR and this monkeypatched version of it make sure FuncX supports the kind of composed functions
+that we submit to FuncX.
+"""
+
+
+def monkeypatch_method(cls):
+    def decorator(func):
+        original_func = getattr(cls, func.__name__, None)
+        setattr(cls, func.__name__, func)
+        func.original_func = original_func
+        return func
+
+    return decorator
+
+
+@monkeypatch_method(DillCodeSource)
+def serialize(self, *args, **kwargs):
+    if args[0].__closure__ is not None:
+        raise SerializerError("Payload non-local variables ignored by `getsource`.")
+    return self.original_func(*args, **kwargs)
+
+
+@monkeypatch_method(DillCodeTextInspect)
+def serialize(self, *args, **kwargs):
+    if args[0].__closure__ is not None:
+        raise SerializerError("Payload non-local variables ignored by `getsource`.")
+    return self.original_func(*args, **kwargs)

--- a/garden_ai/funcx_bandaid/serialization_patch.py
+++ b/garden_ai/funcx_bandaid/serialization_patch.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 from funcx.serialize.base import SerializerError
 from funcx.serialize.concretes import DillCodeSource, DillCodeTextInspect
 


### PR DESCRIPTION
Temporary expedient to unblock #40

## Overview

The FuncX client currently can't handle the way Garden composes functions together. (It effectively only serializes the top level function but leaves out the functions being composed.) This PR uses the idea @OwenPriceSkelly has proposed to the FuncX team as a proper fix.

## Discussion

Hopefully this will be around for a month tops until the fix gets into FuncX.

## Testing

I tested this on Owen's WIP remote execution branch. Without the monkeypatch I got the telltale KeyError at execution time. (See error report in Owen's PR: https://github.com/funcx-faas/funcX/pull/1083) With the monkeypatch included we get past that error and hit our pipeline code. 

<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--103.org.readthedocs.build/en/103/

<!-- readthedocs-preview garden-ai end -->