### PR TITLE
Outsource publish request to garden-backend

### DIFF
--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -449,7 +449,7 @@ class GardenClient:
         -------
         https://docs.globus.org/api/search/reference/get_task/#task
         """
-        return garden_search.publish_garden_metadata(garden, self.search_client)
+        return garden_search.publish_garden_metadata(garden, GARDEN_ENDPOINT)
 
     def search(self, query: str) -> str:
         """

--- a/garden_ai/globus_search/garden_search.py
+++ b/garden_ai/globus_search/garden_search.py
@@ -64,7 +64,7 @@ def get_remote_garden_by_doi(
 
 def publish_garden_metadata(garden: Garden, endpoint: str) -> GlobusHTTPResponse:
     garden_meta = json.loads(garden.expanded_json())
-    res = requests.post(f"{endpoint}/publish", json=garden_meta)
+    res = requests.post(f"{endpoint}/garden-search-record", json=garden_meta)
     if res.status_code >= 400:
         raise RemoteGardenException(
             f"Request to Garden backend to publish garden failed with error: {res.status_code} {res.json()['message']}."


### PR DESCRIPTION
`Fixes #152`

## Overview

Move the request to Globus to the garden-backend so users do not need authorization.

## Discussion

[The corresponding update to the garden-backend](https://github.com/Garden-AI/garden-backend/pull/22).

## Testing

Currently untested. Needs corresponding update to the garden-backend.


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--177.org.readthedocs.build/en/177/

<!-- readthedocs-preview garden-ai end -->