### PR TITLE
`RegisteredPipeline` class

### DIFF
--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -1,9 +1,8 @@
 import json
 import logging
-from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 import rich
 import typer
@@ -207,11 +206,11 @@ def add_pipeline(
     garden = get_garden(garden_id)
     to_add = get_pipeline(pipeline_id)
 
-    if to_add in garden.pipelines:
+    if to_add in garden.collect_pipelines():
         logger.info(f"Pipeline {pipeline_id} is already in Garden {garden_id}")
         return
 
-    garden.pipelines += [to_add]
+    garden.pipeline_ids += [to_add.uuid]
     local_data.put_local_garden(garden)
     logger.info(f"Added pipeline {pipeline_id} to Garden {garden_id}")
 
@@ -234,7 +233,7 @@ def publish(
     garden.doi = client._mint_doi(garden)
 
     try:
-        client.publish_garden_metadata(garden.dict())
+        client.publish_garden_metadata(garden.expanded_metadata())
     except SearchAPIError as e:
         logger.fatal(f"Could not publish garden {garden_id}")
         logger.fatal(e.error_data)

--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -201,10 +201,10 @@ def add_pipeline(
         rich_help_panel="Required",
     ),
 ):
-    """ "Add a registered pipeline to a garden"""
+    """Add a registered pipeline to a garden"""
 
-    garden = get_garden(garden_id)
-    to_add = get_pipeline(pipeline_id)
+    garden = _get_garden(garden_id)
+    to_add = _get_pipeline(pipeline_id)
 
     if to_add in garden.collect_pipelines():
         logger.info(f"Pipeline {pipeline_id} is already in Garden {garden_id}")
@@ -229,18 +229,18 @@ def publish(
     """Push data about a Garden stored to Globus Search so that other users can search for it"""
 
     client = GardenClient()
-    garden = get_garden(garden_id)
+    garden = _get_garden(garden_id)
     garden.doi = client._mint_doi(garden)
 
     try:
-        client.publish_garden_metadata(garden.expanded_metadata())
+        client.publish_garden_metadata(garden)
     except SearchAPIError as e:
         logger.fatal(f"Could not publish garden {garden_id}")
         logger.fatal(e.error_data)
         raise typer.Exit(code=1) from e
 
 
-def get_pipeline(pipeline_id: str) -> RegisteredPipeline:
+def _get_pipeline(pipeline_id: str) -> RegisteredPipeline:
     if "/" in pipeline_id:
         pipeline = local_data.get_local_pipeline_by_doi(pipeline_id)
     else:
@@ -251,7 +251,7 @@ def get_pipeline(pipeline_id: str) -> RegisteredPipeline:
     return pipeline
 
 
-def get_garden(garden_id: str) -> Garden:
+def _get_garden(garden_id: str) -> Garden:
     if "/" in garden_id:
         garden = local_data.get_local_garden_by_doi(garden_id)
     else:

--- a/garden_ai/app/pipeline.py
+++ b/garden_ai/app/pipeline.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import re
 from datetime import datetime
@@ -7,14 +6,12 @@ from pathlib import Path
 from typing import List, Optional
 
 import jinja2
-import rich
 import typer
 from rich import print
 from rich.prompt import Prompt
 
 from garden_ai import GardenClient, Pipeline, step
 from garden_ai.app.console import console
-from garden_ai import local_data
 
 from garden_ai.utils.filesystem import (
     load_pipeline_from_python_file,
@@ -212,11 +209,6 @@ def create(
             f.write("## Please specify all pipeline dependencies here\n")
 
         print(f"Generated pipeline scaffolding in {out_dir}.")
-
-    if verbose:
-        local_data.put_local_pipeline(pipeline)
-        metadata = json.dumps(local_data.get_local_pipeline_by_uuid(pipeline.uuid))
-        rich.print_json(metadata)
 
     return
 

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -357,7 +357,7 @@ class GardenClient:
         local_data.put_local_pipeline(registered)
         return func_uuid
 
-    def publish_garden_metadata(self, garden):
+    def publish_garden_metadata(self, garden: Garden):
         # Takes a garden, and publishes to the GARDEN_INDEX_UUID index.  Polls
         # to discover status, and returns the Task document:
         # https://docs.globus.org/api/search/reference/get_task/#task

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -44,9 +44,6 @@ GARDEN_ENDPOINT = os.environ.get(
     "https://nu3cetwc84.execute-api.us-east-1.amazonaws.com/garden_prod",
 )
 
-LOCAL_STORAGE = Path("~/.garden").expanduser()
-LOCAL_STORAGE.mkdir(parents=True, exist_ok=True)
-
 COMPUTE_RESOURCE_SERVER_NAME = "funcx_service"
 
 logger = logging.getLogger()
@@ -308,12 +305,13 @@ class GardenClient:
 
         def get_existing_doi() -> Optional[str]:
             # check for existing doi, either on object or in db
-            # TODO pipelines too
-            record: Optional[Garden] = local_data.get_local_garden_by_uuid(obj.uuid)
-            if record:
-                return record.doi
+            registered_obj: Optional[Union[Garden, RegisteredPipeline]]
+            if isinstance(obj, Garden):
+                registered_obj = local_data.get_local_garden_by_uuid(obj.uuid)
             else:
-                return None
+                registered_obj = local_data.get_local_pipeline_by_uuid(obj.uuid)
+
+            return registered_obj.doi if registered_obj else None
 
         existing_doi = obj.doi or get_existing_doi()
 
@@ -359,12 +357,11 @@ class GardenClient:
         local_data.put_local_pipeline(registered)
         return func_uuid
 
-    def publish_garden_metadata(self, garden_meta):
-        # Takes a garden_id UUID as a subject, and a garden_doc dict, and
-        # publishes to the GARDEN_INDEX_UUID index.  Polls to discover status,
-        # and returns the Task document:
+    def publish_garden_metadata(self, garden):
+        # Takes a garden, and publishes to the GARDEN_INDEX_UUID index.  Polls
+        # to discover status, and returns the Task document:
         # https://docs.globus.org/api/search/reference/get_task/#task
-
+        garden_meta = json.loads(garden.expanded_json())
         gmeta_ingest = {
             "subject": garden_meta["uuid"],
             "visible_to": ["all_authenticated_users"],

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -256,8 +256,11 @@ class GardenClient:
         pipeline = Pipeline(**data)
         record = local_data.get_local_pipeline_by_uuid(pipeline.uuid)
         if record:
-            logger.info("Found pre-registered pipeline. Reusing remote function ID.")
-            pipeline.func_uuid = record.get("func_uuid")
+            logger.info(
+                "Found pre-registered pipeline. Reusing remote function ID and DOI."
+            )
+            pipeline.func_uuid = record["func_uuid"]
+            pipeline.doi = record["doi"]
 
         return pipeline
 

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -4,7 +4,7 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import List, Optional, Union
 from uuid import UUID
 
 import requests
@@ -308,9 +308,10 @@ class GardenClient:
 
         def get_existing_doi() -> Optional[str]:
             # check for existing doi, either on object or in db
-            record: Optional[Dict] = local_data.get_local_garden_by_uuid(obj.uuid)
+            # TODO pipelines too
+            record: Optional[Garden] = local_data.get_local_garden_by_uuid(obj.uuid)
             if record:
-                return record.get("doi", None)
+                return record.doi
             else:
                 return None
 

--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -104,13 +104,10 @@ class Garden(BaseModel):
         validate_assignment = True  # validators invoked on assignment
         underscore_attrs_are_private = True
 
+    title: str = cast(str, Field(default_factory=lambda: None))
     authors: List[str] = Field(default_factory=list, min_items=1, unique_items=True)
     contributors: List[str] = Field(default_factory=list, unique_items=True)
-    # note: default_factory=lambda:None allows us to have fields which are None by
-    # default, but not automatically considered optional by pydantic
-    title: str = cast(str, Field(default_factory=lambda: None))
-    doi: str = cast(str, Field(default_factory=lambda: None))
-    # ^ casts here to appease mypy
+    doi: Optional[str] = Field(default=None)
     description: Optional[str] = Field(None)
     publisher: str = "Garden"
     year: str = Field(default_factory=lambda: str(datetime.now().year))
@@ -241,7 +238,6 @@ class Garden(BaseModel):
         #   none is not an allowed value (type=type_error.none.not_allowed)
         """
         try:
-            self._sync_author_metadata()
             _ = self.__class__(**self.dict())
         except ValidationError as err:
             logger.error(err)

--- a/garden_ai/globus_compute/remote_functions.py
+++ b/garden_ai/globus_compute/remote_functions.py
@@ -1,6 +1,8 @@
-from garden_ai.pipelines import Pipeline
 from globus_compute_sdk import Client  # type: ignore
 from globus_sdk import GlobusAPIError
+
+from garden_ai.pipelines import Pipeline
+from garden_ai.utils.misc import inject_env_kwarg
 
 
 class PipelineRegistrationException(Exception):
@@ -15,8 +17,9 @@ def register_pipeline(
     container_uuid: str,
 ) -> str:
     try:
+        to_register = inject_env_kwarg(pipeline._composed_steps)
         func_uuid = compute_client.register_function(
-            pipeline._composed_steps, container_uuid=container_uuid, public=True
+            to_register, container_uuid=container_uuid, public=True
         )
     except GlobusAPIError as e:
         raise PipelineRegistrationException(

--- a/garden_ai/local_data.py
+++ b/garden_ai/local_data.py
@@ -168,7 +168,7 @@ def get_local_garden_by_uuid(uuid: Union[UUID, str]) -> Optional[Garden]:
     Optional[Garden]
         If successful, a dictionary in the form given by Garden.json().
     """
-    return _get_resource_by_uuid(uuid, ResourceType.GARDEN)
+    return _get_resource_by_uuid(uuid, ResourceType.GARDEN)  # type: ignore
 
 
 def get_local_pipeline_by_uuid(uuid: Union[UUID, str]) -> Optional[RegisteredPipeline]:
@@ -183,7 +183,7 @@ def get_local_pipeline_by_uuid(uuid: Union[UUID, str]) -> Optional[RegisteredPip
     -------
     Optional[RegisteredPipeline]
     """
-    return _get_resource_by_uuid(uuid, ResourceType.PIPELINE)
+    return _get_resource_by_uuid(uuid, ResourceType.PIPELINE)  # type: ignore
 
 
 def get_local_garden_by_doi(doi: str) -> Optional[Garden]:
@@ -198,7 +198,7 @@ def get_local_garden_by_doi(doi: str) -> Optional[Garden]:
     -------
     Optional[Garden]
     """
-    return _get_resource_by_doi(doi, ResourceType.GARDEN)
+    return _get_resource_by_doi(doi, ResourceType.GARDEN)  # type: ignore
 
 
 def get_local_pipeline_by_doi(doi: str) -> Optional[RegisteredPipeline]:
@@ -213,4 +213,4 @@ def get_local_pipeline_by_doi(doi: str) -> Optional[RegisteredPipeline]:
     -------
     Optional[RegisteredPipeline]
     """
-    return _get_resource_by_doi(doi, ResourceType.PIPELINE)
+    return _get_resource_by_doi(doi, ResourceType.PIPELINE)  # type: ignore

--- a/garden_ai/local_data.py
+++ b/garden_ai/local_data.py
@@ -1,12 +1,12 @@
 import json
 import logging
 from enum import Enum
-from typing import Dict, Union, Optional
 from pathlib import Path
+from typing import Dict, Optional, Union
 from uuid import UUID
 
 from garden_ai.gardens import Garden
-from garden_ai.pipelines import Pipeline
+from garden_ai.pipelines import RegisteredPipeline
 
 LOCAL_STORAGE = Path("~/.garden").expanduser()
 LOCAL_STORAGE.mkdir(parents=True, exist_ok=True)
@@ -68,32 +68,43 @@ def _put_resource_from_metadata(
     _write_local_db(data)
 
 
-def _put_resource_from_obj(resource: Union[Garden, Pipeline]) -> None:
+def _put_resource_from_obj(resource: Union[Garden, RegisteredPipeline]) -> None:
     resource_type = (
         ResourceType.GARDEN if isinstance(resource, Garden) else ResourceType.PIPELINE
     )
-    resource_metadata = json.loads(resource.json())
+    resource_metadata = resource.dict()
     _put_resource_from_metadata(resource_metadata, resource_type)
+
+
+def _make_obj_from_record(
+    record: Dict, resource_type: ResourceType
+) -> Union[Garden, RegisteredPipeline]:
+    if resource_type is ResourceType.GARDEN:
+        return Garden(**record)
+    else:
+        return RegisteredPipeline(**record)
 
 
 def _get_resource_by_uuid(
     uuid: Union[UUID, str], resource_type: ResourceType
-) -> Optional[Dict]:
+) -> Union[Garden, RegisteredPipeline, None]:
     data = _read_local_db()
     uuid = str(uuid)
     resources = data.get(resource_type.value, {})
     if resources and uuid in resources:
-        return resources[uuid]
+        return _make_obj_from_record(resources[uuid], resource_type)
     else:
         return None
 
 
-def _get_resource_by_doi(doi: str, resource_type: ResourceType) -> Optional[Dict]:
+def _get_resource_by_doi(
+    doi: str, resource_type: ResourceType
+) -> Union[Garden, RegisteredPipeline, None]:
     data = _read_local_db()
     resources_by_uuid = data.get(resource_type.value, {})
     resources_by_doi = _reindex_by_doi(resources_by_uuid)
     if resources_by_doi and doi in resources_by_doi:
-        return resources_by_doi[doi]
+        return _make_obj_from_record(resources_by_doi[doi], resource_type)
     else:
         return None
 
@@ -131,7 +142,7 @@ def put_local_garden_from_metadata(garden_metadata: Dict):
     _put_resource_from_metadata(garden_metadata, ResourceType.GARDEN)
 
 
-def put_local_pipeline(pipeline: Pipeline):
+def put_local_pipeline(pipeline: RegisteredPipeline):
     """Helper: write a record to 'local database' for a given Pipeline
     Overwrites any existing entry with the same uuid in ~/.garden/data.json.
 
@@ -144,7 +155,7 @@ def put_local_pipeline(pipeline: Pipeline):
     _put_resource_from_obj(pipeline)
 
 
-def get_local_garden_by_uuid(uuid: Union[UUID, str]) -> Optional[Dict]:
+def get_local_garden_by_uuid(uuid: Union[UUID, str]) -> Optional[Garden]:
     """Helper: fetch a Garden record from ~/.garden/data.json.
 
     Parameters
@@ -154,13 +165,13 @@ def get_local_garden_by_uuid(uuid: Union[UUID, str]) -> Optional[Dict]:
 
     Returns
     -------
-    Optional[Dict]
+    Optional[Garden]
         If successful, a dictionary in the form given by Garden.json().
     """
     return _get_resource_by_uuid(uuid, ResourceType.GARDEN)
 
 
-def get_local_pipeline_by_uuid(uuid: Union[UUID, str]) -> Optional[Dict]:
+def get_local_pipeline_by_uuid(uuid: Union[UUID, str]) -> Optional[RegisteredPipeline]:
     """Helper: fetch a Pipeline record from ~/.garden/data.json.
 
     Parameters
@@ -170,13 +181,12 @@ def get_local_pipeline_by_uuid(uuid: Union[UUID, str]) -> Optional[Dict]:
 
     Returns
     -------
-    Optional[Dict]
-        If successful, a dictionary in the form given by Pipeline.json().
+    Optional[RegisteredPipeline]
     """
     return _get_resource_by_uuid(uuid, ResourceType.PIPELINE)
 
 
-def get_local_garden_by_doi(doi: str) -> Optional[Dict]:
+def get_local_garden_by_doi(doi: str) -> Optional[Garden]:
     """Helper: fetch a Garden record from ~/.garden/data.json.
 
     Parameters
@@ -186,13 +196,12 @@ def get_local_garden_by_doi(doi: str) -> Optional[Dict]:
 
     Returns
     -------
-    Optional[Dict]
-        If successful, a dictionary in the form given by Garden.json().
+    Optional[Garden]
     """
     return _get_resource_by_doi(doi, ResourceType.GARDEN)
 
 
-def get_local_pipeline_by_doi(doi: str) -> Optional[Dict]:
+def get_local_pipeline_by_doi(doi: str) -> Optional[RegisteredPipeline]:
     """Helper: fetch a Pipeline record from ~/.garden/data.json.
 
     Parameters
@@ -202,7 +211,6 @@ def get_local_pipeline_by_doi(doi: str) -> Optional[Dict]:
 
     Returns
     -------
-    Optional[Dict]
-        If successful, a dictionary in the form given by Pipeline.json().
+    Optional[RegisteredPipeline]
     """
     return _get_resource_by_doi(doi, ResourceType.PIPELINE)

--- a/garden_ai/local_data.py
+++ b/garden_ai/local_data.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from garden_ai.gardens import Garden
 from garden_ai.pipelines import RegisteredPipeline
+from garden_ai.utils.misc import garden_json_encoder
 
 LOCAL_STORAGE = Path("~/.garden").expanduser()
 LOCAL_STORAGE.mkdir(parents=True, exist_ok=True)
@@ -41,7 +42,7 @@ def _read_local_db() -> Dict:
 
 
 def _write_local_db(data: Dict) -> None:
-    contents = json.dumps(data)
+    contents = json.dumps(data, default=garden_json_encoder)
     with open(LOCAL_STORAGE / "data.json", "w+") as f:
         f.write(contents)
 

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -7,13 +7,14 @@ import sys
 from datetime import datetime
 from functools import reduce
 from inspect import signature
-from typing import Any, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 from uuid import UUID, uuid4
 
 import dparse  # type: ignore
 import globus_compute_sdk  # type: ignore
 from pydantic import Field, validator
 from pydantic.dataclasses import dataclass
+from pydantic.json import pydantic_encoder
 
 from garden_ai.app.console import console
 from garden_ai.datacite import (
@@ -179,25 +180,16 @@ class Pipeline:
     def __call__(
         self,
         *args: Any,
-        endpoint: Union[UUID, str, None] = None,
-        timeout=None,
         **kwargs: Any,
     ) -> Any:
         """Call the pipeline's composed steps on the given input data.
 
-        Attempt to execute remotely if this pipeline has already been registered
-        and a valid ``endpoint`` is specified, else run locally as a regular
-        python function.
+        To run a Pipeline on a remote endpoint, see ``PipelineMeta``.
 
         Parameters
         ----------
         *args : Any
             Input data passed through the first step in the pipeline
-        endpoint : Union[UUID, str, None]
-            A valid globus compute endpoint uuid
-        timeout : int
-            time (in seconds) to wait for results. Pass `None` to wait
-            indefinitely (default behavior).
         **kwargs : Any
             Additional keyword arguments passed directly to the first step in
             the pipeline.
@@ -215,35 +207,8 @@ class Pipeline:
             function, remotely or otherwise.
 
         """
-        run_locally = not (self.func_uuid and endpoint)
-
-        if run_locally:
-            if endpoint:
-                logger.warning(
-                    f"Pipeline '{self.title}' invoked with endpoint="
-                    f" {endpoint}, but has not been registered yet. The "
-                    "pipeline will not execute remotely.",
-                )
-            if self.func_uuid:
-                logger.warning(
-                    f"Pipeline '{self.title}' has been registered for remote "
-                    "execution, but no endpoint was specified. The pipeline will "
-                    "not execute remotely.",
-                )
-            # pass input directly to underlying steps
-            return self._composed_steps(*args, **kwargs)
-
-        with globus_compute_sdk.Executor(endpoint_id=str(endpoint)) as gce:
-            # TODO: refactor below once the remote-calling interface is settled.
-            # console/spinner is good ux but shouldn't live this deep in the
-            # sdk.
-            with console.status(
-                f"[bold green] executing remotely on endpoint {endpoint}"
-            ):
-                future = gce.submit_to_registered_function(
-                    function_id=str(self.func_uuid), args=args, kwargs=kwargs
-                )
-                return future.result()
+        # pass input directly to underlying steps
+        return self._composed_steps(*args, **kwargs)
 
     def __post_init_post_parse__(self):
         """Finish initializing the pipeline after validators have run.
@@ -296,3 +261,81 @@ class Pipeline:
             if self.description
             else None,
         ).json()
+
+
+@dataclass
+class RegisteredPipeline:
+    """Metadata of a completed and registered ``Pipeline`` object.
+
+    Unlike a plain ``Pipeline``, this object's ``__call__`` executes a
+    registered function remotely.
+
+    Note that this has no direct references to the underlying steps/function
+    objects, so it cannot be used to execute a pipeline locally.
+    """
+
+    title: str = Field(...)
+    authors: List[str] = Field(...)
+    uuid: UUID = Field(...)
+    func_uuid: Optional[UUID] = Field(...)
+    # NOTE: steps as dicts, not Steps
+    steps: List[Dict[str, Optional[List, str]]] = Field(...)
+    doi: Optional[str] = Field(None)
+    contributors: List[str] = Field(default_factory=list, unique_items=True)
+    description: Optional[str] = Field(None)
+    version: str = "0.0.1"
+    year: str = Field(default_factory=lambda: str(datetime.now().year))
+    tags: List[str] = Field(default_factory=list, unique_items=True)
+    # requirements_file: Optional[str] = Field(None)
+    python_version: Optional[str] = Field(None)
+    pip_dependencies: List[str] = Field(default_factory=list)
+    conda_dependencies: List[str] = Field(default_factory=list)
+
+    def __call__(
+        self,
+        *args: Any,
+        endpoint: Union[UUID, str] = None,
+        timeout=None,
+        **kwargs: Any,
+    ) -> Any:
+        """Remotely execute this ``PipelineMeta``'s function from its uuid. An endpoint must be specified.
+
+        Parameters
+        ----------
+        *args : Any
+            Input data passed through the first step in the pipeline
+        endpoint : Union[UUID, str, None]
+            A valid globus compute endpoint UUID
+        timeout : int
+            time (in seconds) to wait for results. Pass `None` to wait
+            indefinitely (default behavior).
+        **kwargs : Any
+            Additional keyword arguments passed directly to the first step in
+            the pipeline.
+
+        Returns
+        -------
+        Any
+            Results from the pipeline's composed steps called with the given
+            input data.
+
+        Raises
+        ------
+        Exception
+            Any exceptions raised over the course of executing the pipeline
+
+        """
+        with globus_compute_sdk.Executor(endpoint_id=str(endpoint)) as gce:
+            # TODO: refactor below once the remote-calling interface is settled.
+            # console/spinner is good ux but shouldn't live this deep in the
+            # sdk.
+            with console.status(
+                f"[bold green] executing remotely on endpoint {endpoint}"
+            ):
+                future = gce.submit_to_registered_function(
+                    function_id=str(self.func_uuid), args=args, kwargs=kwargs
+                )
+                return future.result()
+
+    def json(self) -> str:
+        return json.dumps(self, default=pydantic_encoder)

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -289,7 +289,7 @@ class RegisteredPipeline(BaseModel):
     func_uuid: Optional[UUID] = Field(...)
     title: str = Field(...)
     authors: List[str] = Field(...)
-    # NOTE: steps as dicts here, not Step objects
+    # NOTE: steps are dicts here, not Step objects
     steps: List[Dict[str, Union[str, None, List]]] = Field(...)
     contributors: List[str] = Field(default_factory=list, unique_items=True)
     description: Optional[str] = Field(None)
@@ -309,7 +309,7 @@ class RegisteredPipeline(BaseModel):
         timeout=None,
         **kwargs: Any,
     ) -> Any:
-        """Remotely execute this ``PipelineMeta``'s function from its uuid. An endpoint must be specified.
+        """Remotely execute this ``RegisteredPipeline``'s function from its uuid. An endpoint must be specified.
 
         Parameters
         ----------
@@ -332,10 +332,17 @@ class RegisteredPipeline(BaseModel):
 
         Raises
         ------
+        ValueError
+            If no endpoint is specified
         Exception
             Any exceptions raised over the course of executing the pipeline
 
         """
+        if not endpoint:
+            raise ValueError(
+                "A Globus Compute endpoint uuid must be specified to execute remotely."
+            )
+
         if self._env_vars:
             # see: inject_env_kwarg util
             kwargs = dict(kwargs)

--- a/garden_ai/steps.py
+++ b/garden_ai/steps.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
+import json
 import logging
 import typing
 from functools import update_wrapper, wraps
 from inspect import Parameter, Signature, signature
-from typing import Callable, Dict, List, Optional
-from uuid import UUID, uuid4
+from typing import Any, Callable, Dict, List, Optional
 
 from pydantic import Field, validator
 from pydantic.dataclasses import dataclass
 from typing_extensions import get_type_hints
 
 from garden_ai.mlmodel import Model, _Model
+from garden_ai.utils.misc import garden_json_encoder
 
 logger = logging.getLogger()
 
@@ -120,7 +121,6 @@ class Step:
     description: Optional[str] = Field(None)
     input_info: Optional[str] = Field(None)
     output_info: Optional[str] = Field(None)
-    uuid: UUID = Field(default_factory=uuid4)
     conda_dependencies: List[str] = Field(default_factory=list)
     pip_dependencies: List[str] = Field(default_factory=list)
     python_version: Optional[str] = Field(None)
@@ -207,6 +207,9 @@ class Step:
                 "https://github.com/beartype/beartype#compliance"
             )
         return f
+
+    def json(self) -> Dict[str, Any]:
+        return json.dumps(self, default=garden_json_encoder)
 
 
 def step(func: Callable = None, **kwargs):

--- a/garden_ai/steps.py
+++ b/garden_ai/steps.py
@@ -12,7 +12,7 @@ from pydantic.dataclasses import dataclass
 from typing_extensions import get_type_hints
 
 from garden_ai.mlmodel import Model, _Model
-from garden_ai.utils.misc import garden_json_encoder
+from garden_ai.utils.misc import JSON, garden_json_encoder
 
 logger = logging.getLogger()
 
@@ -208,8 +208,15 @@ class Step:
             )
         return f
 
-    def json(self) -> Dict[str, Any]:
+    def json(self) -> JSON:
         return json.dumps(self, default=garden_json_encoder)
+
+    def dict(self) -> Dict[str, Any]:
+        d = {}
+        for key in self.__dataclass_fields__:
+            val = getattr(self, key)
+            d[key] = val
+        return d
 
 
 def step(func: Callable = None, **kwargs):

--- a/garden_ai/utils/misc.py
+++ b/garden_ai/utils/misc.py
@@ -270,18 +270,18 @@ def validate_pip_lines(lines: List[str]) -> List[str]:
 
 def inject_env_kwarg(func: Callable):
     """
-    Helper: modify a function so that it will accept an ``__env_vars`` keyword argument.
+    Helper: modify a function so that it will accept an ``_env_vars`` keyword argument.
 
     This can be used to dynamically set environment variables before executing the
     original function, particularly useful if the function is executing remotely.
     """
 
     @wraps(func)
-    def inner(*args, __env_vars=None, **kwargs):
-        if __env_vars:
+    def inner(*args, _env_vars=None, **kwargs):
+        if _env_vars:
             import os
 
-            for k, v in __env_vars.items():
+            for k, v in _env_vars.items():
                 os.environ[k] = v
         return func(*args, **kwargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from mlflow.pyfunc import PyFuncModel  # type: ignore
 
 import garden_ai
 from garden_ai import Garden, GardenClient, Pipeline, step
+from garden_ai.pipelines import RegisteredPipeline
 from tests.fixtures.helpers import get_fixture_file_path  # type: ignore
 
 
@@ -42,6 +43,11 @@ def token():
         "access_token": "MyAccessToken",
         "expires_at_seconds": 1024,
     }
+
+
+@pytest.fixture
+def noop_func_uuid():
+    return "9f5688ac-424d-443e-b525-97c72e4e083f"
 
 
 @pytest.fixture
@@ -150,7 +156,14 @@ def pipeline_toy_example(tmp_requirements_txt):
 
 
 @pytest.fixture
-def garden_all_fields(pipeline_toy_example):
+def registered_pipeline_toy_example(pipeline_toy_example, noop_func_uuid):
+    pipeline_toy_example.doi = "10.26311/fake-doi"
+    pipeline_toy_example.func_uuid = noop_func_uuid
+    return RegisteredPipeline.from_pipeline(pipeline_toy_example)
+
+
+@pytest.fixture
+def garden_all_fields(registered_pipeline_toy_example):
     pea_garden = Garden(
         authors=["Mendel, Gregor"],
         title="Experiments on Plant Hybridization",
@@ -161,7 +174,7 @@ def garden_all_fields(pipeline_toy_example):
     pea_garden.version = "0.0.1"
     pea_garden.description = "This Garden houses ML pipelines for Big Pea Data."
     pea_garden.doi = "10.26311/fake-doi"
-    pea_garden.pipelines += [pipeline_toy_example]
+    pea_garden.pipeline_ids += [registered_pipeline_toy_example.uuid]
     pea_garden.validate()
     return pea_garden
 

--- a/tests/fixtures/database_dumps/one_pipeline_one_garden_connected.txt
+++ b/tests/fixtures/database_dumps/one_pipeline_one_garden_connected.txt
@@ -1,6 +1,9 @@
 {
   "pipelines": {
     "b537520b-e86e-45bf-8566-4555a72b0b08": {
+      "uuid": "b537520b-e86e-45bf-8566-4555a72b0b08",
+      "doi": "10.23677/jx31-gx98",
+      "func_uuid": "9f5688ac-424d-443e-b525-97c72e4e083f",
       "title": "Fixture pipeline",
       "authors": [
         "Garden Team"
@@ -14,7 +17,6 @@
           "description": " ",
           "input_info": "{'input_data': <class 'object'>}",
           "output_info": "return: <class 'object'>",
-          "uuid": "abc4356e-b845-42f8-8276-fa2e6de7b3e5",
           "conda_dependencies": [],
           "pip_dependencies": [],
           "python_version": null
@@ -27,7 +29,6 @@
           "description": null,
           "input_info": "{'data': <class 'object'>}",
           "output_info": "return: <class 'object'>",
-          "uuid": "9015f3b0-fa71-4673-b3e4-fd80977a5a78",
           "conda_dependencies": [],
           "pip_dependencies": [],
           "python_version": null
@@ -40,23 +41,20 @@
           "description": null,
           "input_info": "{'input_arg': <class 'object'>}",
           "output_info": "return: <class 'object'>",
-          "uuid": "bb71b032-c9dd-4dd0-9667-b0e9302f8218",
           "conda_dependencies": [],
           "pip_dependencies": [],
           "python_version": null
         }
       ],
       "contributors": [],
-      "doi": "10.23677/jx31-gx98",
-      "uuid": "b537520b-e86e-45bf-8566-4555a72b0b08",
-      "funcx_uuid": "c0158db4-5904-499b-a02a-e4cb8cbb0daa",
       "description": "",
       "version": "0.0.1",
       "year": "2023",
       "tags": [],
-      "requirements_file": null,
-      "python_version": "3.9.6",
-      "pip_dependencies": [],
+      "python_version": "3.10.10",
+      "pip_dependencies": [
+        "garden-ai@ git+https://github.com/garden-ai/garden.git"
+      ],
       "conda_dependencies": []
     }
   },
@@ -67,18 +65,15 @@
       ],
       "contributors": [],
       "title": "Will Test Garden",
-      "doi": "10.23677/jx31-db53",
+      "doi": "10.23677/fake-doi",
       "description": "",
       "publisher": "Garden",
       "year": "2023",
       "language": "en",
       "tags": [],
       "version": "0.0.1",
-      "pipelines": [
-        {
-          "uuid": "b537520b-e86e-45bf-8566-4555a72b0b08",
-          "doi": "10.23677/jx31-gx98"
-        }
+      "pipeline_ids": [
+        "b537520b-e86e-45bf-8566-4555a72b0b08"
       ],
       "uuid": "e1a3b50b-4efc-42c8-8422-644f4f858b87"
     }

--- a/tests/fixtures/database_dumps/one_pipeline_one_garden_unconnected.txt
+++ b/tests/fixtures/database_dumps/one_pipeline_one_garden_unconnected.txt
@@ -1,6 +1,9 @@
 {
   "pipelines": {
     "b537520b-e86e-45bf-8566-4555a72b0b08": {
+      "uuid": "b537520b-e86e-45bf-8566-4555a72b0b08",
+      "doi": "10.23677/jx31-gx98",
+      "func_uuid": "9f5688ac-424d-443e-b525-97c72e4e083f",
       "title": "Fixture pipeline",
       "authors": [
         "Garden Team"
@@ -14,7 +17,6 @@
           "description": " ",
           "input_info": "{'input_data': <class 'object'>}",
           "output_info": "return: <class 'object'>",
-          "uuid": "abc4356e-b845-42f8-8276-fa2e6de7b3e5",
           "conda_dependencies": [],
           "pip_dependencies": [],
           "python_version": null
@@ -27,7 +29,6 @@
           "description": null,
           "input_info": "{'data': <class 'object'>}",
           "output_info": "return: <class 'object'>",
-          "uuid": "9015f3b0-fa71-4673-b3e4-fd80977a5a78",
           "conda_dependencies": [],
           "pip_dependencies": [],
           "python_version": null
@@ -40,23 +41,20 @@
           "description": null,
           "input_info": "{'input_arg': <class 'object'>}",
           "output_info": "return: <class 'object'>",
-          "uuid": "bb71b032-c9dd-4dd0-9667-b0e9302f8218",
           "conda_dependencies": [],
           "pip_dependencies": [],
           "python_version": null
         }
       ],
       "contributors": [],
-      "doi": "10.23677/jx31-gx98",
-      "uuid": "b537520b-e86e-45bf-8566-4555a72b0b08",
-      "funcx_uuid": "c0158db4-5904-499b-a02a-e4cb8cbb0daa",
       "description": "",
       "version": "0.0.1",
       "year": "2023",
       "tags": [],
-      "requirements_file": null,
-      "python_version": "3.9.6",
-      "pip_dependencies": [],
+      "python_version": "3.10.10",
+      "pip_dependencies": [
+        "garden-ai@ git+https://github.com/garden-ai/garden.git"
+      ],
       "conda_dependencies": []
     }
   },
@@ -67,14 +65,14 @@
       ],
       "contributors": [],
       "title": "Will Test Garden",
-      "doi": null,
+      "doi": "10.23677/fake-doi",
       "description": "",
       "publisher": "Garden",
       "year": "2023",
       "language": "en",
       "tags": [],
       "version": "0.0.1",
-      "pipelines": [],
+      "pipeline_ids": [],
       "uuid": "e1a3b50b-4efc-42c8-8422-644f4f858b87"
     }
   }

--- a/tests/fixtures/fixture_pipeline/integration_pipeline.py
+++ b/tests/fixtures/fixture_pipeline/integration_pipeline.py
@@ -1,5 +1,4 @@
 ## THIS FILE WAS AUTOMATICALLY GENERATED ##
-import typing
 from pathlib import Path
 
 from garden_ai import GardenClient, Pipeline, step

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,6 +140,7 @@ def test_garden_publish(database_with_connected_pipeline, mocker, use_doi):
     garden_uuid = "e1a3b50b-4efc-42c8-8422-644f4f858b87"
     garden_doi = "10.23677/fake-doi"
     pipeline_uuid = "b537520b-e86e-45bf-8566-4555a72b0b08"
+    mock_client._mint_doi.return_value = garden_doi
 
     def run_test_with_id(garden_id):
         command = [
@@ -154,9 +155,12 @@ def test_garden_publish(database_with_connected_pipeline, mocker, use_doi):
         mock_client._mint_doi.assert_called_once()
 
         args = mock_client.publish_garden_metadata.call_args.args
-        denormalized_garden_metadata = args[0]
+        garden = args[0]
+        denormalized_garden_metadata = garden.expanded_metadata()
         assert denormalized_garden_metadata["pipelines"][0]["steps"] is not None
-        assert denormalized_garden_metadata["pipelines"][0]["uuid"] == pipeline_uuid
+        assert (
+            str(denormalized_garden_metadata["pipelines"][0]["uuid"]) == pipeline_uuid
+        )
 
     if use_doi:
         run_test_with_id(garden_doi)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,14 @@
-import pytest
-from garden_ai.app.main import app
-from garden_ai.client import GardenClient
-from typer.testing import CliRunner
-import string
 import random
+import string
 from keyword import iskeyword
-from garden_ai.app.pipeline import clean_identifier
+
+import pytest
+from typer.testing import CliRunner
+
 from garden_ai import local_data
+from garden_ai.app.main import app
+from garden_ai.app.pipeline import clean_identifier
+from garden_ai.client import GardenClient
 
 runner = CliRunner()
 
@@ -107,15 +109,17 @@ def test_garden_pipeline_add(database_with_unconnected_pipeline, mocker, use_doi
 
     def run_test_with_ids(garden_id, pipeline_id):
         before_addition = local_data.get_local_garden_by_uuid(garden_id)
-        assert len(before_addition["pipelines"]) == 0
+        assert len(before_addition.pipeline_ids) == 0
 
         command = ["garden", "add-pipeline", "-g", garden_id, "-p", pipeline_id]
         result = runner.invoke(app, command)
         assert result.exit_code == 0
 
-        after_addition = local_data.get_local_garden_by_uuid(garden_id)
+        garden_after_addition = local_data.get_local_garden_by_uuid(garden_id)
+        # expanded metadata includes "pipelines" attribute
+        after_addition = garden_after_addition.expanded_metadata()
         assert len(after_addition["pipelines"]) == 1
-        assert after_addition["pipelines"][0]["uuid"] == pipeline_uuid
+        assert str(after_addition["pipelines"][0]["uuid"]) == pipeline_uuid
         assert after_addition["pipelines"][0]["doi"] == pipeline_doi
 
     if use_doi:
@@ -134,7 +138,7 @@ def test_garden_publish(database_with_connected_pipeline, mocker, use_doi):
     mocker.patch("garden_ai.app.garden.GardenClient").return_value = mock_client
 
     garden_uuid = "e1a3b50b-4efc-42c8-8422-644f4f858b87"
-    garden_doi = "10.23677/jx31-db53"
+    garden_doi = "10.23677/fake-doi"
     pipeline_uuid = "b537520b-e86e-45bf-8566-4555a72b0b08"
 
     def run_test_with_id(garden_id):

--- a/tests/test_local_db.py
+++ b/tests/test_local_db.py
@@ -1,37 +1,39 @@
-import json
-
 from garden_ai import local_data
 
 
 def test_local_storage_garden(mocker, garden_client, garden_all_fields, tmp_path):
     # mock to replace "~/.garden/db"
-    mocker.patch("garden_ai.client.LOCAL_STORAGE", new=tmp_path)
+    mocker.patch("garden_ai.local_data.LOCAL_STORAGE", new=tmp_path)
     uuid = garden_all_fields.uuid
     local_data.put_local_garden(garden_all_fields)
-    record = local_data.get_local_garden_by_uuid(uuid)
-    assert json.dumps(record) == garden_all_fields.json()
+    from_record = local_data.get_local_garden_by_uuid(uuid)
+    assert from_record == garden_all_fields
 
 
-def test_local_storage_pipeline(mocker, garden_client, pipeline_toy_example, tmp_path):
+def test_local_storage_pipeline(
+    mocker, garden_client, registered_pipeline_toy_example, tmp_path
+):
     # mock to replace "~/.garden/db"
-    mocker.patch("garden_ai.client.LOCAL_STORAGE", new=tmp_path)
-    uuid = pipeline_toy_example.uuid
-    local_data.put_local_pipeline(pipeline_toy_example)
-    record = local_data.get_local_pipeline_by_uuid(uuid)
-    assert json.dumps(record) == pipeline_toy_example.json()
+    mocker.patch("garden_ai.local_data.LOCAL_STORAGE", new=tmp_path)
+    local_data.put_local_pipeline(registered_pipeline_toy_example)
+    uuid = registered_pipeline_toy_example.uuid
+    from_record = local_data.get_local_pipeline_by_uuid(uuid)
+    assert from_record == registered_pipeline_toy_example
 
 
-def test_local_storage_keyerror(mocker, garden_client, garden_all_fields, tmp_path):
+def test_local_storage_keyerror(
+    mocker, garden_client, registered_pipeline_toy_example, garden_all_fields, tmp_path
+):
     # mock to replace "~/.garden/db"
     tmp_path.mkdir(parents=True, exist_ok=True)
-    mocker.patch("garden_ai.client.LOCAL_STORAGE", new=tmp_path)
-    pipeline, *_ = garden_all_fields.pipelines
-    # put the pipeline, not garden (hence db is nonempty)
+    mocker.patch("garden_ai.local_data.LOCAL_STORAGE", new=tmp_path)
+    # put the pipeline, not the garden
+    pipeline = registered_pipeline_toy_example
     local_data.put_local_pipeline(pipeline)
 
     # can't find the garden
     assert local_data.get_local_garden_by_uuid(garden_all_fields.uuid) is None
 
     # can find the pipeline
-    record = local_data.get_local_pipeline_by_uuid(pipeline.uuid)
-    assert json.dumps(record) == pipeline.json()
+    from_record = local_data.get_local_pipeline_by_uuid(pipeline.uuid)
+    assert from_record == pipeline

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -33,11 +33,10 @@ def test_validate_no_fields(garden_no_fields):
 def test_validate_required_only(garden_no_fields):
     garden = garden_no_fields
     garden.authors = ["Mendel, Gregor"]
-    garden.title = "Experiments on Plant Hybridization"
     assert not garden.doi
     with pytest.raises(ValidationError):
         garden.validate()
-    garden.doi = "10.26311/fake-doi"
+    garden.title = "Experiments on Plant Hybridization"
     garden.validate()
 
 
@@ -214,31 +213,6 @@ def test_step_authors_are_pipeline_contributors(pipeline_toy_example):
             assert author in pipe.contributors
         for contributor in s.contributors:
             assert contributor in pipe.contributors
-
-
-def test_pipeline_authors_are_garden_contributors(
-    garden_all_fields,
-    pipeline_toy_example,
-):
-    # verify that adding a pipeline with new authors
-    # updates the garden's 'contributors' field
-    garden, pipe = garden_all_fields, pipeline_toy_example
-    garden.add_new_pipeline(
-        pipe.title,
-        pipe.steps,
-        authors=pipe.authors,
-        requirements_file=pipe.requirements_file,
-    )
-
-    known_authors = [a for a in garden.authors]
-    known_contributors = [c for c in garden.contributors]
-    garden._sync_author_metadata()
-    # should never modify garden.authors implicitly
-    assert known_authors == garden.authors
-    # should not lose contributors by adding pipelines
-    assert set(known_contributors) <= set(garden.contributors)
-    # 'contributors' at any pipeline level should propagate to garden
-    assert set(pipe.contributors) <= set(garden.contributors)
 
 
 def test_upload_model(mocker, tmp_path):


### PR DESCRIPTION
Closes #113 

## Overview

This PR introduces the `RegisteredPipeline` class, which is strictly metadata so that it can be de-/serialized without losing anything. 

This PR also changes the `Garden` class so that it only has a list of `pipeline_ids`, rather than full pipeline objects -- to access more than just the uuid of a garden's pipeline, the class now has a few helpers like `garden.collect_pipelines()` and `.expanded_metadata()`. 

## Discussion

All the database helper functions that previously returned a dictionary now return an object 
See also the description of #113 
## Testing

How did you test this? 
Painstakingly 


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--115.org.readthedocs.build/en/115/

<!-- readthedocs-preview garden-ai end -->