### PR TITLE
add auth header to outbound request

### DIFF
--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -449,7 +449,8 @@ class GardenClient:
         -------
         https://docs.globus.org/api/search/reference/get_task/#task
         """
-        return garden_search.publish_garden_metadata(garden, GARDEN_ENDPOINT)
+        header = {"Authorization": self.garden_authorizer.get_authorization_header()}
+        return garden_search.publish_garden_metadata(garden, GARDEN_ENDPOINT, header)
 
     def search(self, query: str) -> str:
         """

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -17,7 +17,6 @@ from globus_sdk import (
     NativeAppAuthClient,
     RefreshTokenAuthorizer,
     SearchClient,
-    GlobusHTTPResponse,
 )
 from globus_sdk.scopes import AuthScopes, ScopeBuilder, SearchScopes
 from globus_sdk.tokenstorage import SimpleJSONFileAdapter
@@ -439,7 +438,7 @@ class GardenClient:
         }
         return registered
 
-    def publish_garden_metadata(self, garden: Garden) -> GlobusHTTPResponse:
+    def publish_garden_metadata(self, garden: Garden) -> None:
         """
         Takes a garden, and publishes to the GARDEN_INDEX_UUID index.  Polls
         to discover status, and returns the Task document.

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -17,7 +17,6 @@ from globus_sdk import (
     NativeAppAuthClient,
     RefreshTokenAuthorizer,
     SearchClient,
-    GlobusHTTPResponse,
     ClientCredentialsAuthorizer,
     ConfidentialAppAuthClient,
 )

--- a/garden_ai/globus_search/garden_search.py
+++ b/garden_ai/globus_search/garden_search.py
@@ -62,14 +62,16 @@ def get_remote_garden_by_doi(
     return garden
 
 
-def publish_garden_metadata(garden: Garden, endpoint: str) -> GlobusHTTPResponse:
+def publish_garden_metadata(garden: Garden, endpoint: str, header: dict) -> None:
     garden_meta = json.loads(garden.expanded_json())
-    res = requests.post(f"{endpoint}/garden-search-record", json=garden_meta)
+    res = requests.post(
+        f"{endpoint}/garden-search-record", headers=header, json=garden_meta
+    )
     if res.status_code >= 400:
         raise RemoteGardenException(
             f"Request to Garden backend to publish garden failed with error: {res.status_code} {res.json()['message']}."
         )
-    return res.json()
+    return None
 
 
 def search_gardens(query: str, search_client: SearchClient) -> str:

--- a/garden_ai/globus_search/garden_search.py
+++ b/garden_ai/globus_search/garden_search.py
@@ -2,7 +2,7 @@ import json
 import requests
 
 from garden_ai.gardens import Garden
-from globus_sdk import SearchClient, GlobusAPIError, GlobusHTTPResponse
+from globus_sdk import SearchClient, GlobusAPIError
 from pydantic import ValidationError
 
 # garden-dev index


### PR DESCRIPTION
## Overview

Add auth header to publish garden request so that it doesn't 401 Unauthorized.

## Testing

The request was sent through local deployment of the SDK and returned successfully.


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--179.org.readthedocs.build/en/179/

<!-- readthedocs-preview garden-ai end -->