### PR TITLE
generate presigned_urls at publish time

### DIFF
--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -429,6 +429,7 @@ class GardenClient:
         Publishes a Garden's expanded_json to the backend /garden-search-route,
         making it visible on our Globus Search index.
         """
+        self._generate_presigned_urls_for_garden(garden)
         self._update_datacite(garden)
         try:
             self.backend_client.publish_garden_metadata(garden)


### PR DESCRIPTION
`Fixes #205 `

## Overview

Fixes #205 by generating presigned URLs at garden publish time.

## Testing

I implemented this change locally, and observed success in an end-to-end test.


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--214.org.readthedocs.build/en/214/

<!-- readthedocs-preview garden-ai end -->