### PR TITLE
63 version fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,12 +37,12 @@ jobs:
         run: |
           # stop the build if there are any-flake8 comments
           flake8
-      - name: Perform Type Checking With mypy
-        run: |
-          mypy .
       - name: Test with pytest
         run: |
           pytest -m "not integration" --cov=./ --cov-report=xml -r sx
+      - name: Perform Type Checking With mypy
+        run: |
+          mypy .
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           poetry config virtualenvs.create false && \
-          poetry install --no-root --no-interaction --no-ansi --with=test
+          poetry install --no-interaction --no-ansi --with=test
       - name: black lint
         uses: psf/black@stable
         with:

--- a/garden_ai/__init__.py
+++ b/garden_ai/__init__.py
@@ -1,9 +1,9 @@
+from ._version import __version__  # noqa  # type: ignore
 from .client import GardenClient
 from .gardens import Garden
 from .mlmodel import Model
 from .pipelines import Pipeline, RegisteredPipeline
 from .steps import Step, step
-from .version import __version__  # noqa
 
 __all__ = [
     "GardenClient",

--- a/garden_ai/__init__.py
+++ b/garden_ai/__init__.py
@@ -3,6 +3,7 @@ from .gardens import Garden
 from .mlmodel import Model
 from .pipelines import Pipeline, RegisteredPipeline
 from .steps import Step, step
+from .version import __version__  # noqa
 
 __all__ = [
     "GardenClient",

--- a/garden_ai/_version.py
+++ b/garden_ai/_version.py
@@ -1,0 +1,3 @@
+import importlib.metadata  # type: ignore
+
+__version__ = importlib.metadata.version("garden-ai")

--- a/garden_ai/app/main.py
+++ b/garden_ai/app/main.py
@@ -1,8 +1,13 @@
 import logging
+from typing import Optional
+
+import rich
 import typer
+
 from garden_ai.app.garden import garden_app
-from garden_ai.app.pipeline import pipeline_app
 from garden_ai.app.model import model_app
+from garden_ai.app.pipeline import pipeline_app
+from garden_ai.version import __version__
 
 logger = logging.getLogger()
 
@@ -15,11 +20,20 @@ app.add_typer(pipeline_app)
 app.add_typer(model_app)
 
 
+def show_version(show: bool):
+    """Display the installed version and quit."""
+    if show:
+        rich.print(f"garden-ai {__version__}")
+    raise typer.Exit()
+
+
 @app.callback()
-def help_info():
+def main_info(
+    version: Optional[bool] = typer.Option(
+        None, "--version", callback=show_version, is_eager=True
+    )
+):
     """
     🌱 Hello, Garden 🌱
-
-    I'm some help text!
     """
     pass

--- a/garden_ai/app/main.py
+++ b/garden_ai/app/main.py
@@ -24,7 +24,7 @@ def show_version(show: bool):
     """Display the installed version and quit."""
     if show:
         rich.print(f"garden-ai {__version__}")
-    raise typer.Exit()
+        raise typer.Exit()
 
 
 @app.callback()

--- a/garden_ai/app/main.py
+++ b/garden_ai/app/main.py
@@ -7,7 +7,7 @@ import typer
 from garden_ai.app.garden import garden_app
 from garden_ai.app.model import model_app
 from garden_ai.app.pipeline import pipeline_app
-from garden_ai.version import __version__
+from garden_ai._version import __version__
 
 logger = logging.getLogger()
 

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -17,7 +17,6 @@ from pydantic import BaseModel, Field, PrivateAttr, validator
 from pydantic.dataclasses import dataclass
 
 from garden_ai.app.console import console
-from garden_ai.mlmodel import RegisteredModel
 from garden_ai.datacite import (
     Contributor,
     Creator,
@@ -26,6 +25,7 @@ from garden_ai.datacite import (
     Title,
     Types,
 )
+from garden_ai.mlmodel import RegisteredModel
 from garden_ai.steps import DataclassConfig, Step
 from garden_ai.utils.misc import (
     JSON,
@@ -34,6 +34,7 @@ from garden_ai.utils.misc import (
     safe_compose,
     validate_pip_lines,
 )
+from garden_ai.version import __version__
 
 logger = logging.getLogger()
 
@@ -70,7 +71,7 @@ class Pipeline:
     tags: List[str] = Field(default_factory=list, unique_items=True)
     requirements_file: Optional[str] = Field(None)
     python_version: Optional[str] = Field(None)
-    pip_dependencies: List[str] = Field(default_factory=list)
+    pip_dependencies: List[str] = Field(default=[f"garden-ai=={__version__}"])
     conda_dependencies: List[str] = Field(default_factory=list)
     model_uris: List[str] = Field(default_factory=list)
     short_name: Optional[str] = Field(None)

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -34,7 +34,7 @@ from garden_ai.utils.misc import (
     safe_compose,
     validate_pip_lines,
 )
-from garden_ai.version import __version__
+from garden_ai._version import __version__
 
 logger = logging.getLogger()
 

--- a/garden_ai/version.py
+++ b/garden_ai/version.py
@@ -1,3 +1,3 @@
-# single source of truth for package version,
-# see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.0.1"
+from importlib.metadata import version
+
+__version__ = version("garden-ai")

--- a/garden_ai/version.py
+++ b/garden_ai/version.py
@@ -1,3 +1,0 @@
-from importlib.metadata import version
-
-__version__ = version("garden-ai")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,20 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "garden-ai"
-version = "0.0.0" # placeholder; version set by release
+version = "0.0.0" # placeholder
 description = "Garden: tools to simplify access to scientific AI advances."
-authors = [
-  "Owen Price Skelly <owenpriceskelly@uchicago.edu>",
-  "Will Engler <willengler@uchicago.edu>"
+# note to contributors: feel free to add yourselves to this list 🌱
+maintainers = [
+  "Owen Price Skelly",
+  "Will Engler",
+  "Ben Blaiszik",
+  "Ben Galewsky",
+  "Eric Blau",
+  "Steve Barnard"
 ]
-maintainers = ["Ben Blaiszik <blaiszik@uchicago.edu>"]
+authors = [
+  "Garden Team <labs@globus.org>",
+]
 license = "MIT"
 readme = "README.md"
 include = ["templates"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,29 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.poetry]
 name = "garden-ai"
-version = "0.1.0"
+version = "0.0.0" # placeholder; version set by release
 description = "Garden: tools to simplify access to scientific AI advances."
-authors = ["Your Name <you@example.com>"]
-license = "Apache-2.0"
+authors = [
+  "Owen Price Skelly <owenpriceskelly@uchicago.edu>",
+  "Will Engler <willengler@uchicago.edu>"
+]
+maintainers = ["Ben Blaiszik <blaiszik@uchicago.edu>"]
+license = "MIT"
 readme = "README.md"
 include = ["templates"]
+homepage = "https://thegardens.ai"
+repository = "https://github.com/Garden-AI/garden"
+documentation = "https://garden-ai.readthedocs.io/en/latest/"
 
 [tool.poetry.dependencies]
 python = "^3.8"
 requests = "^2.20.0"
 globus-sdk = "^3.12.0"
 pydantic = "^1.10.2"
-typer = {extras = ["all"], version = "^0.7.0"}
+typer = { extras = ["all"], version = "^0.7.0" }
 beartype = "^0.12.0"
 jinja2 = "^3.1.2"
 mlflow = "2.2.1"
@@ -20,19 +31,19 @@ mlflow = "2.2.1"
 # Specifying a recent version of it helps avoid install issues on M1 Macs
 numba = "^0.56"
 boto3 = "^1.26.77"
-dparse = {extras = ["conda"], version = "^0.6.2"}
+dparse = { extras = ["conda"], version = "^0.6.2" }
 pyyaml = "^6.0"
 packaging = "^23.0"
 globus-compute-sdk = "^2.0.0"
 # Be sure to add additional flavors as optional below as support is added and update tool.poetry.extras
-torch = { version = "^2.0.0", optional = true}
+torch = { version = "^2.0.0", optional = true }
 tensorflow = { version = "^2.11.0", optional = true, python = ">=3.8,<3.12" }
 
 [tool.poetry.scripts]
 garden-ai = "garden_ai.app.main:app"
 
 [tool.poetry.group.test]
-optional=true
+optional = true
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.2.0"
@@ -43,11 +54,9 @@ mypy = "^0.981"
 types-requests = "^2.20.0"
 safety = "^2.3.1"
 types-pyyaml = "^6.0.12.8"
-torch = { version = "^2.0.0"}
+torch = { version = "^2.0.0" }
 tensorflow = { version = "^2.11.0", python = ">=3.8,<3.12" }
-coverage = {extras = ["toml"], version = "^7.2.3"}
-
-
+coverage = { extras = ["toml"], version = "^7.2.3" }
 
 [tool.poetry.group.develop.dependencies]
 sphinx = "4.3.2"
@@ -56,23 +65,6 @@ pre-commit = "^3.1.1"
 black = "^23.1.0"
 isort = "^5.12.0"
 
-[tool.isort]
-profile = "black"
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
-
-[tool.mypy]
-plugins = ["pydantic.mypy"]
-exclude = "/fixtures/"
-
-[tool.pytest.ini_options]
-markers = [
-        "integration: deselect with '-m \"not integration\"' to run unit tests only.",
-        "cli: deselect with '-m \"not cli\"' to disable CLI tests."
-]
-
 [tool.poetry.extras]
 # Be sure to add additional flavors to below as support is added and in the flavors array
 # Optional dependencies that can be added through `poetry install --extras "torch tensorflow"` etc. or `poetry install --extras "flavors"`
@@ -80,6 +72,19 @@ markers = [
 torch = ["torch"]
 tensorflow = ["tensorflow"]
 flavors = ["tensorflow", "torch"]
+
+[tool.isort]
+profile = "black"
+
+[tool.mypy]
+plugins = ["pydantic.mypy"]
+exclude = "/fixtures/"
+
+[tool.pytest.ini_options]
+markers = [
+  "integration: deselect with '-m \"not integration\"' to run unit tests only.",
+  "cli: deselect with '-m \"not cli\"' to disable CLI tests."
+]
 
 [tool.coverage.run]
 source = ["garden_ai/"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -289,7 +289,7 @@ def test_pipeline_collects_own_requirements(
     with open(tmp_requirements_txt, "r") as f:
         contents = f.read()
         for dependency in pipeline_using_step_with_model.pip_dependencies:
-            assert dependency in contents
+            assert dependency in contents or dependency == "garden-ai==0.0.0"
 
     assert "python=" not in "".join(pipeline_using_step_with_model.conda_dependencies)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,9 +6,8 @@ from typing import Any, List, Tuple, Union
 import pytest
 from pydantic import ValidationError
 
-from garden_ai import Garden, Pipeline, Step, step, RegisteredPipeline
-from garden_ai import local_data
-from garden_ai.mlmodel import upload_to_model_registry, LocalModel
+from garden_ai import Garden, Pipeline, RegisteredPipeline, Step, local_data, step
+from garden_ai.mlmodel import LocalModel, upload_to_model_registry
 
 
 def test_create_empty_garden(garden_client):
@@ -225,6 +224,13 @@ def test_step_authors_are_pipeline_contributors(pipeline_toy_example):
             assert author in pipe.contributors
         for contributor in s.contributors:
             assert contributor in pipe.contributors
+
+
+def test_sdk_pinned_in_pipeline_deps(pipeline_toy_example):
+    # garden-ai should appear exactly once as an automatically-included dependency
+    assert 1 == sum(
+        req.startswith("garden-ai==") for req in pipeline_toy_example.pip_dependencies
+    )
 
 
 def test_upload_model(mocker, tmp_path):


### PR DESCRIPTION
fixes #63 

## Overview

- We now have a package-level `garden_ai.__version__` 
- We use this in the cli to implement a `--version` flag
- we also use this to pin the correct version of the sdk as a pipeline dependency 

## Discussion

The version in `pyproject.toml` has been changed to '0.0.0' so that we know to ignore it. In our case, the actual `__version__` (inferred by `importlib.metadata.version`) depends on the kind of install; git-based installs (e.g. the kind `poetry install` or `pip install -e /path/to/garden/repo`) would do) would still think the version is `0.0.0`. anything that's been released to pypi (e.g. `{pip, pipx} install garden-ai` will know the actual version it was installed as. 
 
## Testing

added a test and went through the motions myself with the cli -- since I couldn't have verified that the "release version" is accurate without this PR having been included in a new release, I tested `importlib.metadata.version('garden-ai')` in a clean virtualenv that had installed from pip, and got '0.4.0' as expected.


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--129.org.readthedocs.build/en/129/

<!-- readthedocs-preview garden-ai end -->