### PR TITLE
144 steps copy source code

### DIFF
--- a/garden_ai/steps.py
+++ b/garden_ai/steps.py
@@ -8,7 +8,7 @@ from functools import update_wrapper, wraps
 from inspect import Parameter, Signature, signature
 from typing import Any, Callable, Dict, List, Optional
 
-from pydantic import Field, ValidationError, validator
+from pydantic import Field, validator
 from pydantic.dataclasses import dataclass
 from typing_extensions import get_type_hints
 
@@ -192,16 +192,17 @@ class Step:
         # passing an arbitrary callable directly to the Step constructor, but
         # because only plain python can be decorated, if they're using the
         # decorator this shouldn't be problematic.
-        func = values["func"]
-        try:
-            return inspect.getsource(func)
-        except (OSError, TypeError) as e:
-            raise ValueError(
-                f"Could not find python source code for {func}. If using a \
-            builtin or externally-defined function as a step, best practice is \
-            to use @step to decorate a minimal function that invokes it, rather \
-            than using it as a step directly."
-            ) from e
+        if "func" in values:
+            func = values["func"]
+            try:
+                return inspect.getsource(func)
+            except (OSError, TypeError) as e:
+                raise ValueError(
+                    f"Could not find python source code for {func}. If using a \
+                builtin or externally-defined function as a step, best practice is \
+                to use @step to decorate a minimal function that invokes it, rather \
+                than using it as a step directly."
+                ) from e
 
     def json(self) -> JSON:
         return json.dumps(self, default=garden_json_encoder)

--- a/garden_ai/steps.py
+++ b/garden_ai/steps.py
@@ -62,9 +62,7 @@ class Step:
             A reference to the models used in this step, if any. Model identifiers are as stored in MLFlow (not including the 'models:/' prefix).
         source (Optional[str]):
             Should not be set by users. Consists of the plain python source code \
-            used to define `func`, if possible. If not possible (e.g. builtin \
-            functions which don't have python source), the likely import \
-            statement used to bring `func` into the current scope.
+            used to define `func`, if possible.
 
     Raises:
         TypeError:
@@ -199,9 +197,9 @@ class Step:
             except (OSError, TypeError) as e:
                 raise ValueError(
                     f"Could not find python source code for {func}. If using a \
-                builtin or externally-defined function as a step, best practice is \
-                to use @step to decorate a minimal function that invokes it, rather \
-                than using it as a step directly."
+builtin or externally-defined function as a step, best practice is \
+to use @step to decorate a minimal function that invokes it, rather \
+than using it as a step directly."
                 ) from e
 
     def json(self) -> JSON:

--- a/garden_ai/steps.py
+++ b/garden_ai/steps.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import typing
@@ -7,7 +8,7 @@ from functools import update_wrapper, wraps
 from inspect import Parameter, Signature, signature
 from typing import Any, Callable, Dict, List, Optional
 
-from pydantic import Field, validator
+from pydantic import Field, ValidationError, validator
 from pydantic.dataclasses import dataclass
 from typing_extensions import get_type_hints
 
@@ -59,8 +60,11 @@ class Step:
             The main researchers involved in producing the Step, for citation and discoverability purposes.
         model_uris (List[str]):
             A reference to the models used in this step, if any. Model identifiers are as stored in MLFlow (not including the 'models:/' prefix).
-        uuid (UUID):
-            short for "uuid"
+        source (Optional[str]):
+            Should not be set by users. Consists of the plain python source code \
+            used to define `func`, if possible. If not possible (e.g. builtin \
+            functions which don't have python source), the likely import \
+            statement used to bring `func` into the current scope.
 
     Raises:
         TypeError:
@@ -95,6 +99,7 @@ class Step:
     pip_dependencies: List[str] = Field(default_factory=list)
     python_version: Optional[str] = Field(None)
     model_uris: List[str] = Field(default_factory=list)
+    source: Optional[str] = Field(None)
 
     def __post_init_post_parse__(self):
         # like __post_init__, but called after pydantic validation
@@ -179,6 +184,24 @@ class Step:
                 "https://github.com/beartype/beartype#compliance"
             )
         return f
+
+    @validator("source", always=True, pre=False)
+    def has_findable_source(cls, _, values):
+        # ignores any prior value for the "source" field, populating it with the
+        # found source of `func`.  There are tons of edge cases if the user is
+        # passing an arbitrary callable directly to the Step constructor, but
+        # because only plain python can be decorated, if they're using the
+        # decorator this shouldn't be problematic.
+        func = values["func"]
+        try:
+            return inspect.getsource(func)
+        except (OSError, TypeError) as e:
+            raise ValueError(
+                f"Could not find python source code for {func}. If using a \
+            builtin or externally-defined function as a step, best practice is \
+            to use @step to decorate a minimal function that invokes it, rather \
+            than using it as a step directly."
+            ) from e
 
     def json(self) -> JSON:
         return json.dumps(self, default=garden_json_encoder)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from collections import namedtuple
-from typing import Any, List, Tuple, Union
+from typing import Any, Iterable, List, Tuple, Union
 
 import pytest
 from pydantic import ValidationError
@@ -103,6 +103,17 @@ def test_auto_input_output_metadata():
 
     assert lovingly_annotated.input_info == "This step LOVES accepting arguments"
     assert lovingly_annotated.output_info == "it also returns important results"
+
+
+def test_steps_collect_source():
+    with pytest.raises(ValidationError):
+        # won't be able to find source (or annotations) for builtins
+        builtin_sum_step = Step(func=sum)
+
+    # ... but this is fine
+    @step
+    def builtin_sum_step(xs: Iterable) -> Union[int, float]:
+        return sum(xs)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")


### PR DESCRIPTION
Completes #144 

## Overview

This adds a `source` field to steps, containing the snippet of source code users wrote defining the underlying function. This means that builtins and some other functions can't be used as steps, but they can still be easily used within steps, even if they're only one line. Also, we apparently already made it impossible to use builtins because they wouldn't have had annotations we could use -- I couldn't come up with any steps that would be invalid now but valid before this, anyway. 


```python
# also works as expected if this is in a notebook cell
@step
def preprocessing(input_data: pd.DataFrame) -> pd.DataFrame:
    """doing some preprocessing"""
    smiles = input_data["smiles"]
    return smiles
    
assert preprocessing.source == '@step\ndef preprocessing(input_data: pd.DataFrame) -> pd.DataFrame:\n    """doing some preprocessing"""\n    smiles = input_data["smiles"]\n    return smiles\n'
```

## Discussion

This isn't likely to add a ton of immediate value (this _could_ be useful for #132, depending on how we want to go about that), but regardless I think carrying a copy of the source code is a good-metadata-practice and I'd be surprised if we don't find ways to use it in the future, e.g. on the frontend I think it'll be nice eventually to be able to view the contents of steps. At the very least, if you're the sort of scientist to develop an otherwise lovely pipeline entirely in some `Untitled14.ipynb`, we're keeping a copy of the code you wrote safe somewhere you can't lose it. 

That being said, the `step.source` should not be treated as a source of truth -- there are many weird pathological edge cases that I don't _think_ we need to worry about, but make me nervous anyway. 

For example, if you (1) defined that `preprocessing` function in a plain python module (but not as a step); (2) imported it into a REPL/notebook; and then (3) edited the source file to read:
```python
# pipeline.py
def preprocessing(input_data: pd.DataFrame) -> pd.DataFrame:
    """doing some preprocessing"""
    frowns = input_data["frowns"]  # 😈
    return frowns
```
... and _then_ you constructed the step like: 
```python
# Untitled14.ipynb
my_step = Step(func=preprocessing)
```
You would have a step whose `func` is the code object corresponding to the original function, but whose `source` is the edited text which it only grabbed from the source file when it was asked to. 

I think I can still sleep at night, but only because I couldn't contrive an example that  used the `@step` decorator -- which makes sense, because you can only use the decorator syntax if you're defining the step at the same time you're defining the function itself. 

## Testing

I added a quick unit test and also sanity-checked in a couple notebooks, using steps defined in-notebook and imported from other modules

## Documentation

I updated the `Step` docstring and checked that it looked ok when I ran `mkdocs serve`, but reviewers could check the readthedocs PR build, too.


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--147.org.readthedocs.build/en/147/

<!-- readthedocs-preview garden-ai end -->