### PR TITLE
Container caching

### DIFF
--- a/garden_ai/app/pipeline.py
+++ b/garden_ai/app/pipeline.py
@@ -352,11 +352,9 @@ def register(
         console.log(f"Could not parse {pipeline_file} as a Garden pipeline. " + str(e))
         raise
     with console.status(
-        "[bold green]Building container. This operation times out after 30 minutes."
+        "[bold green]Building container and registering pipeline. This operation times out after 30 minutes."
     ):
-        container_uuid = client.build_container(user_pipeline)
-    console.print(f"Created container {container_uuid}")
-    func_uuid = client.register_pipeline(user_pipeline, container_uuid)
+        func_uuid = client.register_pipeline(user_pipeline)
     console.print(f"Created function {func_uuid}")
     console.print(f"Done! Pipeline was registered with doi {user_pipeline.doi}.")
 

--- a/garden_ai/app/pipeline.py
+++ b/garden_ai/app/pipeline.py
@@ -354,8 +354,7 @@ def register(
     with console.status(
         "[bold green]Building container and registering pipeline. This operation times out after 30 minutes."
     ):
-        func_uuid = client.register_pipeline(user_pipeline)
-    console.print(f"Created function {func_uuid}")
+        client.register_pipeline(user_pipeline)
     console.print(f"Done! Pipeline was registered with doi {user_pipeline.doi}.")
 
 

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -396,7 +396,10 @@ class GardenClient:
         built_container_uuid = build_container(self.compute_client, pipeline)
         return built_container_uuid
 
-    def register_pipeline(self, pipeline: Pipeline, container_uuid: str) -> str:
+    def register_pipeline(self, pipeline: Pipeline, container_uuid: Optional[str] = None) -> str:
+        if container_uuid is None:
+            # CACHING LOGIC HERE
+            container_uuid = self.build_container(pipeline)
         func_uuid = register_pipeline(self.compute_client, pipeline, container_uuid)
         pipeline.func_uuid = UUID(func_uuid)
         self._update_datacite(pipeline)

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -412,7 +412,11 @@ class GardenClient:
     ) -> RegisteredPipeline:
         if container_uuid is None:
             cache = _read_local_cache().get(get_cache_tag(pipeline.pip_dependencies))
-            container_uuid = cache or self.build_container(pipeline)
+            if cache is not None:
+                container_uuid = cache
+                print("Cache hit! Using pre-built container.")
+            else:
+                container_uuid = self.build_container(pipeline)
 
         func_uuid = register_pipeline(self.compute_client, pipeline, container_uuid)
         pipeline.func_uuid = UUID(func_uuid)

--- a/garden_ai/local_data.py
+++ b/garden_ai/local_data.py
@@ -43,7 +43,7 @@ resource_type_to_id_key = {
 }
 
 
-def _read_local_cache() -> dict:
+def _read_local_cache() -> Dict[int, str]:
     if not (LOCAL_STORAGE / "cache.json").exists():
         return {}
 
@@ -55,7 +55,7 @@ def _read_local_cache() -> dict:
     return data
 
 
-def _write_local_cache(data: dict) -> None:
+def _write_local_cache(data: Dict[int, str]) -> None:
     with open(LOCAL_STORAGE / "cache.json", "w") as f:
         json.dump(data, f)
 

--- a/garden_ai/local_data.py
+++ b/garden_ai/local_data.py
@@ -43,7 +43,7 @@ resource_type_to_id_key = {
 }
 
 
-def _read_local_cache() -> Dict[int, str]:
+def _read_local_cache() -> Dict[str, str]:
     if not (LOCAL_STORAGE / "cache.json").exists():
         return {}
 
@@ -55,7 +55,7 @@ def _read_local_cache() -> Dict[int, str]:
     return data
 
 
-def _write_local_cache(data: Dict[int, str]) -> None:
+def _write_local_cache(data: Dict[str, str]) -> None:
     with open(LOCAL_STORAGE / "cache.json", "w") as f:
         json.dump(data, f)
 

--- a/garden_ai/local_data.py
+++ b/garden_ai/local_data.py
@@ -43,6 +43,23 @@ resource_type_to_id_key = {
 }
 
 
+def _read_local_cache() -> dict:
+    if not (LOCAL_STORAGE / "cache.json").exists():
+        return {}
+
+    with open(LOCAL_STORAGE / "cache.json", "r") as f:
+        try:
+            data = json.load(f)
+        except json.JSONDecodeError as e:
+            raise LocalDataException("Could not parse cache.json as valid json") from e
+    return data
+
+
+def _write_local_cache(data: dict) -> None:
+    with open(LOCAL_STORAGE / "cache.json", "w") as f:
+        json.dump(data, f)
+
+
 def _read_local_db() -> Dict:
     data = {}
     if (LOCAL_STORAGE / "data.json").exists():

--- a/garden_ai/utils/misc.py
+++ b/garden_ai/utils/misc.py
@@ -6,6 +6,7 @@ import sys
 from inspect import Parameter, Signature, signature
 from keyword import iskeyword
 from typing import Callable, List, Optional, Tuple
+from binascii import crc32
 
 import beartype.door
 import requests
@@ -22,7 +23,7 @@ issubtype = beartype.door.is_subhint
 
 def get_cache_tag(pip_reqs: List[str]) -> int:
     """Used for container uuid caching based on pip dependencies"""
-    return hash(frozenset(pip_reqs))
+    return crc32(str(sorted(set(pip_reqs))).encode())
 
 
 def safe_compose(f: Callable, g: Callable):

--- a/garden_ai/utils/misc.py
+++ b/garden_ai/utils/misc.py
@@ -21,9 +21,9 @@ logger = logging.getLogger()
 issubtype = beartype.door.is_subhint
 
 
-def get_cache_tag(pip_reqs: List[str]) -> int:
+def get_cache_tag(pip_reqs: List[str]) -> str:
     """Used for container uuid caching based on pip dependencies"""
-    return crc32(str(sorted(set(pip_reqs))).encode())
+    return str(crc32(str(sorted(set(pip_reqs))).encode()))
 
 
 def safe_compose(f: Callable, g: Callable):

--- a/garden_ai/utils/misc.py
+++ b/garden_ai/utils/misc.py
@@ -20,6 +20,11 @@ logger = logging.getLogger()
 issubtype = beartype.door.is_subhint
 
 
+def get_cache_tag(pip_reqs: List[str]) -> int:
+    """Used for container uuid caching based on pip dependencies"""
+    return hash(frozenset(pip_reqs))
+
+
 def safe_compose(f: Callable, g: Callable):
     """Helper: compose function `f` with function `g`, provided their annotations indicate compatibility.
     Arguments with defaults are ignored.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,6 +158,7 @@ def pipeline_toy_example(tmp_requirements_txt):
 
     pea_edibility_pipeline = Pipeline(
         title="Pea Edibility Pipeline",
+        short_name="pea_pipeline",
         steps=[split_peas, make_soup, rate_soup],
         authors=["Brian Jacques"],
         description="A pipeline for perfectly-reproducible soup ratings.",

--- a/tests/test_local_db.py
+++ b/tests/test_local_db.py
@@ -56,14 +56,41 @@ def test_local_storage_model(mocker, database_with_model, second_draft_of_model)
     assert overwritten_model.flavor == "pytorch"
 
 
-def test_local_cache():
-    reqs_set_a = ["tensorflow", "pandas", "mlflow==2.5.0"]
+def test_local_cache(mocker, garden_client, pipeline_toy_example):
+    build_method = mocker.patch(
+        "garden_ai.client.build_container",
+        return_value="d1fc6d30-be1c-4ac4-a289-d87b27e84357",
+    )
+    # return value is the checksum for pip_dependencies=["tensorflow"] (implicitly also contains pandas<3 and mlflow-skinny==2.5.0)
+    mocker.patch(
+        "garden_ai.client._read_local_cache",
+        return_value={"1529529185": "04332b26-bc14-45e1-a296-482e27c72500"},
+    )
+    mocker.patch("garden_ai.client._write_local_cache", return_value=None)
+    mocker.patch(
+        "garden_ai.client.register_pipeline",
+        return_value="9f5688ac-424d-443e-b525-97c72e4e083f",
+    )
+    mocker.patch("garden_ai.client.GardenClient._update_datacite", return_value=None)
+    mocker.patch("garden_ai.client.local_data.put_local_pipeline", return_value=None)
+
+    pipeline_toy_example.pip_dependencies = ["tensorflow"]
+    garden_client.register_pipeline(pipeline_toy_example)
+
+    assert build_method.call_count == 0
+
+    pipeline_toy_example.pip_dependencies = ["opencv-python"]
+    garden_client.register_pipeline(pipeline_toy_example)
+
+    assert build_method.call_count == 1
+
+    reqs_a = ["tensorflow", "pandas", "mlflow==2.5.0"]
     reqs_dup_a = ["tensorflow", "pandas", "mlflow==2.5.0", "pandas"]
     reqs_reorder_a = ["mlflow==2.5.0", "tensorflow", "pandas"]
-    reqs_set_b = ["pandas<3", "opencv-python", "mlflow==2.4.2"]
+    reqs_b = ["pandas<3", "opencv-python", "mlflow==2.4.2"]
     assert (
-        get_cache_tag(reqs_set_a)
+        get_cache_tag(reqs_a)
         == get_cache_tag(reqs_dup_a)
         == get_cache_tag(reqs_reorder_a)
     )
-    assert get_cache_tag(reqs_set_a) != get_cache_tag(reqs_set_b)
+    assert get_cache_tag(reqs_a) != get_cache_tag(reqs_b)

--- a/tests/test_local_db.py
+++ b/tests/test_local_db.py
@@ -1,4 +1,5 @@
 from garden_ai import local_data
+from garden_ai.utils.misc import get_cache_tag
 
 
 def test_local_storage_garden(mocker, garden_client, garden_all_fields, tmp_path):
@@ -53,3 +54,16 @@ def test_local_storage_model(mocker, database_with_model, second_draft_of_model)
         second_draft_of_model.full_name
     )
     assert overwritten_model.flavor == "pytorch"
+
+
+def test_local_cache():
+    reqs_set_a = ["tensorflow", "pandas", "mlflow==2.5.0"]
+    reqs_dup_a = ["tensorflow", "pandas", "mlflow==2.5.0", "pandas"]
+    reqs_reorder_a = ["mlflow==2.5.0", "tensorflow", "pandas"]
+    reqs_set_b = ["pandas<3", "opencv-python", "mlflow==2.4.2"]
+    assert (
+        get_cache_tag(reqs_set_a)
+        == get_cache_tag(reqs_dup_a)
+        == get_cache_tag(reqs_reorder_a)
+    )
+    assert get_cache_tag(reqs_set_a) != get_cache_tag(reqs_set_b)


### PR DESCRIPTION
`Fixes #217`

## Overview

Adds caching to the container building process. Will work for pipelines sharing a DOI and all dependencies.

## Discussion

Is this actually usable behavior? Does the content of the container not also depend on the content of the pipeline itself? If it doesn't (just needs uuid or otherwise), fantastic, but if it does, this may not be a usable feature except in very specific cases.

## Testing

I ran from scratch several builds locally, and the caching worked as expected.

## Documentation

There is additionally a change in the return type of `client.register_pipeline`, just for fun. I'll fix what breaks in relation to that.

<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--236.org.readthedocs.build/en/236/

<!-- readthedocs-preview garden-ai end -->