### PR TITLE
164 cli tab completion

### DIFF
--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -43,6 +43,22 @@ garden-ai --version
 
 You should see the version of your installed Garden package printed to the console.
 
+Garden also supports tab completion in the CLI to show options of local models, pipelines, and gardens.
+If you want to use Garden with tab completion, run:
+```bash
+garden-ai --install-completion
+```
+> [!NOTE] Note
+> ``--install-completion`` should already modify your ``.zshrc``, but in some cases the following additional configuration has been necessary for ``zsh`` users. Ensure it matches exactly to:
+>```bash
+>autoload -Uz compinit
+>zstyle ':completion:*' menu select
+>fpath+=~/.zfunc
+>compinit
+>```
+> This helps configure and enable a modified tab-completion for Garden.
+> Now, autocompletion can work such as: ```garden-ai garden publish -g [TAB] [TAB]```
+
 Now you're ready to start Gardening!
 
 > [!NOTE] Note

--- a/garden_ai/app/completion.py
+++ b/garden_ai/app/completion.py
@@ -1,0 +1,37 @@
+from garden_ai import local_data
+
+
+def complete_model(incomplete: str):
+    completion = []
+    models = local_data.get_all_local_models()
+    all_model_names = [model.full_name for model in models]
+    if not incomplete:
+        return all_model_names
+    for name in all_model_names:
+        if name.startswith(incomplete):
+            completion.append(name)
+    return completion
+
+
+def complete_pipeline(incomplete: str):
+    completion = []
+    pipelines = local_data.get_all_local_pipelines()
+    all_pipelines = [(pipeline.doi, pipeline.title) for pipeline in pipelines]
+    if not incomplete:
+        return all_pipelines
+    for name, help_text in all_pipelines:
+        if name.startswith(incomplete):
+            completion.append((name, help_text))
+    return completion
+
+
+def complete_garden(incomplete: str):
+    completion = []
+    gardens = local_data.get_all_local_gardens()
+    all_gardens = [(garden.doi, garden.title) for garden in gardens]
+    if not incomplete:
+        return all_gardens
+    for name, help_text in all_gardens:
+        if name.startswith(incomplete):
+            completion.append((name, help_text))
+    return completion

--- a/garden_ai/app/completion.py
+++ b/garden_ai/app/completion.py
@@ -4,7 +4,7 @@ from garden_ai import local_data
 def complete_model(incomplete: str):
     completion = []
     models = local_data.get_all_local_models()
-    all_model_names = [model.full_name for model in models]
+    all_model_names = [model.full_name for model in models] if models else []
     if not incomplete:
         return all_model_names
     for name in all_model_names:
@@ -16,7 +16,9 @@ def complete_model(incomplete: str):
 def complete_pipeline(incomplete: str):
     completion = []
     pipelines = local_data.get_all_local_pipelines()
-    all_pipelines = [(pipeline.doi, pipeline.title) for pipeline in pipelines]
+    all_pipelines = (
+        [(pipeline.doi, pipeline.title) for pipeline in pipelines] if pipelines else []
+    )
     if not incomplete:
         return all_pipelines
     for name, help_text in all_pipelines:
@@ -28,7 +30,7 @@ def complete_pipeline(incomplete: str):
 def complete_garden(incomplete: str):
     completion = []
     gardens = local_data.get_all_local_gardens()
-    all_gardens = [(garden.doi, garden.title) for garden in gardens]
+    all_gardens = [(garden.doi, garden.title) for garden in gardens] if gardens else []
     if not incomplete:
         return all_gardens
     for name, help_text in all_gardens:

--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -17,6 +17,7 @@ from garden_ai.globus_search.garden_search import (
 from garden_ai.gardens import Garden
 from garden_ai.pipelines import RegisteredPipeline
 from garden_ai.app.console import console, get_local_garden_rich_table
+from garden_ai.app.completion import complete_garden, complete_pipeline
 
 logger = logging.getLogger()
 
@@ -227,6 +228,7 @@ def add_pipeline(
         ...,
         "-g",
         "--garden",
+        autocompletion=complete_garden,
         prompt="Please enter the DOI of a garden",
         help="The name of the garden you want to add a pipeline to",
         rich_help_panel="Required",
@@ -235,6 +237,7 @@ def add_pipeline(
         ...,
         "-p",
         "--pipeline",
+        autocompletion=complete_pipeline,
         prompt="Please enter the DOI of a pipeline",
         help="The name of the pipeline you want to add",
         rich_help_panel="Required",
@@ -282,6 +285,7 @@ def publish(
         ...,
         "-g",
         "--garden",
+        autocompletion=complete_garden,
         prompt="Please enter the DOI of a garden",
         help="The DOI of the garden you want to publish",
         rich_help_panel="Required",
@@ -332,6 +336,7 @@ def show(
         ...,
         help="The DOIs of the Gardens you want to show the local data for. "
         "e.g. ``garden show garden1_doi garden2_doi`` will show the local data for both Gardens listed.",
+        autocompletion=complete_garden,
     ),
 ):
     """Shows all info for some Gardens"""

--- a/garden_ai/app/model.py
+++ b/garden_ai/app/model.py
@@ -14,7 +14,6 @@ from garden_ai.mlmodel import (
 from garden_ai.app.console import console, get_local_model_rich_table
 from garden_ai.app.completion import complete_model
 import typer
-from typing_extensions import Annotated
 import rich
 from rich.prompt import Prompt
 import logging

--- a/garden_ai/app/model.py
+++ b/garden_ai/app/model.py
@@ -12,8 +12,9 @@ from garden_ai.mlmodel import (
 )
 
 from garden_ai.app.console import console, get_local_model_rich_table
-
+from garden_ai.app.completion import complete_model
 import typer
+from typing_extensions import Annotated
 import rich
 from rich.prompt import Prompt
 import logging
@@ -98,6 +99,7 @@ def add_dataset(
         ...,
         "-m",
         "--model",
+        autocompletion=complete_model,
         help="The name of the model you would like to link your dataset to",
         rich_help_panel="Required",
     ),
@@ -173,8 +175,9 @@ def list():
 def show(
     model_ids: List[str] = typer.Argument(
         ...,
-        help="The URIs of the models you want to show the local data for. "
+        help="The full model names of the models you want to show the local data for. "
         "e.g. ``model show email@addr.ess-model-name/2 email@addr.ess-model-name-2/4`` will show the local data for both models listed.",
+        autocompletion=complete_model,
     ),
 ):
     """Shows all info for some Models"""

--- a/garden_ai/app/pipeline.py
+++ b/garden_ai/app/pipeline.py
@@ -12,6 +12,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from garden_ai import GardenClient, Pipeline, step, GardenConstants
 from garden_ai.app.console import console, get_local_pipeline_rich_table
+from garden_ai.app.completion import complete_pipeline
 from garden_ai.pipelines import Repository, Paper
 from garden_ai.local_data import put_local_pipeline, get_local_pipeline_by_doi
 from garden_ai.mlmodel import PipelineLoadScaffoldedException
@@ -197,6 +198,7 @@ def add_repository(
         ...,
         "-d",
         "--doi",
+        autocompletion=complete_pipeline,
         help="The doi for the pipeline you would like to add a repository to",
         rich_help_panel="Required",
     ),
@@ -257,6 +259,7 @@ def add_paper(
         ...,
         "-d",
         "--doi",
+        autocompletion=complete_pipeline,
         help="The doi for the pipeline you would like to add a repository to",
         rich_help_panel="Required",
     ),
@@ -478,6 +481,7 @@ def show(
         ...,
         help="The DOIs of the pipelines you want to show the local data for. "
         "e.g. ``pipeline show pipeline1_doi pipeline2_doi`` will show the local data for both pipelines listed.",
+        autocompletion=complete_pipeline,
     ),
 ):
     """Shows all info for some Gardens"""

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,0 +1,44 @@
+from garden_ai.app.completion import complete_model, complete_pipeline, complete_garden
+
+
+def test_complete_model(second_draft_of_model, mocker):
+    registered_model = second_draft_of_model
+    mocker.patch("garden_ai.local_data.get_all_local_models").return_value = [
+        registered_model
+    ]
+
+    model_full_name = registered_model.full_name
+
+    empty_search = complete_model("")
+    assert [model_full_name] == empty_search
+
+    not_existing_search = complete_model("not-a-full-model-name-that-can-be-found")
+    assert len(not_existing_search) == 0
+
+
+def test_complete_pipeline(database_with_connected_pipeline, mocker):
+    mocker.patch(
+        "garden_ai.local_data.LOCAL_STORAGE", new=database_with_connected_pipeline
+    )
+    pipeline_doi = "10.23677/jx31-gx98"
+    pipeline_title = "Fixture pipeline"
+
+    empty_search = complete_pipeline("")
+    assert [(pipeline_doi, pipeline_title)] == empty_search
+
+    not_existing_search = complete_model("a-pipeline-that-cannot-be-found")
+    assert len(not_existing_search) == 0
+
+
+def test_complete_garden(database_with_connected_pipeline, mocker):
+    mocker.patch(
+        "garden_ai.local_data.LOCAL_STORAGE", new=database_with_connected_pipeline
+    )
+    garden_doi = "10.23677/fake-doi"
+    garden_title = "Will Test Garden"
+
+    empty_search = complete_garden("")
+    assert [(garden_doi, garden_title)] == empty_search
+
+    not_existing_search = complete_model("a-garden-that-cannot-be-found")
+    assert len(not_existing_search) == 0


### PR DESCRIPTION
Link to any related issues, companion PRs, or blockers. eg, `Fixes #37`
https://github.com/Garden-AI/garden/issues/164
## Overview
When a user wants to reference a garden, pipeline, or model, in hitting the key [TAB][TAB] twice in the CLI shows a list of potential options they can select from. 
Here are some possible options:
- garden-ai model show [TAB][TAB]
- garden-ai model add-dataset --model [TAB][TAB]
- garden-ai pipeline show [TAB][TAB]
- garden-ai pipeline add-repository --doi [TAB][TAB]
- garden-ai pipeline add-paper --doi [TAB][TAB]
- garden-ai garden show [TAB][TAB]
- garden-ai garden add-pipeline --garden [TAB][TAB] --pipeline [TAB][TAB]
- garden-ai garden publish --garden [TAB][TAB]

## Discussion

Important changes a user needs to make in order to make tab completion working:
1. In your terminal, run garden-ai --install-completion
2. Make the following modification to your .zshrc file: (May already have this or something similar-- but make sure matches exactly to this) 
autoload -Uz compinit
zstyle ':completion:*' menu select
fpath+=~/.zfunc
compinit


## Testing

I tested it in the CLI to see if I could get my local list of models/gardens/pipelines and created test cases to ensure the appropriate list was returning.

## Documentation

Does this PR update any docs pages? Should it?


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--245.org.readthedocs.build/en/245/

<!-- readthedocs-preview garden-ai end -->