### PR TITLE
remove extra "model.zip" during upload

### DIFF
--- a/garden_ai/model_file_transfer/upload.py
+++ b/garden_ai/model_file_transfer/upload.py
@@ -13,8 +13,7 @@ def upload_mlmodel_to_s3(
     local_directory: str, local_model: LocalModel, backend_client: BackendClient
 ):
     # Get url from Garden API
-    model_storage_path = f"{local_model.full_name}/model.zip"
-    presigned_url_response = backend_client.get_model_upload_url(model_storage_path)
+    presigned_url_response = backend_client.get_model_upload_url(local_model.full_name)
     _upload_directory_to_s3_presigned(local_directory, presigned_url_response)
 
 

--- a/tests/test_mlmodel.py
+++ b/tests/test_mlmodel.py
@@ -41,7 +41,7 @@ def test_upload_model_to_s3(mocker, local_model, tmp_path):
 
     upload_mlmodel_to_s3(fake_staging_dir, local_model, backend_client)
     backend_client.get_model_upload_url.assert_called_with(
-        "test@example.com/unit-test-model/model.zip"
+        "test@example.com/unit-test-model"
     )
     mock_upload.assert_called_with(fake_staging_dir, mock_presigned_url_response)
 


### PR DESCRIPTION
## Overview

Fixes a bug that caused model uploading to fail due to a path suffix being appended in two places.

## Testing

I ran an end-to-end test that went all the way through with no errors.


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--192.org.readthedocs.build/en/192/

<!-- readthedocs-preview garden-ai end -->