### PR TITLE
Fix cli error catching

### DIFF
--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -10,7 +10,10 @@ from rich.prompt import Prompt
 
 from garden_ai import local_data
 from garden_ai.client import GardenClient
-from garden_ai.globus_search.garden_search import GARDEN_INDEX_UUID, RemoteGardenException
+from garden_ai.globus_search.garden_search import (
+    GARDEN_INDEX_UUID,
+    RemoteGardenException,
+)
 from garden_ai.gardens import Garden
 from garden_ai.pipelines import RegisteredPipeline
 from garden_ai.app.console import console, get_local_garden_rich_table

--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -304,7 +304,7 @@ def publish(
         client.publish_garden_metadata(garden)
     except RemoteGardenException as e:
         logger.fatal(f"Could not publish garden {garden_id}")
-        logger.fatal(e.error_data)
+        logger.fatal(str(e))
         raise typer.Exit(code=1) from e
     console.print(
         f"Successfully published garden {garden.title} with DOI {garden.doi}!"

--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -10,7 +10,7 @@ from rich.prompt import Prompt
 
 from garden_ai import local_data
 from garden_ai.client import GardenClient
-from garden_ai.globus_search.garden_search import GARDEN_INDEX_UUID
+from garden_ai.globus_search.garden_search import GARDEN_INDEX_UUID, RemoteGardenException
 from garden_ai.gardens import Garden
 from garden_ai.pipelines import RegisteredPipeline
 from garden_ai.app.console import console, get_local_garden_rich_table
@@ -299,7 +299,7 @@ def publish(
         local_data.put_local_garden(garden)
     try:
         client.publish_garden_metadata(garden)
-    except SearchAPIError as e:
+    except RemoteGardenException as e:
         logger.fatal(f"Could not publish garden {garden_id}")
         logger.fatal(e.error_data)
         raise typer.Exit(code=1) from e


### PR DESCRIPTION
## Overview

I noticed that the error the CLI catches when publishing is no longer something that the publishing function would ever raise, so I simply switched which exception it catches to the correct one.


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--180.org.readthedocs.build/en/180/

<!-- readthedocs-preview garden-ai end -->