### PR TITLE
add naive approach to token refresh

### DIFF
--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -40,7 +40,6 @@ from garden_ai.mlflow_bandaid.binary_header_provider import (
 from garden_ai.mlmodel import (
     LocalModel,
     RegisteredModel,
-    PossibleOldToken,
     upload_to_model_registry,
 )
 from garden_ai.pipelines import Pipeline, RegisteredPipeline

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -37,7 +37,12 @@ from garden_ai.local_data import GardenNotFoundException, PipelineNotFoundExcept
 from garden_ai.mlflow_bandaid.binary_header_provider import (
     BinaryContentTypeHeaderProvider,
 )
-from garden_ai.mlmodel import LocalModel, RegisteredModel, PossibleOldToken, upload_to_model_registry
+from garden_ai.mlmodel import (
+    LocalModel,
+    RegisteredModel,
+    PossibleOldToken,
+    upload_to_model_registry,
+)
 from garden_ai.pipelines import Pipeline, RegisteredPipeline
 from garden_ai.utils.misc import extract_email_from_globus_jwt
 

--- a/garden_ai/mlmodel.py
+++ b/garden_ai/mlmodel.py
@@ -120,7 +120,9 @@ class RegisteredModel(BaseModel):
         self.model_uri = f"{self.namespaced_model_name}/{self.version}"
 
 
-def upload_to_model_registry(local_model: LocalModel, retry: bool = False) -> RegisteredModel:
+def upload_to_model_registry(
+    local_model: LocalModel, retry: bool = False
+) -> RegisteredModel:
     """Upload a model to Garden-AI's MLflow model registry.
 
     Args:


### PR DESCRIPTION
Fixes #78 

## Overview

Prevents users from needing to manually re-authorize by refreshing tokens as necessary before they are used. This is accomplished by ensuring they are valid before returning them in the new get method.

## Discussion

A quick run-through of the codebase revealed no further usages of the `client.garden_authorizer.access_token`, but any current and future uses of this property should instead be replaced with the new get method `_get_garden_access_token()`.

## Testing

This is a rather annoying problem to test, however, it could be done by simply waiting on an old token.


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--149.org.readthedocs.build/en/149/

<!-- readthedocs-preview garden-ai end -->