### PR TITLE
Persist model metadata to Globus Search

### DIFF
--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -159,7 +159,7 @@ class Garden(BaseModel):
         """
 
         data = self.dict()
-        data["pipelines"] = [p.dict() for p in self.collect_pipelines()]
+        data["pipelines"] = [p.expanded_metadata() for p in self.collect_pipelines()]
         return data
 
     def expanded_json(self) -> JSON:

--- a/garden_ai/mlmodel.py
+++ b/garden_ai/mlmodel.py
@@ -192,6 +192,7 @@ class _Model:
         model_full_name: str,
     ):
         self.model = None
+        self.model_full_name = model_full_name
         self.model_uri = f"models:/{model_full_name}"
         # extract dependencies without loading model into memory
         # make it easier for steps to infer

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -410,11 +410,3 @@ class RegisteredPipeline(BaseModel):
         data = self.dict()
         data["models"] = [m.dict() for m in self.collect_models()]
         return data
-
-    def expanded_json(self) -> JSON:
-        """Helper: return the expanded pipeline metadata as JSON.
-
-        See: ``RegisteredPipeline.expanded_metadata`` method
-        """
-        data = self.expanded_metadata()
-        return json.dumps(data, default=garden_json_encoder)

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field, PrivateAttr, validator
 from pydantic.dataclasses import dataclass
 
 from garden_ai.app.console import console
+from garden_ai.mlmodel import RegisteredModel
 from garden_ai.datacite import (
     Contributor,
     Creator,
@@ -51,6 +52,7 @@ class Pipeline:
     authors (List[str]): A list of the authors of the pipeline.
     title (str): The title of the pipeline.
     steps (List[Step]): A list of the steps in the pipeline.
+    model_uris (List[str]): A list of model uris used in the pipeline.
 
     """
 
@@ -69,6 +71,7 @@ class Pipeline:
     python_version: Optional[str] = Field(None)
     pip_dependencies: List[str] = Field(default_factory=list)
     conda_dependencies: List[str] = Field(default_factory=list)
+    model_uris: List[str] = Field(default_factory=list)
 
     def _composed_steps(*args, **kwargs):
         """ "This method intentionally left blank"
@@ -127,7 +130,7 @@ class Pipeline:
     def _collect_requirements(self):
         """collect requirements to pass to globus compute container service.
 
-        Populates attributes: ``self.python_version, self.pip_dependencies, self.conda_dependencies``
+        Populates attributes: ``self.python_version, self.pip_dependencies, self.conda_dependencies, self.models``
         """
 
         # mapping of python-version-witness: python-version (collected for warning msg below)
@@ -158,6 +161,7 @@ class Pipeline:
         for step in self.steps:
             self.conda_dependencies += step.conda_dependencies
             self.pip_dependencies += step.pip_dependencies
+            self.model_uris += step.model_uris
             py_versions[step.__name__] = step.python_version
 
         self.python_version = py_versions["pipeline"] or py_versions["system"]
@@ -301,6 +305,7 @@ class RegisteredPipeline(BaseModel):
     pip_dependencies: List[str] = Field(default_factory=list)
     conda_dependencies: List[str] = Field(default_factory=list)
     _env_vars: Dict[str, str] = PrivateAttr(default_factory=dict)
+    model_uris: List[str] = Field(default_factory=list)
 
     def __call__(
         self,
@@ -368,3 +373,48 @@ class RegisteredPipeline(BaseModel):
         record = pipeline.json()
         data = json.loads(record)
         return cls(**data)
+
+    def collect_models(self) -> List[RegisteredModel]:
+        """Collect the RegisteredModel objects if possible, and uri stubs if not."""
+        from .local_data import get_local_model_by_uri
+
+        models = []
+        for uri in self.model_uris:
+            model = get_local_model_by_uri(uri)
+            if model:
+                models += [model]
+            else:
+                logger.warning(
+                    f"No record in local database for model {uri}. "
+                    "Published garden will not have detailed metadata for that model."
+                )
+        return models
+
+    def expanded_metadata(self) -> Dict[str, Any]:
+        """Helper: build the "complete" metadata dict with nested ``Model`` metadata.
+
+        Notes
+        ------
+        When serializing normally with ``registered_pipeline.{dict(), json()}``, only the
+        uris of the models in the pipeline are included.
+
+        This returns a superset of ``registered_pipeline.dict()``, so that the following holds:
+
+            pipeline == Registered_Pipeline(**pipeline.expanded_metadata()) == Registered_Pipeline(**pipeline.dict())
+
+        Returns
+        -------
+        Dict[str, Any]  ``RegisteredPipeline`` metadata dict augmented with a list of ``RegisteredModel`` metadata
+        """
+
+        data = self.dict()
+        data["models"] = [m.dict() for m in self.collect_models()]
+        return data
+
+    def expanded_json(self) -> JSON:
+        """Helper: return the expanded pipeline metadata as JSON.
+
+        See: ``RegisteredPipeline.expanded_metadata`` method
+        """
+        data = self.expanded_metadata()
+        return json.dumps(data, default=garden_json_encoder)

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -130,7 +130,7 @@ class Pipeline:
     def _collect_requirements(self):
         """collect requirements to pass to globus compute container service.
 
-        Populates attributes: ``self.python_version, self.pip_dependencies, self.conda_dependencies, self.models``
+        Populates attributes: ``self.python_version, self.pip_dependencies, self.conda_dependencies, self.model_uris``
         """
 
         # mapping of python-version-witness: python-version (collected for warning msg below)
@@ -375,7 +375,7 @@ class RegisteredPipeline(BaseModel):
         return cls(**data)
 
     def collect_models(self) -> List[RegisteredModel]:
-        """Collect the RegisteredModel objects if possible, and uri stubs if not."""
+        """Collect the RegisteredModel objects that are present in the local DB"""
         from .local_data import get_local_model_by_uri
 
         models = []

--- a/garden_ai/steps.py
+++ b/garden_ai/steps.py
@@ -82,7 +82,8 @@ class Step:
         purposes.
 
     model_uris: List[str]
-        A reference to the models used in this step, if any. Model uris as stored in MLFlow.
+        A reference to the models used in this step, if any.
+        Model identifiers as stored in MLFlow (not including the 'models:/' prefix).
 
     uuid: UUID
         short for "uuid"

--- a/garden_ai/steps.py
+++ b/garden_ai/steps.py
@@ -81,6 +81,9 @@ class Step:
         The main researchers involved in producing the Step, for citation and discoverability
         purposes.
 
+    model_uris: List[str]
+        A reference to the models used in this step, if any. Model uris as stored in MLFlow.
+
     uuid: UUID
         short for "uuid"
 
@@ -124,6 +127,7 @@ class Step:
     conda_dependencies: List[str] = Field(default_factory=list)
     pip_dependencies: List[str] = Field(default_factory=list)
     python_version: Optional[str] = Field(None)
+    model_uris: List[str] = Field(default_factory=list)
 
     def __post_init_post_parse__(self):
         # like __post_init__, but called after pydantic validation
@@ -161,6 +165,7 @@ class Step:
                 self.python_version = model.python_version
                 self.conda_dependencies += model.conda_dependencies
                 self.pip_dependencies += model.pip_dependencies
+                self.model_uris += [model.model_full_name]
         return
 
     @validator("func")

--- a/tests/cli/test_garden.py
+++ b/tests/cli/test_garden.py
@@ -97,11 +97,13 @@ def test_garden_publish(database_with_connected_pipeline, mocker, use_doi):
 
         args = mock_client.publish_garden_metadata.call_args.args
         garden = args[0]
+        # Confirm that expanded gardens include pipelines
         denormalized_garden_metadata = garden.expanded_metadata()
         assert denormalized_garden_metadata["pipelines"][0]["steps"] is not None
         assert (
             str(denormalized_garden_metadata["pipelines"][0]["uuid"]) == pipeline_uuid
         )
+        # Confirm that pipelines within expanded gardens contain models
         model = denormalized_garden_metadata["pipelines"][0]["models"][0]
         assert model["version"] == "3"
         assert len(model["connections"]) == 1

--- a/tests/cli/test_garden.py
+++ b/tests/cli/test_garden.py
@@ -102,6 +102,9 @@ def test_garden_publish(database_with_connected_pipeline, mocker, use_doi):
         assert (
             str(denormalized_garden_metadata["pipelines"][0]["uuid"]) == pipeline_uuid
         )
+        model = denormalized_garden_metadata["pipelines"][0]["models"][0]
+        assert model["version"] == "3"
+        assert len(model["connections"]) == 1
 
     if use_doi:
         run_test_with_id(garden_doi)

--- a/tests/fixtures/database_dumps/one_pipeline_one_garden_connected.txt
+++ b/tests/fixtures/database_dumps/one_pipeline_one_garden_connected.txt
@@ -19,7 +19,8 @@
           "output_info": "return: <class 'object'>",
           "conda_dependencies": [],
           "pip_dependencies": [],
-          "python_version": null
+          "python_version": null,
+          "model_uris": []
         },
         {
           "func": "another_step: (data: object) -> object",
@@ -31,7 +32,8 @@
           "output_info": "return: <class 'object'>",
           "conda_dependencies": [],
           "pip_dependencies": [],
-          "python_version": null
+          "python_version": null,
+          "model_uris": []
         },
         {
           "func": "run_inference: (input_arg: object) -> object",
@@ -43,7 +45,8 @@
           "output_info": "return: <class 'object'>",
           "conda_dependencies": [],
           "pip_dependencies": [],
-          "python_version": null
+          "python_version": null,
+          "model_uris": ["willengler@uchicago.edu-will-test-model/3"]
         }
       ],
       "contributors": [],
@@ -55,7 +58,27 @@
       "pip_dependencies": [
         "garden-ai@ git+https://github.com/garden-ai/garden.git"
       ],
-      "conda_dependencies": []
+      "conda_dependencies": [],
+      "model_uris": ["willengler@uchicago.edu-will-test-model/3"]
+    }
+  },
+  "models": {
+    "willengler@uchicago.edu-will-test-model/3": {
+      "model_name": "will-test-model",
+      "version": "3",
+      "user_email": "willengler@uchicago.edu",
+      "flavor": "sklearn",
+      "connections": [
+        {
+          "type": "dataset",
+          "relationship": "origin",
+          "doi": "10.18126/wg3u-g8vu",
+          "repository": "Foundry",
+          "url": "https://foundry-ml.org/#/datasets/10.18126%2Fwg3u-g8vu"
+        }
+      ],
+      "namespaced_model_name": "willengler@uchicago.edu-will-test-model",
+      "model_uri": "willengler@uchicago.edu-will-test-model/3"
     }
   },
   "gardens": {

--- a/tests/fixtures/database_dumps/one_pipeline_one_garden_unconnected.txt
+++ b/tests/fixtures/database_dumps/one_pipeline_one_garden_unconnected.txt
@@ -19,7 +19,8 @@
           "output_info": "return: <class 'object'>",
           "conda_dependencies": [],
           "pip_dependencies": [],
-          "python_version": null
+          "python_version": null,
+          "model_uris": ["willengler@uchicago.edu-will-test-model/3"]
         },
         {
           "func": "another_step: (data: object) -> object",
@@ -31,7 +32,8 @@
           "output_info": "return: <class 'object'>",
           "conda_dependencies": [],
           "pip_dependencies": [],
-          "python_version": null
+          "python_version": null,
+          "model_uris": ["willengler@uchicago.edu-will-test-model/3"]
         },
         {
           "func": "run_inference: (input_arg: object) -> object",
@@ -43,7 +45,8 @@
           "output_info": "return: <class 'object'>",
           "conda_dependencies": [],
           "pip_dependencies": [],
-          "python_version": null
+          "python_version": null,
+          "model_uris": ["willengler@uchicago.edu-will-test-model/3"]
         }
       ],
       "contributors": [],
@@ -55,7 +58,27 @@
       "pip_dependencies": [
         "garden-ai@ git+https://github.com/garden-ai/garden.git"
       ],
-      "conda_dependencies": []
+      "conda_dependencies": [],
+      "model_uris": ["willengler@uchicago.edu-will-test-model/3"]
+    }
+  },
+  "models": {
+    "willengler@uchicago.edu-will-test-model/3": {
+      "model_name": "will-test-model",
+      "version": "3",
+      "user_email": "willengler@uchicago.edu",
+      "flavor": "sklearn",
+      "connections": [
+        {
+          "type": "dataset",
+          "relationship": "origin",
+          "doi": "10.18126/wg3u-g8vu",
+          "repository": "Foundry",
+          "url": "https://foundry-ml.org/#/datasets/10.18126%2Fwg3u-g8vu"
+        }
+      ],
+      "namespaced_model_name": "willengler@uchicago.edu-will-test-model",
+      "model_uri": "willengler@uchicago.edu-will-test-model/3"
     }
   },
   "gardens": {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -262,6 +262,10 @@ def test_step_collect_model_requirements(step_with_model, tmp_conda_yml):
     return
 
 
+def test_step_collect_model(step_with_model):
+    assert step_with_model.model_uris == ["email@addr.ess-fake-model/fake-version"]
+
+
 def test_pipeline_collects_own_requirements(
     pipeline_using_step_with_model, tmp_requirements_txt
 ):
@@ -281,6 +285,12 @@ def test_pipeline_collects_step_requirements(
 
     for step_dependency in step_with_model.pip_dependencies:
         assert step_dependency in pipeline_using_step_with_model.pip_dependencies
+
+
+def test_pipeline_collects_step_models(pipeline_using_step_with_model):
+    assert pipeline_using_step_with_model.model_uris == [
+        "email@addr.ess-fake-model/fake-version"
+    ]
 
 
 def test_step_compose_ignores_defaults(tmp_requirements_txt):


### PR DESCRIPTION
Closes #97

## Overview

This PR creates a link from Pipelines to Models via a new `model_uris` field in Pipelines and Steps. It populates those fields at Pipeline init time. And the model metadata gets persisted by enriching Pipeline models at search ingest time, taking Pipelines' references to models and fleshing them out with a full Model metadata object.

## Discussion

## Testing

Added or expanded unit tests to make sure I covered:
- At `garden publish` time, model metadata is included in the expanded garden metadata. (Gardens include full pipelines as children and pipelines include full models as children.)
- model_uris get added to pipelines at pipeline init time as part of the same process where we pull step requirements into pipeline requirements.

<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--124.org.readthedocs.build/en/124/

<!-- readthedocs-preview garden-ai end -->