### PR TITLE
135 fix dependency conflict

### DIFF
--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -12,7 +12,7 @@ Broadly speaking, `step` and `Model` are lower-level abstractions for users to b
 A `Step` is the smallest "unit of code" usable to the Garden framework. A step is just a single function or callable that performs a specific task - such as pre-processing data or running inference - wrapped in some additional metadata (such as input/output type annotations) so that it can be composed with other steps in a Pipeline.
 
 > [!NOTE]
-> If your step references a `Model`, the step will attempt to collect its dependencies as part of its metadata.
+> If your step references a `Model`, the step will attempt to infer its dependencies as part of its metadata. These inferred dependencies won't be included in the container unless explicitly required by an enclosing `Pipeline`, but a warning will be logged for any apparent incompatibilities or mismatches.
 
 In other words, the only user code a `Pipeline` can "see" is the code contained in its steps, so its steps need to contain *all* of the code necessary to run it.
 

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -228,7 +228,6 @@ class Pipeline:
         }
 
         for step in self.steps:
-            self.model_uris += step.model_uris
             for r in step.pip_dependencies:
                 requirement = Requirement(r)
                 # warn about step requirements we're ignoring in favor of the pipeline's
@@ -238,13 +237,13 @@ class Pipeline:
                 )
                 if would_ignore_req:
                     logger.warning(
-                        f"Warning: step {step.__name__} suggested requirement '{requirement}', which is also required by the pipeline. "
+                        f"Warning: step {step.__name__} has inferred a requirement '{requirement}', which is also required by the pipeline. "
                         f"Only the pipeline's explicit requirement ({explicit_requirements[requirement.name]}) will be used."
                     )
                 # warn about potentially missing requirements
                 elif requirement.name not in explicit_requirements:
                     logger.warning(
-                        f"Warning: step {step.__name__} suggested requirement '{requirement}', which is not required by the pipeline. "
+                        f"Warning: step {step.__name__} has inferred a requirement '{requirement}', which is not required by the pipeline. "
                         f"If this package needs to be present in the container, please add '{requirement.name}' to the pipeline's requirements.txt "
                     )
 
@@ -253,7 +252,7 @@ class Pipeline:
             for r in step.conda_dependencies:
                 if r not in self.conda_dependencies:
                     logger.warning(
-                        f"Warning: step {step.__name__} suggested conda requirement '{r}', which is not required by the pipeline. "
+                        f"Warning: step {step.__name__} has inferred a conda requirement '{r}', which is not required by the pipeline. "
                         f"If this package needs to be present in the container, please add '{r}' to the pipeline's requirements."
                     )
 
@@ -262,7 +261,7 @@ class Pipeline:
 
         self.python_version = py_versions["pipeline"] or py_versions["system"]
         self.conda_dependencies = list(set(self.conda_dependencies))
-        self.pip_dependencies = list(set(validate_pip_lines(self.pip_dependencies)))
+        self.pip_dependencies = list(set(self.pip_dependencies))
 
         distinct_py_versions = set(
             py_versions[k] for k in py_versions if py_versions[k]

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -34,7 +34,6 @@ from garden_ai.utils.misc import (
     garden_json_encoder,
     read_conda_deps,
     safe_compose,
-    validate_pip_lines,
 )
 
 logger = logging.getLogger()

--- a/garden_ai/utils/misc.py
+++ b/garden_ai/utils/misc.py
@@ -259,13 +259,6 @@ def validate_pip_lines(lines: List[str]) -> List[str]:
             logger.warning(f"Could not parse requirement line: {line}")
             raise
 
-    # hack: user-dependencies like `examol @ git+https://github.com/exalearn/ExaMol.git`,
-    # which are not on pypi, should be read _before_ a line saying
-    # `examol==0.0.1` so pip won't worry that it's not on pypi, otherwise
-    # pip will claim it could not be installed.
-
-    # sorts s.t. url-based installs are read first
-    requirements.sort(key=lambda requirement: requirement.url is None)
     return [str(r) for r in requirements]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,8 +206,14 @@ def tmp_conda_yml(tmp_path):
       - python=3.8
       - flask=2.1.1
       - pandas>=1.3.0
-      - numpy==1.21.2
-      - scikit-learn>=0.24.2
+    - pip:
+      - mlflow<3,>=2.2
+      - cloudpickle==2.2.1
+      - numpy==1.23.5
+      - psutil==5.9.4
+      - scikit-learn==1.2.2
+      - fake-package==9.9.9
+
     """
     file_path = tmp_path / "conda.yml"
     with open(file_path, "w") as f:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,23 +198,22 @@ def tmp_conda_yml(tmp_path):
     """
     Fixture that creates a temporary `conda.yml` file.
     """
-    contents = """
-    name: my_env
-    channels:
-      - defaults
-    dependencies:
-      - python=3.8
-      - flask=2.1.1
-      - pandas>=1.3.0
-    - pip:
-      - mlflow<3,>=2.2
-      - cloudpickle==2.2.1
-      - numpy==1.23.5
-      - psutil==5.9.4
-      - scikit-learn==1.2.2
-      - fake-package==9.9.9
-
-    """
+    contents = """\
+name: my_env
+channels:
+- defaults
+dependencies:
+- python=3.8
+- flask=2.1.1
+- pandas>=1.3.0
+- pip:
+    - mlflow<3,>=2.2
+    - cloudpickle==2.2.1
+    - numpy==1.23.5
+    - psutil==5.9.4
+    - scikit-learn==1.2.2
+    - fake-package==9.9.9
+"""
     file_path = tmp_path / "conda.yml"
     with open(file_path, "w") as f:
         f.write(contents)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -305,14 +305,12 @@ def test_pipeline_collects_own_requirements(
     assert "python=" not in "".join(pipeline_using_step_with_model.conda_dependencies)
 
 
-def test_pipeline_collects_step_requirements(
+def test_pipeline_does_not_collect_step_requirements(
     pipeline_using_step_with_model, step_with_model
 ):
-    for step_dependency in step_with_model.conda_dependencies:
-        assert step_dependency in pipeline_using_step_with_model.conda_dependencies
-
-    for step_dependency in step_with_model.pip_dependencies:
-        assert step_dependency in pipeline_using_step_with_model.pip_dependencies
+    assert step_with_model in pipeline_using_step_with_model.steps
+    assert "fake-package==9.9.9" in step_with_model.pip_dependencies
+    assert "fake-package==9.9.9" not in pipeline_using_step_with_model.pip_dependencies
 
 
 def test_pipeline_collects_step_models(pipeline_using_step_with_model):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,9 @@
 import pytest
 
 from garden_ai.utils.misc import (
+    InvalidRequirement,
     extract_email_from_globus_jwt,
     validate_pip_lines,
-    InvalidRequirement,
 )
 
 
@@ -26,17 +26,12 @@ def test_validate_pip_lines():
         "pandas>=1.3.3",
         "scipy!=1.7.2",
         "matplotlib",
-        "package @ https://github.com/user/package/archive/v1.0.0.tar.gz",
+        "package@ https://github.com/user/package/archive/v1.0.0.tar.gz",
     ]
 
     result = validate_pip_lines(valid_lines)
-    assert result == [
-        "package@ https://github.com/user/package/archive/v1.0.0.tar.gz",
-        "numpy==1.21.2",
-        "pandas>=1.3.3",
-        "scipy!=1.7.2",
-        "matplotlib",
-    ]
+    assert set(result) == set(valid_lines)
+
     with pytest.raises(InvalidRequirement):
         invalid_lines = [
             "numpy --hash=sha256:abc",


### PR DESCRIPTION
fixes #135 

## Overview

Previously, there had been several places we collected dependencies that would eventually become part of the container spec:
1. from a model, whether implicitly via mlflow or explicitly via the CLI
2. from a step, whether explicitly by setting the attribute(s) or inferred from some model it uses (see 1)
3. the pipeline itself, explicitly via the attribute(s), explicitly via a requirements file, or implicitly from a step (see 2)

Now the only dependencies that the pipeline keeps are those explicitly set via the respective attributes or (typically) via a requirements file. 

Step- and model-level dependencies are still collected for the sake of warning users when there's a mismatch, but they don't have any effect on the actual packages requested in the container. 

## Testing

Updated old tests/fixtures to reflect the new desired behavior. 


## Documentation

Added a sentence to a note in the architecture overview clarifying that only explicit pipeline deps will go in the container.


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--151.org.readthedocs.build/en/151/

<!-- readthedocs-preview garden-ai end -->