### PR TITLE
#222 Load Model Without Predict

### DIFF
--- a/garden_ai/_model.py
+++ b/garden_ai/_model.py
@@ -3,10 +3,15 @@ class _Model:
         self,
         model_full_name: str,
     ):
-        self.model = None
+        self._model = None
         self.full_name = model_full_name
 
         return
+
+    @property
+    def model(self):
+        self._lazy_load_model()
+        return self._model
 
     def download_and_stage(
         self, presigned_download_url: str, full_model_name: str
@@ -95,10 +100,10 @@ class _Model:
         """download and deserialize the underlying model, if necessary."""
         import mlflow  # type: ignore
 
-        if self.model is None:
+        if self._model is None:
             download_url = self.get_download_url(self.full_name)
             local_model_path = self.download_and_stage(download_url, self.full_name)
-            self.model = mlflow.pyfunc.load_model(
+            self._model = mlflow.pyfunc.load_model(
                 local_model_path, suppress_warnings=True
             )
             try:
@@ -127,5 +132,4 @@ class _Model:
         Results of model prediction
 
         """
-        self._lazy_load_model()
         return self.model.predict(data)

--- a/tests/test_mlmodel.py
+++ b/tests/test_mlmodel.py
@@ -53,6 +53,21 @@ def test_get_download_url(model_url_env_var):
     assert url == "presigned-url.aws.com"
 
 
+def test_load_model_before_predict(mocker, model_url_env_var):
+    from mlflow.pyfunc import PyFuncModel
+
+    mock_pyfunc_model = mocker.MagicMock(PyFuncModel)
+    mocker.patch("mlflow.pyfunc.load_model").return_value = mock_pyfunc_model
+    mocker.patch(
+        "garden_ai._model._Model.download_and_stage"
+    ).return_value = (
+        "/Users/FakeUser/.garden/mlflow/willengler@uchicago.edu/test_model/unzipped"
+    )
+    model = _Model("willengler@uchicago.edu/test_model")
+    assert model.model is not None
+    assert isinstance(model.model, PyFuncModel)
+
+
 def test_generate_presigned_urls_for_garden(
     mocker, garden_client, garden_all_fields, registered_pipeline_toy_example
 ):

--- a/tests/test_mlmodel.py
+++ b/tests/test_mlmodel.py
@@ -54,7 +54,7 @@ def test_get_download_url(model_url_env_var):
 
 
 def test_load_model_before_predict(mocker, model_url_env_var):
-    from mlflow.pyfunc import PyFuncModel
+    from mlflow.pyfunc import PyFuncModel  # type: ignore
 
     mock_pyfunc_model = mocker.MagicMock(PyFuncModel)
     mocker.patch("mlflow.pyfunc.load_model").return_value = mock_pyfunc_model


### PR DESCRIPTION
Link to any related issues, companion PRs, or blockers. eg, `Fixes #37`
https://github.com/Garden-AI/garden/issues/222
## Overview

A user is able to access the loaded model from S3 by calling model.model.

## Discussion

Any additional context that you think is important for reviewers or future users/contributors looking at this PR.
The issue originated from issue #200. Currently cannot replicate loading the model locally due to issues in dependencies with the required pyyaml version of ml-mast and cython.
https://github.com/yaml/pyyaml/issues/724
https://github.com/yaml/pyyaml/issues/728
## Testing

Testing it through a pipeline as well as by trying to create a _Model object through the Model function and a registered model's name. In testing just obtaining the model, you need to obtain a presigned_url_response with client.backend_client.get_model_download_urls([model's name])

## Documentation

Does this PR update any docs pages? Should it? 
--


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--239.org.readthedocs.build/en/239/

<!-- readthedocs-preview garden-ai end -->