### PR TITLE
161 changes for DLHub endpoint if not user specified

### DIFF
--- a/garden_ai/constants.py
+++ b/garden_ai/constants.py
@@ -10,3 +10,4 @@ class GardenConstants:
         "GARDEN_ENDPOINT",
         "https://nu3cetwc84.execute-api.us-east-1.amazonaws.com/garden_prod",
     )
+    DLHUB_ENDPOINT = "86a47061-f3d9-44f0-90dc-56ddc642c000"

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -113,7 +113,8 @@ class Pipeline:
     tags: List[str] = Field(default_factory=list, unique_items=True)
     requirements_file: Optional[str] = Field(None)
     python_version: Optional[str] = Field(None)
-    pip_dependencies: List[str] = Field(default=["garden-ai@ git+https://github.com/Garden-AI/garden.git@b8deb5480f4bf4593485392610972a2e61bdafdb"])
+    pip_dependencies: List[str] = Field(default=[f"garden-ai=={__version__}"])
+
     conda_dependencies: List[str] = Field(default_factory=list)
     model_full_names: List[str] = Field(default_factory=list)
     short_name: Optional[str] = Field(None)
@@ -386,31 +387,23 @@ class RegisteredPipeline(BaseModel):
         endpoint: Union[UUID, str] = None,
         **kwargs: Any,
     ) -> Any:
-        """Remotely execute this ``RegisteredPipeline``'s function from the function uuid. An endpoint must be specified.
+        """Remotely execute this ``RegisteredPipeline``'s function from the function uuid.
 
         Args:
             *args (Any):
                 Input data passed through the first step in the pipeline
             endpoint (UUID | str | None):
-                Where to run the pipeline. Must be a valid Globus Compute endpoint UUID.
+                Where to run the pipeline. Must be a valid Globus Compute endpoint UUID. If no endpoint is specified, the DLHub default compute endpoint is used.
             **kwargs (Any):
                 Additional keyword arguments passed directly to the first step in the pipeline.
 
         Returns:
             Results from the pipeline's composed steps called with the given input data.
 
-        Raises:
-            ValueError:
-                If no endpoint is specified -- modified to be replaced with globus compute endpoint
-            Exception:
-                Any exceptions raised over the course of executing the pipeline
 
         """
         if not endpoint:
-            endpoint =  '86a47061-f3d9-44f0-90dc-56ddc642c000'
-            #raise ValueError(
-             #   "A Globus Compute endpoint uuid must be specified to execute remotely."
-            #)
+            endpoint = GardenConstants.DLHUB_ENDPOINT
 
         if self._env_vars:
             # see: utils.misc.inject_env_kwarg

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -113,7 +113,7 @@ class Pipeline:
     tags: List[str] = Field(default_factory=list, unique_items=True)
     requirements_file: Optional[str] = Field(None)
     python_version: Optional[str] = Field(None)
-    pip_dependencies: List[str] = Field(default=[f"garden-ai=={__version__}"])
+    pip_dependencies: List[str] = Field(default=["garden-ai@ git+https://github.com/Garden-AI/garden.git@b8deb5480f4bf4593485392610972a2e61bdafdb"])
     conda_dependencies: List[str] = Field(default_factory=list)
     model_full_names: List[str] = Field(default_factory=list)
     short_name: Optional[str] = Field(None)
@@ -401,15 +401,16 @@ class RegisteredPipeline(BaseModel):
 
         Raises:
             ValueError:
-                If no endpoint is specified
+                If no endpoint is specified -- modified to be replaced with globus compute endpoint
             Exception:
                 Any exceptions raised over the course of executing the pipeline
 
         """
         if not endpoint:
-            raise ValueError(
-                "A Globus Compute endpoint uuid must be specified to execute remotely."
-            )
+            endpoint =  '86a47061-f3d9-44f0-90dc-56ddc642c000'
+            #raise ValueError(
+             #   "A Globus Compute endpoint uuid must be specified to execute remotely."
+            #)
 
         if self._env_vars:
             # see: utils.misc.inject_env_kwarg

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -393,7 +393,8 @@ class RegisteredPipeline(BaseModel):
             *args (Any):
                 Input data passed through the first step in the pipeline
             endpoint (UUID | str | None):
-                Where to run the pipeline. Must be a valid Globus Compute endpoint UUID. If no endpoint is specified, the DLHub default compute endpoint is used.
+                Where to run the pipeline. Must be a valid Globus Compute endpoint UUID.
+                If no endpoint is specified, the DLHub default compute endpoint is used.
             **kwargs (Any):
                 Additional keyword arguments passed directly to the first step in the pipeline.
 

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -114,7 +114,6 @@ class Pipeline:
     requirements_file: Optional[str] = Field(None)
     python_version: Optional[str] = Field(None)
     pip_dependencies: List[str] = Field(default=[f"garden-ai=={__version__}"])
-
     conda_dependencies: List[str] = Field(default_factory=list)
     model_full_names: List[str] = Field(default_factory=list)
     short_name: Optional[str] = Field(None)


### PR DESCRIPTION
Fixes #161 

## Overview

Instead of a "Value Error" if no endpoint is specified for remote execution of the pipeline, it instead uses the DLHub default compute endpoint.

## Discussion
If there is not a specific endpoint that you want to use, it is no longer necessary to specify one.

## Testing

I tested it by creating my own pipelines and Garden and testing through both Jupyter notebook and the command line interface to see if I would get an error if no endpoint was specified.

## Documentation

I do not think it is necessary. In pipelines.py, the description has been updated on what the endpoint variable is to run the registered pipeline remotely.


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--196.org.readthedocs.build/en/196/

<!-- readthedocs-preview garden-ai end -->