### PR TITLE
Sklearn preprocessor support 

### DIFF
--- a/.github/workflows/ete_test_full.yml
+++ b/.github/workflows/ete_test_full.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8"]
-        repository-ref: ["main", "${{needs.get-latest-tag.outputs.latest-tag}}"]
+        repository-ref: ["max/sklearn-preprocessing"]
       fail-fast: false
       max-parallel: 1
     name: build

--- a/.github/workflows/ete_test_full.yml
+++ b/.github/workflows/ete_test_full.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8"]
-        repository-ref: ["max/sklearn-preprocessing"]
+        repository-ref: ["main", "${{needs.get-latest-tag.outputs.latest-tag}}"]
       fail-fast: false
       max-parallel: 1
     name: build

--- a/garden_ai/_model.py
+++ b/garden_ai/_model.py
@@ -121,7 +121,6 @@ class _Model:
                 )
             elif mlflow_load_strategy == "sklearn":
                 self._model = mlflow.sklearn.load_model(local_model_path)
-                # self.do_passthough = True
             elif mlflow_load_strategy == "pytorch":
                 # Load torch models with mlflow.torch so they can taketorch.tensors inputs
                 # Will also cause torch models to fail with np.ndarrays or pd.dataframes inputs
@@ -130,7 +129,6 @@ class _Model:
                 self._model = self._TorchWrapper(
                     mlflow.pytorch.load_model(local_model_path)
                 )
-                # self.do_passthough = True
             else:
                 raise Exception(
                     f"Invlaid garden_load_strategy given: {mlflow_load_strategy}"
@@ -164,7 +162,7 @@ class _Model:
         """
         return self.model.predict(data)
 
-    # Dill serialization and breaks with __getattr__ if missing this.
+    # Dill serialization breaks using new __getattr__ if missing this.
     def __getstate__(self):
         return self.__dict__
 

--- a/garden_ai/_model.py
+++ b/garden_ai/_model.py
@@ -164,19 +164,24 @@ class _Model:
         """
         return self.model.predict(data)
 
+    # Dill serialization and breaks with __getattr__ if missing this.
     def __getstate__(self):
         return self.__dict__
 
     def __getattr__(self, attr):
-        if attr == "_model" or attr == "full_name":
-            # Dill serialization infinitely recursive without this
+        if attr == "_model":
+            # Dill deserialization infinitely recursive without this
             raise AttributeError()
         if self._model is not None:
             if attr in self.__dict__:
+                # Use self definition of attr
                 return self.__getattribute__(attr)
             else:
+                # self does not have definition of attr
+                # Search _model instead
                 return self._model.__getattribute__(attr)
         else:
+            # _model is None, lazy load and try again.
             self._lazy_load_model()
             return self.__getattr__(attr)
 

--- a/garden_ai/_model.py
+++ b/garden_ai/_model.py
@@ -111,7 +111,7 @@ class _Model:
                 mlflow_load_strategy = mlflow_metadata["metadata"][
                     "garden_load_strategy"
                 ]
-            except Exception:
+            except KeyError:
                 # Default to mlflow.pyfunc if can't find garden_load_strategy
                 mlflow_load_strategy = "pyfunc"
 
@@ -173,7 +173,7 @@ class _Model:
         if self._model is not None:
             if attr in self.__dict__:
                 # Use self definition of attr
-                return self.__getattribute__(attr)
+                return self.__dict__[attr]
             else:
                 # self does not have definition of attr
                 # Search _model instead
@@ -181,7 +181,7 @@ class _Model:
         else:
             # _model is None, lazy load and try again.
             self._lazy_load_model()
-            return self.__getattr__(attr)
+            return getattr(self, attr)
 
     class _TorchWrapper(object):
         """

--- a/garden_ai/_model.py
+++ b/garden_ai/_model.py
@@ -111,7 +111,7 @@ class _Model:
                 mlflow_load_strategy = mlflow_metadata["metadata"][
                     "garden_load_strategy"
                 ]
-            except Exception as e:
+            except Exception:
                 # Default to mlflow.pyfunc if can't find garden_load_strategy
                 mlflow_load_strategy = "pyfunc"
 

--- a/garden_ai/mlmodel.py
+++ b/garden_ai/mlmodel.py
@@ -191,6 +191,7 @@ def stage_model_for_upload(local_model: LocalModel) -> str:
                 raise SerializationFormatException(
                     f"Unsupported serialization format of type {serialization_type} for flavor {flavor}"
                 )
+            metadata = {"garden_load_strategy": "sklearn"}
         elif flavor == ModelFlavor.TENSORFLOW.value:
             if (
                 serialization_type == SerializeType.KERAS.value
@@ -208,6 +209,7 @@ def stage_model_for_upload(local_model: LocalModel) -> str:
                 raise SerializationFormatException(
                     f"Unsupported serialization format of type {serialization_type} for flavor {flavor}"
                 )
+            metadata = {"garden_load_strategy": "pyfunc"}
         elif flavor == ModelFlavor.PYTORCH.value and pathlib.Path(local_path).is_file:
             if (
                 serialization_type == SerializeType.TORCH.value
@@ -221,6 +223,7 @@ def stage_model_for_upload(local_model: LocalModel) -> str:
                 raise SerializationFormatException(
                     f"Unsupported serialization format of type {serialization_type} for flavor {flavor}"
                 )
+            metadata = {"garden_load_strategy": "pytorch"}
         else:
             raise ModelUploadException(f"Unsupported model flavor {flavor}")
 
@@ -239,6 +242,7 @@ def stage_model_for_upload(local_model: LocalModel) -> str:
                 loaded_model,
                 artifact_path,
                 registered_model_name=local_model.mlflow_name,
+                metadata=metadata,
             )
             model_dir = os.path.join(
                 str(MODEL_STAGING_DIR),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -371,6 +371,35 @@ flavors:
     pickled_model: model.pkl
     serialization_format: cloudpickle
     sklearn_version: 1.3.0
+metadata:
+    garden_load_strategy: pyfunc
+mlflow_version: 2.4.2
+model_uuid: 7741a74966b04ee2b02ddc11c84260cb
+run_id: 6949be777da74b75b9c6dba8a4ecc5c6
+utc_time_created: '2023-07-31 15:17:38.890648'
+"""
+    return metadata_string
+
+
+@pytest.fixture
+def mlflow_metadata_sklearn():
+    metadata_string = """artifact_path: sklearn_test_model
+flavors:
+  python_function:
+    env:
+      conda: conda.yaml
+      virtualenv: python_env.yaml
+    loader_module: mlflow.sklearn
+    model_path: model.pkl
+    predict_fn: predict
+    python_version: 3.8.16
+  sklearn:
+    code: null
+    pickled_model: model.pkl
+    serialization_format: cloudpickle
+    sklearn_version: 1.3.0
+metadata:
+    garden_load_strategy: sklearn
 mlflow_version: 2.4.2
 model_uuid: 7741a74966b04ee2b02ddc11c84260cb
 run_id: 6949be777da74b75b9c6dba8a4ecc5c6
@@ -395,6 +424,8 @@ flavors:
     code: null
     model_data: data
     pytorch_version: 2.0.0
+metadata:
+    garden_load_strategy: pytorch
 mlflow_version: 2.4.2
 model_uuid: fd9d9378bc054c41b5e07730a4ed8cd6
 run_id: 4d906cddf11b4c99addb1c3374a0a2d1

--- a/tests/test_mlmodel.py
+++ b/tests/test_mlmodel.py
@@ -69,6 +69,26 @@ def test_load_model_before_predict(mocker, model_url_env_var, mlflow_metadata):
     assert isinstance(model.model, PyFuncModel)
 
 
+def test_load_model_before_predict_sklearn(
+    mocker, model_url_env_var, mlflow_metadata_sklearn
+):
+    from mlflow.pyfunc import PyFuncModel  # type: ignore
+
+    # Mock mlflow.sklearn.load_model with PyFuncModel output instead of sklearn model
+    # Done to avoid importing sklearn to test suite
+    mock_sklearn_model = mocker.MagicMock(PyFuncModel)
+    mocker.patch("mlflow.sklearn.load_model").return_value = mock_sklearn_model
+    mocker.patch(
+        "garden_ai._model._Model.download_and_stage"
+    ).return_value = (
+        "/Users/FakeUser/.garden/mlflow/willengler@uchicago.edu/test_model/unzipped"
+    )
+    mocker.patch("builtins.open", mocker.mock_open(read_data=mlflow_metadata_sklearn))
+    model = _Model("willengler@uchicago.edu/test_model")
+    assert model.model is not None
+    assert isinstance(model.model, PyFuncModel)
+
+
 def test_load_model_before_predict_torch(
     mocker, model_url_env_var, mlflow_metadata_torch
 ):


### PR DESCRIPTION
Fixes #218 

## Overview
Allows sklearn pipelines and preprocessors to be upload as models to Garden. 

* Redefines `__getattr__` in `_Model` to proxy all attributes of the stored `_model` to the `_Model` class. This allows users to be able to call the internal `_model` methods using their `_Model` object.
* Changes mlflow load for sklearn models from `mlflow.pyfunc.load_model` to `mlflow.sklearn.load_model`.
* Adds new metadata `garden_load_strategy` to mlflow upload.
* Adds unit tests for loading sklearn models.


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--246.org.readthedocs.build/en/246/

<!-- readthedocs-preview garden-ai end -->