### PR TITLE
End to end test latest-tag output fix

### DIFF
--- a/.github/workflows/ete_test_full.yml
+++ b/.github/workflows/ete_test_full.yml
@@ -12,21 +12,21 @@ env:
 jobs:
   get-latest-tag:
     runs-on: ubuntu-latest
+    outputs:
+      latest-tag: ${{steps.get-latest-tag-step.outputs.tag}}
     steps:
       - name: Checkout repo content
         uses: actions/checkout@v2
-      - name: Get latest tag
+      - name: "Get latest tag"
         id: get-latest-tag-step
         uses: actions-ecosystem/action-get-latest-tag@v1
-      - name: Save latest tag to outputs
-        run: echo "ETE_LATEST_TAG=${{steps.get-latest-tag-step.outputs.tag}}" >> $GITHUB_OUTPUT
   build:
     runs-on: ubuntu-latest
     needs: [get-latest-tag]
     strategy:
       matrix:
         python-version: ["3.8"]
-        repository-ref: ["main", "${{needs.get-latest-tag.outputs.ETE_LATEST_TAG}}"]
+        repository-ref: ["main", "${{needs.get-latest-tag.outputs.latest-tag}}"]
       fail-fast: false
       max-parallel: 1
     name: build

--- a/.github/workflows/ete_test_skinny.yml
+++ b/.github/workflows/ete_test_skinny.yml
@@ -12,21 +12,21 @@ env:
 jobs:
   get-latest-tag:
     runs-on: ubuntu-latest
+    outputs:
+      latest-tag: ${{steps.get-latest-tag-step.outputs.tag}}
     steps:
       - name: Checkout repo content
         uses: actions/checkout@v2
-      - name: Get latest tag
+      - name: "Get latest tag"
         id: get-latest-tag-step
         uses: actions-ecosystem/action-get-latest-tag@v1
-      - name: Save latest tag to outputs
-        run: echo "ETE_LATEST_TAG=${{steps.get-latest-tag-step.outputs.tag}}" >> $GITHUB_OUTPUT
   build:
     runs-on: ubuntu-latest
     needs: [get-latest-tag]
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        repository-ref: ["main", "${{needs.get-latest-tag.outputs.ETE_LATEST_TAG}}"]
+        repository-ref: ["main", "${{needs.get-latest-tag.outputs.latest-tag}}"]
       fail-fast: false
       max-parallel: 1
     name: build


### PR DESCRIPTION
PR #235 broke the get-latest-tag action in the end to end test workflow. Fixes set output for get-latest-tag action.



<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--238.org.readthedocs.build/en/238/

<!-- readthedocs-preview garden-ai end -->