### PR TITLE
Initializing a GardenClient with a Client Credentials Grant

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,9 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
     name: build
+    env:
+      GARDEN_API_CLIENT_ID: ${{ secrets.GARDEN_API_CLIENT_ID }}
+      GARDEN_API_CLIENT_SECRET: ${{ secrets.GARDEN_API_CLIENT_SECRET }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -90,6 +90,9 @@ class GardenClient:
             "GARDEN_CLIENT_ID", "cf9f8938-fb72-439c-a70b-85addf1b8539"
         )
 
+        # If auth_client is type ConfidentialAppAuthClient, then we want to make our autherizers with
+        # ClientCredentialsAuthorizer to do a Client Credentials Grant. Otherwise we do an
+        # Authorization Code Grant and make RefreshTokenAuthorizer.
         if isinstance(auth_client, ConfidentialAppAuthClient):
             self.auth_client = auth_client
             self.openid_authorizer = ClientCredentialsAuthorizer(

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -27,7 +27,7 @@ from rich import print
 from rich.prompt import Prompt
 
 import garden_ai.funcx_bandaid.serialization_patch  # type: ignore # noqa: F401
-from garden_ai import local_data
+from garden_ai import local_data, GardenConstants
 from garden_ai.gardens import Garden
 from garden_ai.globus_compute.containers import build_container
 from garden_ai.globus_compute.login_manager import ComputeLoginManager
@@ -143,6 +143,8 @@ class GardenClient:
                 self.auth_client, GardenClient.scopes.test_scope
             )
 
+            local_data._store_user_email(GardenConstants.GARDEN_TEST_EMAIL)
+
         self.compute_client = self._make_compute_client()
         self._set_up_mlflow_env()
 
@@ -170,7 +172,7 @@ class GardenClient:
                 AuthClient.scopes.email,
                 GroupsClient.scopes.view_my_groups_and_memberships,
                 SearchClient.scopes.all,
-                GardenClient.scopes.action_all,
+                GardenClient.scopes.test_scope,
                 Client.FUNCX_SCOPE,
             ],
             refresh_tokens=True,

--- a/garden_ai/constants.py
+++ b/garden_ai/constants.py
@@ -1,2 +1,3 @@
 class GardenConstants:
     SCAFFOLDED_MODEL_NAME = "YOUR MODEL'S NAME HERE"
+    GARDEN_TEST_EMAIL = "garden-test-runner@email.com"

--- a/garden_ai/globus_compute/login_manager.py
+++ b/garden_ai/globus_compute/login_manager.py
@@ -15,7 +15,16 @@ class ComputeLoginManager:
     https://github.com/funcx-faas/funcX/blob/main/funcx_sdk/funcx/sdk/login_manager/protocol.py#L18
     """
 
-    def __init__(self, authorizers: Dict[str, globus_sdk.RefreshTokenAuthorizer]):
+    def __init__(
+        self,
+        authorizers: Dict[
+            str,
+            Union[
+                globus_sdk.RefreshTokenAuthorizer,
+                globus_sdk.ClientCredentialsAuthorizer,
+            ],
+        ],
+    ):
         self.authorizers = authorizers
 
     def get_auth_client(self) -> globus_sdk.AuthClient:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -327,11 +327,6 @@ def second_draft_of_model():
 
 
 @pytest.fixture
-def is_gha():
-    return os.getenv("GITHUB_ACTIONS")
-
-
-@pytest.fixture
 def cc_grant_tuple():
     client_id = os.getenv("GARDEN_API_CLIENT_ID")
     client_secret = os.getenv("GARDEN_API_CLIENT_SECRET")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from typing import List
 
 import pytest
+import os
 from globus_compute_sdk import Client  # type: ignore
 from globus_sdk import AuthClient, OAuthTokenResponse, SearchClient
 from globus_sdk.tokenstorage import SimpleJSONFileAdapter
@@ -323,6 +324,18 @@ def second_draft_of_model():
             )
         ],
     )
+
+
+@pytest.fixture
+def is_gha():
+    return os.getenv("GITHUB_ACTIONS")
+
+
+@pytest.fixture
+def cc_grant_tuple():
+    client_id = os.getenv("GARDEN_API_CLIENT_ID")
+    client_secret = os.getenv("GARDEN_API_CLIENT_SECRET")
+    return (client_id, client_secret)
 
 
 # Fixture JSON responses from the Search API

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,7 +10,7 @@ from globus_sdk import (
     ClientCredentialsAuthorizer,
     ConfidentialAppAuthClient,
 )
-from globus_compute_sdk import Client
+from globus_compute_sdk import Client  # type: ignore
 
 
 def test_client_no_previous_tokens(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,4 @@
 import pytest
-from typer.testing import CliRunner
 
 from garden_ai import GardenClient
 from garden_ai.client import AuthException
@@ -12,9 +11,6 @@ from globus_sdk import (
     ConfidentialAppAuthClient,
 )
 from globus_compute_sdk import Client
-from garden_ai.app.main import app
-
-runner = CliRunner()
 
 
 def test_client_no_previous_tokens(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -152,8 +152,18 @@ def test_client_credentials_grant(is_gha, cc_grant_tuple):
 
         assert isinstance(gc.auth_client, ConfidentialAppAuthClient)
 
-        gc.auth_client.oauth2_validate_token(gc.openid_authorizer.access_token)
-        gc.auth_client.oauth2_validate_token(gc.groups_authorizer.access_token)
-        gc.auth_client.oauth2_validate_token(gc.search_authorizer.access_token)
-        gc.auth_client.oauth2_validate_token(gc.compute_authorizer.access_token)
-        gc.auth_client.oauth2_validate_token(gc.garden_authorizer.access_token)
+        assert gc.auth_client.oauth2_validate_token(gc.openid_authorizer.access_token)[
+            "active"
+        ]
+        assert gc.auth_client.oauth2_validate_token(gc.groups_authorizer.access_token)[
+            "active"
+        ]
+        assert gc.auth_client.oauth2_validate_token(gc.search_authorizer.access_token)[
+            "active"
+        ]
+        assert gc.auth_client.oauth2_validate_token(gc.compute_authorizer.access_token)[
+            "active"
+        ]
+        assert gc.auth_client.oauth2_validate_token(gc.garden_authorizer.access_token)[
+            "active"
+        ]


### PR DESCRIPTION
Part of (#153)

Currently when initializing a GardenClient, it always requires refresh tokens. However, if we want to initialize with a Client Credentials Grant, rather than the regular Authorization Code Grant, we won't have a refresh token.

## Overview

Changed GardenClient __init__ to also accept auth_client of type ConfidentialAppAuthClient to initialize with a Client Credentials Grant.

Added github secrets GARDEN_API_CLIENT_ID and GARDEN_API_CLIENT_SECRET to github action env vars.

## Discussion

In order to do end-to-end testing, we needed a Client Credentials Grant since the Authorization Code Grant requires the user to manually login.

## Testing

Added unit test for GardenClient init with Client Credentials Grant.

## Documentation

No documentation added.

<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--178.org.readthedocs.build/en/178/

<!-- readthedocs-preview garden-ai end -->