### PR TITLE
add all container spec vars to cache tag

### DIFF
--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -402,7 +402,11 @@ class GardenClient:
         built_container_uuid = build_container(self.compute_client, pipeline)
 
         cache = _read_local_cache()
-        tag = get_cache_tag(pipeline.pip_dependencies)
+        tag = get_cache_tag(
+            pipeline.pip_dependencies,
+            pipeline.conda_dependencies,
+            pipeline.python_version,
+        )
         cache[tag] = built_container_uuid
         _write_local_cache(cache)
 
@@ -412,7 +416,13 @@ class GardenClient:
         self, pipeline: Pipeline, container_uuid: Optional[str] = None
     ) -> RegisteredPipeline:
         if container_uuid is None:
-            cache = _read_local_cache().get(get_cache_tag(pipeline.pip_dependencies))
+            cache = _read_local_cache().get(
+                get_cache_tag(
+                    pipeline.pip_dependencies,
+                    pipeline.conda_dependencies,
+                    pipeline.python_version,
+                )
+            )
             if cache is not None:
                 container_uuid = cache
                 print("Cache hit! Using pre-built container.")

--- a/garden_ai/utils/misc.py
+++ b/garden_ai/utils/misc.py
@@ -21,9 +21,13 @@ logger = logging.getLogger()
 issubtype = beartype.door.is_subhint
 
 
-def get_cache_tag(pip_reqs: List[str], conda_deps: List[str], py_version: str) -> str:
+def get_cache_tag(
+    pip_reqs: List[str], conda_deps: List[str], py_version: Optional[str]
+) -> str:
     """Used for container uuid caching based on pip/conda dependencies"""
-    full_spec = pip_reqs + conda_deps + [py_version]
+    full_spec = (
+        pip_reqs + conda_deps + [py_version or ".".join(map(str, sys.version_info[:3]))]
+    )
     return str(crc32(str(sorted(set(full_spec))).encode()))
 
 

--- a/garden_ai/utils/misc.py
+++ b/garden_ai/utils/misc.py
@@ -21,9 +21,10 @@ logger = logging.getLogger()
 issubtype = beartype.door.is_subhint
 
 
-def get_cache_tag(pip_reqs: List[str]) -> str:
-    """Used for container uuid caching based on pip dependencies"""
-    return str(crc32(str(sorted(set(pip_reqs))).encode()))
+def get_cache_tag(pip_reqs: List[str], conda_deps: List[str], py_version: str) -> str:
+    """Used for container uuid caching based on pip/conda dependencies"""
+    full_spec = pip_reqs + conda_deps + [py_version]
+    return str(crc32(str(sorted(set(full_spec))).encode()))
 
 
 def safe_compose(f: Callable, g: Callable):

--- a/tests/test_local_db.py
+++ b/tests/test_local_db.py
@@ -62,7 +62,7 @@ def test_local_cache(mocker, garden_client, pipeline_toy_example):
     reqs_reorder_a = ["mlflow==2.5.0", "tensorflow", "pandas"]
     reqs_b = ["pandas<3", "opencv-python", "mlflow==2.4.2"]
 
-    py_version = "3.10.8"
+    py_version = pipeline_toy_example.python_version
 
     assert (
         get_cache_tag(reqs_a, [], py_version)
@@ -75,7 +75,7 @@ def test_local_cache(mocker, garden_client, pipeline_toy_example):
     assert get_cache_tag(reqs_a, [], py_version) != get_cache_tag(
         reqs_a, ["not-equal"], py_version
     )
-    assert get_cache_tag(reqs_a, [], py_version) != get_cache_tag(reqs_a, [], "3.10.9")
+    assert get_cache_tag(reqs_a, [], py_version) != get_cache_tag(reqs_a, [], "2.7.0")
 
     build_method = mocker.patch(
         "garden_ai.client.build_container",

--- a/tests/test_local_db.py
+++ b/tests/test_local_db.py
@@ -61,21 +61,33 @@ def test_local_cache(mocker, garden_client, pipeline_toy_example):
     reqs_dup_a = ["tensorflow", "pandas", "mlflow==2.5.0", "pandas"]
     reqs_reorder_a = ["mlflow==2.5.0", "tensorflow", "pandas"]
     reqs_b = ["pandas<3", "opencv-python", "mlflow==2.4.2"]
+
+    py_version = "3.10.8"
+
     assert (
-        get_cache_tag(reqs_a)
-        == get_cache_tag(reqs_dup_a)
-        == get_cache_tag(reqs_reorder_a)
+        get_cache_tag(reqs_a, [], py_version)
+        == get_cache_tag(reqs_dup_a, [], py_version)
+        == get_cache_tag(reqs_reorder_a, [], py_version)
     )
-    assert get_cache_tag(reqs_a) != get_cache_tag(reqs_b)
+    assert get_cache_tag(reqs_a, [], py_version) != get_cache_tag(
+        reqs_b, [], py_version
+    )
+    assert get_cache_tag(reqs_a, [], py_version) != get_cache_tag(
+        reqs_a, ["not-equal"], py_version
+    )
+    assert get_cache_tag(reqs_a, [], py_version) != get_cache_tag(reqs_a, [], "3.10.9")
 
     build_method = mocker.patch(
         "garden_ai.client.build_container",
         return_value="d1fc6d30-be1c-4ac4-a289-d87b27e84357",
     )
-    # return value is the checksum for pip_dependencies=["tensorflow"] (implicitly also contains pandas<3 and mlflow-skinny==2.5.0)
     mocker.patch(
         "garden_ai.client._read_local_cache",
-        return_value={get_cache_tag(reqs_a): "04332b26-bc14-45e1-a296-482e27c72500"},
+        return_value={
+            get_cache_tag(
+                reqs_a, [], py_version
+            ): "d1fc6d30-be1c-4ac4-a289-d87b27e84357"
+        },
     )
     mocker.patch("garden_ai.client._write_local_cache", return_value=None)
     mocker.patch(


### PR DESCRIPTION
## Overview

Adds every parameter to the container build operation as a component of the cache tag.

## Testing

I tested the cache locally and it worked.

<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--249.org.readthedocs.build/en/249/

<!-- readthedocs-preview garden-ai end -->