### PR TITLE
list and show cmds for gardens, models and pipelines.

### DIFF
--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -14,6 +14,9 @@ from garden_ai.globus_search.garden_search import GARDEN_INDEX_UUID
 from garden_ai.gardens import Garden
 from garden_ai.pipelines import RegisteredPipeline
 
+from garden_ai.utils.misc import garden_json_encoder
+
+
 logger = logging.getLogger()
 
 garden_app = typer.Typer(name="garden", no_args_is_help=True)
@@ -298,8 +301,10 @@ def publish(
         raise typer.Exit(code=1) from e
 
 
-@garden_app.command(no_args_is_help=False, help="Lists all local Gardens.")
+@garden_app.command(no_args_is_help=False)
 def list():
+    """Lists all local Gardens."""
+
     console = rich.console.Console()
     console.print("\n")
     table = rich.table.Table(title="Local Gardens")
@@ -309,6 +314,26 @@ def list():
     for d in data:
         table.add_row(*(d))
     console.print(table)
+
+
+@garden_app.command(no_args_is_help=True)
+def show(
+    garden_id: str = typer.Option(
+        ...,
+        "-g",
+        "--garden",
+        prompt="Please enter the UUID or DOI of a garden",
+        help="The UUID or DOI of the garden you want to show",
+        rich_help_panel="Required",
+    ),
+):
+    """Shows all info for one Garden"""
+
+    garden_json = local_data.get_local_garden_json(garden_id)
+    if not garden_json:
+        logger.fatal(f"Could not find garden with id {garden_id}")
+        raise typer.Exit(code=1)
+    rich.print_json(data=garden_json)
 
 
 def _get_pipeline(pipeline_id: str) -> RegisteredPipeline:

--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -14,8 +14,6 @@ from garden_ai.globus_search.garden_search import GARDEN_INDEX_UUID
 from garden_ai.gardens import Garden
 from garden_ai.pipelines import RegisteredPipeline
 
-from garden_ai.utils.misc import garden_json_encoder
-
 
 logger = logging.getLogger()
 
@@ -307,12 +305,9 @@ def list():
 
     console = rich.console.Console()
     console.print("\n")
-    table = rich.table.Table(title="Local Gardens")
-    data, fields = local_data.get_local_garden_data(fields=["doi", "title"])
-    for f in fields:
-        table.add_column(f)
-    for d in data:
-        table.add_row(*(d))
+    table = local_data.get_local_garden_table(
+        fields=["doi", "title"], table_name="Local Gardens"
+    )
     console.print(table)
 
 

--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -298,6 +298,19 @@ def publish(
         raise typer.Exit(code=1) from e
 
 
+@garden_app.command(no_args_is_help=False, help="Lists all local Gardens.")
+def list():
+    console = rich.console.Console()
+    console.print("\n")
+    table = rich.table.Table(title="Local Gardens")
+    data, fields = local_data.get_local_garden_data(fields=["doi", "title"])
+    for f in fields:
+        table.add_column(f)
+    for d in data:
+        table.add_row(*(d))
+    console.print(table)
+
+
 def _get_pipeline(pipeline_id: str) -> RegisteredPipeline:
     if "/" in pipeline_id:
         pipeline = local_data.get_local_pipeline_by_doi(pipeline_id)

--- a/garden_ai/app/model.py
+++ b/garden_ai/app/model.py
@@ -108,12 +108,9 @@ def list():
 
     console = rich.console.Console()
     console.print("\n")
-    table = rich.table.Table(title="Local Models")
-    data, fields = local_data.get_local_model_data(fields=["model_name", "flavor"])
-    for f in fields:
-        table.add_column(f)
-    for d in data:
-        table.add_row(*(d))
+    table = local_data.get_local_model_table(
+        fields=["model_name", "flavor"], table_name="Local Models"
+    )
     console.print(table)
 
 

--- a/garden_ai/app/model.py
+++ b/garden_ai/app/model.py
@@ -3,6 +3,7 @@ from typing import Optional, List
 
 from garden_ai.client import GardenClient
 from garden_ai.mlmodel import DatasetConnection, LocalModel, ModelFlavor
+from garden_ai import local_data
 
 import typer
 import rich
@@ -96,3 +97,16 @@ def register(
     rich.print(
         f"Successfully uploaded your model! The full name to include in your pipeline is '{model_uri}'"
     )
+
+
+@model_app.command(no_args_is_help=False, help="Lists all local Models.")
+def list():
+    console = rich.console.Console()
+    console.print("\n")
+    table = rich.table.Table(title="Local Models")
+    data, fields = local_data.get_local_model_data(fields=["model_name", "flavor"])
+    for f in fields:
+        table.add_column(f)
+    for d in data:
+        table.add_row(*(d))
+    console.print(table)

--- a/garden_ai/app/model.py
+++ b/garden_ai/app/model.py
@@ -7,8 +7,11 @@ from garden_ai import local_data
 
 import typer
 import rich
+import logging
 
 model_app = typer.Typer(name="model", no_args_is_help=True)
+
+logger = logging.getLogger()
 
 
 @model_app.callback()
@@ -99,8 +102,10 @@ def register(
     )
 
 
-@model_app.command(no_args_is_help=False, help="Lists all local Models.")
+@model_app.command(no_args_is_help=False)
 def list():
+    """Lists all local models."""
+
     console = rich.console.Console()
     console.print("\n")
     table = rich.table.Table(title="Local Models")
@@ -110,3 +115,23 @@ def list():
     for d in data:
         table.add_row(*(d))
     console.print(table)
+
+
+@model_app.command(no_args_is_help=True)
+def show(
+    model_id: str = typer.Option(
+        ...,
+        "-m",
+        "--model",
+        prompt="Please enter the URI of a model",
+        help="The Model URI of the model you want to show",
+        rich_help_panel="Required",
+    ),
+):
+    """Shows all info for one model"""
+
+    model_json = local_data.get_local_model_json(model_id)
+    if not model_json:
+        logger.fatal(f"Could not find model with URI {model_id}")
+        raise typer.Exit(code=1)
+    rich.print_json(data=model_json)

--- a/garden_ai/app/pipeline.py
+++ b/garden_ai/app/pipeline.py
@@ -238,12 +238,9 @@ def list():
 
     console = rich.console.Console()
     console.print("\n")
-    table = rich.table.Table(title="Local Pipelines")
-    data, fields = local_data.get_local_pipeline_data(fields=["doi", "title"])
-    for f in fields:
-        table.add_column(f)
-    for d in data:
-        table.add_row(*(d))
+    table = local_data.get_local_pipeline_table(
+        fields=["doi", "title"], table_name="Local Pipelines"
+    )
     console.print(table)
 
 

--- a/garden_ai/app/pipeline.py
+++ b/garden_ai/app/pipeline.py
@@ -237,7 +237,7 @@ def list():
     console = rich.console.Console()
     console.print("\n")
     table = rich.table.Table(title="Local Pipelines")
-    data, fields = local_data.get_local_pipeline_data(fields=["title", "doi"])
+    data, fields = local_data.get_local_pipeline_data(fields=["doi", "title"])
     for f in fields:
         table.add_column(f)
     for d in data:

--- a/garden_ai/app/pipeline.py
+++ b/garden_ai/app/pipeline.py
@@ -5,12 +5,14 @@ from typing import List, Optional
 
 import jinja2
 import typer
+import rich
 from rich import print
 from rich.prompt import Prompt
 
 from garden_ai import GardenClient, Pipeline, step
 from garden_ai.app.console import console
 from garden_ai import GardenConstants
+from garden_ai import local_data
 
 from garden_ai.mlmodel import PipelineLoadScaffoldedException
 from garden_ai.utils.filesystem import (
@@ -228,3 +230,16 @@ def register(
     func_uuid = client.register_pipeline(user_pipeline, container_uuid)
     console.print(f"Created function {func_uuid}")
     console.print("Done! Pipeline is registered.")
+
+
+@pipeline_app.command(no_args_is_help=False, help="Lists all local Pipelines.")
+def list():
+    console = rich.console.Console()
+    console.print("\n")
+    table = rich.table.Table(title="Local Pipelines")
+    data, fields = local_data.get_local_pipeline_data(fields=["title", "doi"])
+    for f in fields:
+        table.add_column(f)
+    for d in data:
+        table.add_row(*(d))
+    console.print(table)

--- a/garden_ai/app/pipeline.py
+++ b/garden_ai/app/pipeline.py
@@ -232,8 +232,10 @@ def register(
     console.print("Done! Pipeline is registered.")
 
 
-@pipeline_app.command(no_args_is_help=False, help="Lists all local Pipelines.")
+@pipeline_app.command(no_args_is_help=False)
 def list():
+    """Lists all local pipelines."""
+
     console = rich.console.Console()
     console.print("\n")
     table = rich.table.Table(title="Local Pipelines")
@@ -243,3 +245,23 @@ def list():
     for d in data:
         table.add_row(*(d))
     console.print(table)
+
+
+@pipeline_app.command(no_args_is_help=True)
+def show(
+    pipeline_id: str = typer.Option(
+        ...,
+        "-p",
+        "--pipeline",
+        prompt="Please enter the UUID or DOI of a pipeline",
+        help="The UUID or DOI of a pipeline you want to show",
+        rich_help_panel="Required",
+    ),
+):
+    """Shows all info for one pipeline"""
+
+    pipeline_json = local_data.get_local_pipeline_json(pipeline_id)
+    if not pipeline_json:
+        logger.fatal(f"Could not find pipeline with the id {pipeline_id}")
+        raise typer.Exit(code=1)
+    rich.print_json(data=pipeline_json)

--- a/garden_ai/local_data.py
+++ b/garden_ai/local_data.py
@@ -182,7 +182,7 @@ def _get_local_resource_table(
     return table
 
 
-def _get_resource_json(
+def _get_local_resource_json(
     id_: Union[UUID, str], resource_type: ResourceType
 ) -> Optional[Dict]:
     data = _read_local_db()
@@ -275,7 +275,7 @@ def get_local_garden_json(garden_id: Union[UUID, str]) -> Optional[Dict]:
     Optional[Dict]
         If successful, returns the json of a local Garden.
     """
-    return _get_resource_json(garden_id, ResourceType.GARDEN)  # type: ignore
+    return _get_local_resource_json(garden_id, ResourceType.GARDEN)  # type: ignore
 
 
 def get_local_pipeline_json(pipeline_id: Union[UUID, str]) -> Optional[Dict]:
@@ -291,7 +291,7 @@ def get_local_pipeline_json(pipeline_id: Union[UUID, str]) -> Optional[Dict]:
     Optional[Dict]
         If successful, returns the json of a local pipeline.
     """
-    return _get_resource_json(pipeline_id, ResourceType.PIPELINE)  # type: ignore
+    return _get_local_resource_json(pipeline_id, ResourceType.PIPELINE)  # type: ignore
 
 
 def get_local_model_json(model_uri: str) -> Optional[Dict]:
@@ -307,7 +307,7 @@ def get_local_model_json(model_uri: str) -> Optional[Dict]:
     Optional[Dict]
         If successful, returns the json of a local model.
     """
-    return _get_resource_json(model_uri, ResourceType.MODEL)  # type: ignore
+    return _get_local_resource_json(model_uri, ResourceType.MODEL)  # type: ignore
 
 
 def put_local_garden(garden: Garden):

--- a/tests/cli/test_garden.py
+++ b/tests/cli/test_garden.py
@@ -44,6 +44,28 @@ def test_garden_create(garden_all_fields, tmp_path, mocker):
 
 
 @pytest.mark.cli
+def test_garden_list(database_with_connected_pipeline, tmp_path, mocker):
+    mocker.patch(
+        "garden_ai.local_data.LOCAL_STORAGE", new=database_with_connected_pipeline
+    )
+
+    garden_uuid = "e1a3b50b-4efc-42c8-8422-644f4f858b87"
+    garden_title = "Will Test Garden"
+    garden_doi = "10.23677/fake-doi"
+
+    command = [
+        "garden",
+        "list",
+    ]
+    result = runner.invoke(app, command)
+    assert result.exit_code == 0
+
+    assert garden_uuid in result.stdout
+    assert garden_title in result.stdout
+    assert garden_doi in result.stdout
+
+
+@pytest.mark.cli
 @pytest.mark.parametrize("use_doi", [True, False])
 def test_garden_pipeline_add(database_with_unconnected_pipeline, mocker, use_doi):
     mocker.patch(

--- a/tests/cli/test_garden.py
+++ b/tests/cli/test_garden.py
@@ -66,6 +66,43 @@ def test_garden_list(database_with_connected_pipeline, tmp_path, mocker):
 
 
 @pytest.mark.cli
+def test_garden_show(database_with_connected_pipeline, tmp_path, mocker):
+    mocker.patch(
+        "garden_ai.local_data.LOCAL_STORAGE", new=database_with_connected_pipeline
+    )
+
+    garden_uuid = "e1a3b50b-4efc-42c8-8422-644f4f858b87"
+    garden_title = "Will Test Garden"
+    garden_doi = "10.23677/fake-doi"
+
+    command = [
+        "garden",
+        "show",
+        "--garden",
+        garden_uuid,
+    ]
+    result = runner.invoke(app, command)
+    assert result.exit_code == 0
+
+    assert garden_uuid in result.stdout
+    assert garden_title in result.stdout
+    assert garden_doi in result.stdout
+
+    command = [
+        "garden",
+        "show",
+        "-g",
+        garden_doi,
+    ]
+    result = runner.invoke(app, command)
+    assert result.exit_code == 0
+
+    assert garden_uuid in result.stdout
+    assert garden_title in result.stdout
+    assert garden_doi in result.stdout
+
+
+@pytest.mark.cli
 @pytest.mark.parametrize("use_doi", [True, False])
 def test_garden_pipeline_add(database_with_unconnected_pipeline, mocker, use_doi):
     mocker.patch(

--- a/tests/cli/test_model.py
+++ b/tests/cli/test_model.py
@@ -41,3 +41,25 @@ def test_model_upload(mocker, tmp_path):
     assert dataset_connection.doi == "uc-435t/abcde"
     assert dataset_connection.url == "example.com/123456"
     assert dataset_connection.repository == "Foundry"
+
+
+@pytest.mark.cli
+def test_model_list(database_with_connected_pipeline, tmp_path, mocker):
+    mocker.patch(
+        "garden_ai.local_data.LOCAL_STORAGE", new=database_with_connected_pipeline
+    )
+
+    model_uri = "willengler@uchicago.edu-will-test-model/3"
+    model_name = "will-test-model"
+    model_flavor = "sklearn"
+
+    command = [
+        "model",
+        "list",
+    ]
+    result = runner.invoke(app, command)
+    assert result.exit_code == 0
+
+    assert model_uri in result.stdout
+    assert model_name in result.stdout
+    assert model_flavor in result.stdout

--- a/tests/cli/test_model.py
+++ b/tests/cli/test_model.py
@@ -63,3 +63,27 @@ def test_model_list(database_with_connected_pipeline, tmp_path, mocker):
     assert model_uri in result.stdout
     assert model_name in result.stdout
     assert model_flavor in result.stdout
+
+
+@pytest.mark.cli
+def test_model_show(database_with_connected_pipeline, tmp_path, mocker):
+    mocker.patch(
+        "garden_ai.local_data.LOCAL_STORAGE", new=database_with_connected_pipeline
+    )
+
+    model_uri = "willengler@uchicago.edu-will-test-model/3"
+    model_name = "will-test-model"
+    model_flavor = "sklearn"
+
+    command = [
+        "model",
+        "show",
+        "--model",
+        model_uri,
+    ]
+    result = runner.invoke(app, command)
+    assert result.exit_code == 0
+
+    assert model_uri in result.stdout
+    assert model_name in result.stdout
+    assert model_flavor in result.stdout

--- a/tests/cli/test_pipeline.py
+++ b/tests/cli/test_pipeline.py
@@ -41,6 +41,28 @@ def test_pipeline_create(pipeline_toy_example, mocker, tmp_path):
         assert kwargs[key] == getattr(pipeline_toy_example, key)
 
 
+@pytest.mark.cli
+def test_pipeline_list(database_with_connected_pipeline, tmp_path, mocker):
+    mocker.patch(
+        "garden_ai.local_data.LOCAL_STORAGE", new=database_with_connected_pipeline
+    )
+
+    pipeline_uuid = "b537520b-e86e-45bf-8566-4555a72b0b08"
+    pipeline_title = "Fixture pipeline"
+    pipeline_doi = "10.23677/jx31-gx98"
+
+    command = [
+        "pipeline",
+        "list",
+    ]
+    result = runner.invoke(app, command)
+    assert result.exit_code == 0
+
+    assert pipeline_uuid in result.stdout
+    assert pipeline_title in result.stdout
+    assert pipeline_doi in result.stdout
+
+
 def test_clean_identifier():
     possible_name = "".join(random.choices(string.printable, k=50))
     valid_name = clean_identifier(possible_name)

--- a/tests/cli/test_pipeline.py
+++ b/tests/cli/test_pipeline.py
@@ -63,6 +63,43 @@ def test_pipeline_list(database_with_connected_pipeline, tmp_path, mocker):
     assert pipeline_doi in result.stdout
 
 
+@pytest.mark.cli
+def test_pipeline_show(database_with_connected_pipeline, tmp_path, mocker):
+    mocker.patch(
+        "garden_ai.local_data.LOCAL_STORAGE", new=database_with_connected_pipeline
+    )
+
+    pipeline_uuid = "b537520b-e86e-45bf-8566-4555a72b0b08"
+    pipeline_title = "Fixture pipeline"
+    pipeline_doi = "10.23677/jx31-gx98"
+
+    command = [
+        "pipeline",
+        "show",
+        "--pipeline",
+        pipeline_uuid,
+    ]
+    result = runner.invoke(app, command)
+    assert result.exit_code == 0
+
+    assert pipeline_uuid in result.stdout
+    assert pipeline_title in result.stdout
+    assert pipeline_doi in result.stdout
+
+    command = [
+        "pipeline",
+        "show",
+        "-p",
+        pipeline_doi,
+    ]
+    result = runner.invoke(app, command)
+    assert result.exit_code == 0
+
+    assert pipeline_uuid in result.stdout
+    assert pipeline_title in result.stdout
+    assert pipeline_doi in result.stdout
+
+
 def test_clean_identifier():
     possible_name = "".join(random.choices(string.printable, k=50))
     valid_name = clean_identifier(possible_name)

--- a/tests/test_local_db.py
+++ b/tests/test_local_db.py
@@ -9,6 +9,17 @@ def test_local_storage_garden(mocker, garden_client, garden_all_fields, tmp_path
     from_record = local_data.get_local_garden_by_uuid(uuid)
     assert from_record == garden_all_fields
 
+    garden_fields = ["uuid", "doi", "title"]
+    garden_rows = [
+        (str(garden_all_fields.uuid), garden_all_fields.doi, garden_all_fields.title)
+    ]
+    (
+        from_record_garden_rows,
+        from_record_garden_fields,
+    ) = local_data.get_local_garden_data(fields=["doi", "title"])
+    assert from_record_garden_fields == garden_fields
+    assert from_record_garden_rows == garden_rows
+
 
 def test_local_storage_pipeline(
     mocker, garden_client, registered_pipeline_toy_example, tmp_path
@@ -19,6 +30,21 @@ def test_local_storage_pipeline(
     uuid = registered_pipeline_toy_example.uuid
     from_record = local_data.get_local_pipeline_by_uuid(uuid)
     assert from_record == registered_pipeline_toy_example
+
+    pipeline_fields = ["uuid", "doi", "title"]
+    pipeline_rows = [
+        (
+            str(registered_pipeline_toy_example.uuid),
+            registered_pipeline_toy_example.doi,
+            registered_pipeline_toy_example.title,
+        )
+    ]
+    (
+        from_record_pipeline_rows,
+        from_record_pipeline_fields,
+    ) = local_data.get_local_pipeline_data(fields=["doi", "title"])
+    assert from_record_pipeline_fields == pipeline_fields
+    assert from_record_pipeline_rows == pipeline_rows
 
 
 def test_local_storage_keyerror(
@@ -53,3 +79,17 @@ def test_local_storage_model(mocker, database_with_model, second_draft_of_model)
         "test@example.com-unit-test-model/1"
     )
     assert overwritten_model is None
+
+    model_fields = ["model_uri", "model_name", "flavor"]
+    model_rows = [
+        (
+            second_draft_of_model.model_uri,
+            second_draft_of_model.model_name,
+            second_draft_of_model.flavor,
+        )
+    ]
+    from_record_model_rows, from_record_model_fields = local_data.get_local_model_data(
+        fields=["model_name", "flavor"]
+    )
+    assert from_record_model_fields == model_fields
+    assert from_record_model_rows == model_rows

--- a/tests/test_local_db.py
+++ b/tests/test_local_db.py
@@ -1,4 +1,5 @@
 from garden_ai import local_data
+from rich.table import Table
 
 
 def test_local_storage_garden(mocker, garden_client, garden_all_fields, tmp_path):
@@ -9,16 +10,40 @@ def test_local_storage_garden(mocker, garden_client, garden_all_fields, tmp_path
     from_record = local_data.get_local_garden_by_uuid(uuid)
     assert from_record == garden_all_fields
 
+
+def test_get_local_garden_json(mocker, garden_client, garden_all_fields, tmp_path):
+    # mock to replace "~/.garden/db"
+    mocker.patch("garden_ai.local_data.LOCAL_STORAGE", new=tmp_path)
+    local_data.put_local_garden(garden_all_fields)
+
+    garden_data = local_data._read_local_db().get(
+        local_data.ResourceType.GARDEN.value, {}
+    )[str(garden_all_fields.uuid)]
+
+    assert garden_data == local_data.get_local_garden_json(str(garden_all_fields.uuid))
+    assert garden_data == local_data.get_local_garden_json(str(garden_all_fields.doi))
+
+
+def test_get_local_garden_table(mocker, garden_client, garden_all_fields, tmp_path):
+    # mock to replace "~/.garden/db"
+    mocker.patch("garden_ai.local_data.LOCAL_STORAGE", new=tmp_path)
+    local_data.put_local_garden(garden_all_fields)
+
     garden_fields = ["uuid", "doi", "title"]
+    garden_table_name = "Local Gardens"
     garden_rows = [
         (str(garden_all_fields.uuid), garden_all_fields.doi, garden_all_fields.title)
     ]
-    (
-        from_record_garden_rows,
-        from_record_garden_fields,
-    ) = local_data.get_local_garden_data(fields=["doi", "title"])
-    assert from_record_garden_fields == garden_fields
-    assert from_record_garden_rows == garden_rows
+    table = Table(title=garden_table_name)
+
+    for col in garden_fields:
+        table.add_column(col)
+    for row in garden_rows:
+        table.add_row(*(row))
+
+    test_table = local_data.get_local_garden_table(
+        fields=garden_fields[1:], table_name=garden_table_name
+    )
 
 
 def test_local_storage_pipeline(
@@ -31,7 +56,35 @@ def test_local_storage_pipeline(
     from_record = local_data.get_local_pipeline_by_uuid(uuid)
     assert from_record == registered_pipeline_toy_example
 
+
+def test_get_local_pipeline_json(
+    mocker, garden_client, registered_pipeline_toy_example, tmp_path
+):
+    # mock to replace "~/.garden/db"
+    mocker.patch("garden_ai.local_data.LOCAL_STORAGE", new=tmp_path)
+    local_data.put_local_pipeline(registered_pipeline_toy_example)
+
+    pipeline_data = local_data._read_local_db().get(
+        local_data.ResourceType.PIPELINE.value, {}
+    )[str(registered_pipeline_toy_example.uuid)]
+
+    assert pipeline_data == local_data.get_local_pipeline_json(
+        str(registered_pipeline_toy_example.uuid)
+    )
+    assert pipeline_data == local_data.get_local_pipeline_json(
+        str(registered_pipeline_toy_example.doi)
+    )
+
+
+def test_get_local_pipeline_table(
+    mocker, garden_client, registered_pipeline_toy_example, tmp_path
+):
+    # mock to replace "~/.garden/db"
+    mocker.patch("garden_ai.local_data.LOCAL_STORAGE", new=tmp_path)
+    local_data.put_local_pipeline(registered_pipeline_toy_example)
+
     pipeline_fields = ["uuid", "doi", "title"]
+    pipeline_table_name = "Local Pipelines"
     pipeline_rows = [
         (
             str(registered_pipeline_toy_example.uuid),
@@ -39,12 +92,17 @@ def test_local_storage_pipeline(
             registered_pipeline_toy_example.title,
         )
     ]
-    (
-        from_record_pipeline_rows,
-        from_record_pipeline_fields,
-    ) = local_data.get_local_pipeline_data(fields=["doi", "title"])
-    assert from_record_pipeline_fields == pipeline_fields
-    assert from_record_pipeline_rows == pipeline_rows
+    table = Table(title=pipeline_table_name)
+
+    for col in pipeline_fields:
+        table.add_column(col)
+    for row in pipeline_rows:
+        table.add_row(*(row))
+
+    test_table = local_data.get_local_pipeline_table(
+        fields=pipeline_fields[1:], table_name=pipeline_table_name
+    )
+    assert table.__dict__ == test_table.__dict__
 
 
 def test_local_storage_keyerror(
@@ -80,7 +138,28 @@ def test_local_storage_model(mocker, database_with_model, second_draft_of_model)
     )
     assert overwritten_model is None
 
+
+def test_get_local_model_json(mocker, database_with_model, second_draft_of_model):
+    # mock to replace "~/.garden/db"
+    mocker.patch("garden_ai.local_data.LOCAL_STORAGE", new=database_with_model)
+    local_data.put_local_model(second_draft_of_model)
+
+    model_data = local_data._read_local_db().get(
+        local_data.ResourceType.MODEL.value, {}
+    )[str(second_draft_of_model.model_uri)]
+
+    assert model_data == local_data.get_local_model_json(
+        str(second_draft_of_model.model_uri)
+    )
+
+
+def test_get_local_model_table(mocker, database_with_model, second_draft_of_model):
+    # mock to replace "~/.garden/db"
+    mocker.patch("garden_ai.local_data.LOCAL_STORAGE", new=database_with_model)
+    local_data.put_local_model(second_draft_of_model)
+
     model_fields = ["model_uri", "model_name", "flavor"]
+    model_table_name = "Local Models"
     model_rows = [
         (
             second_draft_of_model.model_uri,
@@ -88,8 +167,21 @@ def test_local_storage_model(mocker, database_with_model, second_draft_of_model)
             second_draft_of_model.flavor,
         )
     ]
-    from_record_model_rows, from_record_model_fields = local_data.get_local_model_data(
-        fields=["model_name", "flavor"]
+    model_rows = [
+        (
+            str(second_draft_of_model.model_uri),
+            second_draft_of_model.model_name,
+            second_draft_of_model.flavor,
+        )
+    ]
+    table = Table(title=model_table_name)
+
+    for col in model_fields:
+        table.add_column(col)
+    for row in model_rows:
+        table.add_row(*(row))
+
+    test_table = local_data.get_local_model_table(
+        fields=model_fields[1:], table_name=model_table_name
     )
-    assert from_record_model_fields == model_fields
-    assert from_record_model_rows == model_rows
+    assert table.__dict__ == test_table.__dict__

--- a/tests/test_local_db.py
+++ b/tests/test_local_db.py
@@ -44,6 +44,7 @@ def test_get_local_garden_table(mocker, garden_client, garden_all_fields, tmp_pa
     test_table = local_data.get_local_garden_table(
         fields=garden_fields[1:], table_name=garden_table_name
     )
+    assert table.__dict__ == test_table.__dict__
 
 
 def test_local_storage_pipeline(


### PR DESCRIPTION
Fixes #142

## Overview

Adds a list command for gardens, models and pipelines that displays a table of all the instances of that type of resource from the data.json file.

Adds a show command for gardens, models and pipelines that displays the json data of a specific resource from the data.json file.

## Testing

Added unit tests in test_garden for garden list and garden show
Added unit tests in test_model for model list and model show
Added unit tests in test_pipeline for pipeline list and pipeline show
Added unit tests in test_local_db for new helper functions _get_local_resource_json and _get_local_resource_table

## Documentation

No new documentation added. 
