### PR TITLE
fix: ensure short_name is not None when registering pipeline

### DIFF
--- a/garden_ai/utils/_meta.py
+++ b/garden_ai/utils/_meta.py
@@ -141,6 +141,8 @@ class _USER_PIPELINE_MODULE:
     # Now, one of those class attributes is going to be a Pipeline instance
     for name, value in vars(cls).items():
         if isinstance(value, Pipeline):
+            # use whatever identifier the user assigned the pipeline to in their code
+            value.short_name = value.short_name or name
             return value
     raise ValueError(
         f"Did not find top-level pipeline object defined in {python_file}."


### PR DESCRIPTION
forgot to populate `short_name` in #190 when loading a pipeline from user's `pipeline.py` 

<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--207.org.readthedocs.build/en/207/

<!-- readthedocs-preview garden-ai end -->