### PR TITLE
Add field to Pipeline that lets user specify container uuid

### DIFF
--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -430,7 +430,6 @@ class GardenClient:
             else:
                 container_uuid = self.build_container(pipeline)
 
-        print(container_uuid)
         func_uuid = register_pipeline(self.compute_client, pipeline, container_uuid)
         pipeline.func_uuid = UUID(func_uuid)
         registered = RegisteredPipeline.from_pipeline(pipeline)

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -413,7 +413,9 @@ class GardenClient:
         return built_container_uuid
 
     def register_pipeline(self, pipeline: Pipeline) -> RegisteredPipeline:
-        container_uuid = pipeline.container_uuid
+        container_uuid = (
+            str(pipeline.container_uuid) if pipeline.container_uuid else None
+        )
         if container_uuid is None:
             cache = _read_local_cache().get(
                 get_cache_tag(
@@ -428,6 +430,7 @@ class GardenClient:
             else:
                 container_uuid = self.build_container(pipeline)
 
+        print(container_uuid)
         func_uuid = register_pipeline(self.compute_client, pipeline, container_uuid)
         pipeline.func_uuid = UUID(func_uuid)
         registered = RegisteredPipeline.from_pipeline(pipeline)

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -412,9 +412,8 @@ class GardenClient:
 
         return built_container_uuid
 
-    def register_pipeline(
-        self, pipeline: Pipeline, container_uuid: Optional[str] = None
-    ) -> RegisteredPipeline:
+    def register_pipeline(self, pipeline: Pipeline) -> RegisteredPipeline:
+        container_uuid = pipeline.container_uuid
         if container_uuid is None:
             cache = _read_local_cache().get(
                 get_cache_tag(

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -135,6 +135,9 @@ class Pipeline:
         func_uuid:
             Should not be set by users. Globus Compute function UUID corresponding to \
             the pipeline's composed steps.
+        container_uuid:
+            Optional, can be specified by a user if they have registered a custom container with  Globus Compute. \
+            The pipeline function will be registered against this container.
         pip_dependencies:
             Optional, populated by contents of `requirements_file` if specified. \
             Contains the currently installed version of the garden-ai package by \
@@ -152,6 +155,7 @@ class Pipeline:
     contributors: List[str] = Field(default_factory=list, unique_items=True)
     doi: str = Field(...)
     func_uuid: Optional[UUID] = Field(None)
+    container_uuid: Optional[UUID] = Field(None)
     description: Optional[str] = Field(None)
     version: Optional[str] = "0.0.1"
     year: str = Field(default_factory=lambda: str(datetime.now().year))

--- a/tests/integrations/test_pipeline_registration.py
+++ b/tests/integrations/test_pipeline_registration.py
@@ -51,8 +51,8 @@ def test_register_and_run_with_env_vars(dlhub_endpoint):
     pipeline_path = get_fixture_file_path("fixture_pipeline/env_vars_pipeline.py")
     # NOTE: this pipeline just returns a copy of the os.environ dictionary
     pipeline = load_pipeline_from_python_file(pipeline_path)
-    container_id = "3dc3170e-2cdc-4379-885d-435a0d85b581"
-    client.register_pipeline(pipeline, container_id)
+    pipeline.container_uuid = "3dc3170e-2cdc-4379-885d-435a0d85b581"
+    client.register_pipeline(pipeline)
 
     # load from client, setting mlflow env vars
     registered_pipeline = client.get_registered_pipeline(pipeline.doi)
@@ -79,8 +79,8 @@ def test_register_and_run_with_model(dlhub_endpoint):
     # NOTE: this pipeline references a model, and raises an exception if model
     # fails to lazy-download when model.predict() is called
     pipeline = load_pipeline_from_python_file(pipeline_path)
-    container_id = "3dc3170e-2cdc-4379-885d-435a0d85b581"
-    client.register_pipeline(pipeline, container_id)
+    pipeline.container_uuid = "3dc3170e-2cdc-4379-885d-435a0d85b581"
+    client.register_pipeline(pipeline)
 
     # load from client, setting mlflow env vars
     registered_pipeline = client.get_registered_pipeline(pipeline.doi)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -220,4 +220,4 @@ def test_register_pipeline_with_specified_uuid(
     # Did the container UUID get passed through the right way?
     mocked_fn = garden_ai.client.register_pipeline
     container_arg = mocked_fn.call_args[0][2]
-    assert container_arg == UUID(CONTAINER_UUID)
+    assert container_arg == CONTAINER_UUID

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-from uuid import UUID
 from globus_compute_sdk import Client  # type: ignore
 from globus_compute_sdk.sdk.login_manager.manager import LoginManager  # type: ignore
 from globus_sdk import (


### PR DESCRIPTION
Closes #255

## Overview

Adds a new optional field to the Pipeline object where a user can specify the UUID of a registered container in Globus Compute.

## Discussion

I'm not advertising this far and wide in the docs or any console messages just yet. Still thinking through how we really want to handle cases where we need custom containers, but this is a good escape hatch for now.

## Testing

I added a unit test to confirm that the UUID gets passed into the function registration process as I expect. I also did some manual testing where I registered a pipeline using this parameter and confirmed that it was registered with the specified container.

## Documentation

I'm keeping it sneaky for now.

<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--258.org.readthedocs.build/en/258/

<!-- readthedocs-preview garden-ai end -->