### PR TITLE
fix: pipeline load util doesn't need to mainify

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,17 @@
+import os
 from typing import List
 
 import pytest
-import os
 from globus_compute_sdk import Client  # type: ignore
 from globus_compute_sdk.sdk.login_manager.manager import LoginManager  # type: ignore
 from globus_sdk import AuthClient, OAuthTokenResponse, SearchClient
-from garden_ai.garden_file_adapter import GardenFileAdapter
 from mlflow.pyfunc import PyFuncModel  # type: ignore
 
 import garden_ai
 from garden_ai import Garden, GardenClient, Pipeline, step
+from garden_ai.garden_file_adapter import GardenFileAdapter
+from garden_ai.mlmodel import LocalModel, ModelMetadata
 from garden_ai.pipelines import RegisteredPipeline
-from garden_ai.mlmodel import ModelMetadata, LocalModel
 from tests.fixtures.helpers import get_fixture_file_path  # type: ignore
 
 
@@ -374,3 +374,8 @@ def valid_search_by_doi():
 @pytest.fixture
 def empty_search_by_doi():
     return read_fixture_text("search_results/empty_search_by_doi.json")
+
+
+@pytest.fixture
+def path_to_pipeline_with_main_block():
+    return get_fixture_file_path("fixture_pipeline/pipeline.py")

--- a/tests/fixtures/fixture_pipeline/pipeline.py
+++ b/tests/fixtures/fixture_pipeline/pipeline.py
@@ -1,6 +1,7 @@
 ## THIS FILE WAS AUTOMATICALLY GENERATED ##
-from garden_ai import GardenClient, Model, Pipeline, step
 import typing
+
+from garden_ai import GardenClient, Model, Pipeline, step
 
 ##################################### STEPS #####################################
 """
@@ -65,5 +66,9 @@ fixture_pipeline = Pipeline(
     description="",
     version="0.0.1",
     year=2023,
-    tags=[]
+    tags=[],
 )
+
+if __name__ == "__main__":
+    # should not be tripped when pipeline is loaded from file
+    raise Exception("oh please, __main__ was my father's __name__")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,8 @@ from garden_ai.utils.misc import (
     validate_pip_lines,
 )
 
+from garden_ai.utils.filesystem import load_pipeline_from_python_file
+
 
 def test_extract_email_from_globus_jwt_happy_path(identity_jwt):
     assert extract_email_from_globus_jwt(identity_jwt) == "willengler@uchicago.edu"
@@ -38,3 +40,8 @@ def test_validate_pip_lines():
             "https://github.com/user/package/archive/v1.0.0.tar.gz",
         ]
         result = validate_pip_lines(valid_lines + invalid_lines)
+
+
+def test_pipeline_ifmain_block_surprise(path_to_pipeline_with_main_block):
+    # see pipeline file's `if __name__ == "__main__"` block, which just raises an exception
+    load_pipeline_from_python_file(path_to_pipeline_with_main_block)


### PR DESCRIPTION
fixes #230 

## Overview

When a pipeline is loaded from a user's `pipeline.py` module, their code is no longer "__main__ified" -- it turns out this wasn't necessary, and giving the call to `exec` an empty dict for `globals` works just as well as passing the top-level `__main__.__dict__`. 

## Discussion

I'm pretty sure that this was never necessary -- I originally did it like this because I wanted to guarantee that the user's top level `import garden_ai` line would be a noop, since that's what screwed up our earlier off-the-shelf `importlib` approach, but it turns out that was overkill. 

## Testing

Added a cute little unit test, but I'd made this change locally while working on the BraggNN seedling (I only discovered it trying to make a repro script for #224) and in doing so tested it pretty thoroughly. 

## Documentation

Updated comments but no changes necessary for the docs 


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--241.org.readthedocs.build/en/241/

<!-- readthedocs-preview garden-ai end -->