### PR TITLE
[test, do not merge] Make a trivial change to test remote unit test execution

### DIFF
--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -250,7 +250,7 @@ def add_pipeline(
         ),
     ),
 ):
-    """Add a registered pipeline to a garden"""
+    """Add a registered pipeline to a garden!"""
 
     garden = _get_garden(garden_id)
     if not garden:


### PR DESCRIPTION
Aadit is seeing a unit test failure where it seems like a test is failing on a globus_sdk.services.auth.errors.AuthAPIError. Should a unit test even be reaching out to the Globus backend this way? Why wasn't it triggered before? I'm seeing if I can repro.


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--195.org.readthedocs.build/en/195/

<!-- readthedocs-preview garden-ai end -->