### PR TITLE
Add client method to upload models from memory without serializing to disk first

### DIFF
--- a/docs/Models.md
+++ b/docs/Models.md
@@ -7,4 +7,4 @@
 			- LocalModel
 			- ModelMetadata
 			- DatasetConnection
-			- stage_model_for_upload
+			- stage_model_from_disk

--- a/docs/user_guide/tutorial.md
+++ b/docs/user_guide/tutorial.md
@@ -123,6 +123,8 @@ garden_client.register_model_from_memory(my_model, model_meta)
 
 ```
 
+In this example the name of the registered model to invoke will be `willengler@uchicago.edu/torchmdnet-ethanol`.
+
 ### Register a Pipeline
 
 Once we're satisfied with our pipeline's definition in `pipeline.py`, we can register the pipeline, allowing us to:

--- a/docs/user_guide/tutorial.md
+++ b/docs/user_guide/tutorial.md
@@ -109,6 +109,19 @@ def run_inference(
 > [!NOTE]
 > Regardless of "flavor" (sklearn, pytorch, etc) used when registering the underlying ML model, the `Model` object will appear to have a single `predict` method which passes its input directly to your model and returns its prediction.
 
+Alternatively, if you install the garden-ai package in the environment where you are developing your model, you can use the Garden SDK to register your model without serializing it to disk. For example ...
+
+```python
+my_model = train_pytorch_model()
+
+from garden_ai import GardenClient
+from garden_ai.mlmodel import ModelMetadata
+
+garden_client = GardenClient()
+model_meta = ModelMetadata(model_name="torchmdnet-ethanol", flavor="pytorch", user_email="willengler@uchicago.edu")
+garden_client.register_model_from_memory(my_model, model_meta)
+
+```
 
 ### Register a Pipeline
 

--- a/garden_ai/app/model.py
+++ b/garden_ai/app/model.py
@@ -100,7 +100,7 @@ def register(
         user_email=client.get_email(),
     )
 
-    registered_model = client.register_model(local_model)
+    registered_model = client.register_model_from_disk(local_model)
     rich.print(
         f"Successfully uploaded your model! The full name to include in your pipeline is '{registered_model.full_name}'"
     )

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -46,7 +46,7 @@ from garden_ai.mlmodel import (
     ModelNotFoundException,
     Model,
     clear_mlflow_staging_directory,
-    stage_model_for_upload,
+    stage_model_from_disk,
 )
 from garden_ai.model_file_transfer.upload import upload_mlmodel_to_s3
 from garden_ai.pipelines import Pipeline, RegisteredPipeline, Paper, Repository
@@ -307,7 +307,7 @@ class GardenClient:
     def register_model(self, local_model: LocalModel) -> ModelMetadata:
         try:
             # Create directory in MLModel format
-            model_directory = stage_model_for_upload(local_model)
+            model_directory = stage_model_from_disk(local_model)
             # Push contents of directory to S3
             upload_mlmodel_to_s3(model_directory, local_model, self.backend_client)
         finally:

--- a/garden_ai/mlmodel.py
+++ b/garden_ai/mlmodel.py
@@ -162,7 +162,7 @@ class LocalModel(ModelMetadata):
     extra_paths: List[str] = Field(default_factory=list)
 
 
-def stage_model_for_upload(local_model: LocalModel) -> str:
+def stage_model_from_disk(local_model: LocalModel) -> str:
     """
     Parameters
     ----------
@@ -185,16 +185,13 @@ def stage_model_for_upload(local_model: LocalModel) -> str:
             ):
                 with open(local_path, "rb") as f:
                     loaded_model = pickle.load(f)
-                    log_model_variant = mlflow.sklearn.log_model
             elif serialization_type == SerializeType.JOBLIB.value:
                 with open(local_path, "rb") as f:
                     loaded_model = joblib.load(f)
-                    log_model_variant = mlflow.sklearn.log_model
             else:
                 raise SerializationFormatException(
                     f"Unsupported serialization format of type {serialization_type} for flavor {flavor}"
                 )
-            metadata = {"garden_load_strategy": "sklearn"}
         elif flavor == ModelFlavor.TENSORFLOW.value:
             if (
                 serialization_type == SerializeType.KERAS.value
@@ -205,14 +202,10 @@ def stage_model_for_upload(local_model: LocalModel) -> str:
                 from tensorflow import keras  # type: ignore
 
                 loaded_model = keras.models.load_model(local_path)
-                log_model_variant = (
-                    mlflow.tensorflow.log_model
-                )  # TODO explore artifact path and sigs
             else:
                 raise SerializationFormatException(
                     f"Unsupported serialization format of type {serialization_type} for flavor {flavor}"
                 )
-            metadata = {"garden_load_strategy": "pyfunc"}
         elif flavor == ModelFlavor.PYTORCH.value and pathlib.Path(local_path).is_file:
             if (
                 serialization_type == SerializeType.TORCH.value
@@ -224,54 +217,97 @@ def stage_model_for_upload(local_model: LocalModel) -> str:
                     loaded_model = torch.load(local_path)
                 else:
                     loaded_model = torch.load(local_path, map_location="cpu")
-                for file in extra_paths:
-                    path = pathlib.Path(file)
-                    if not path.exists() or not path.is_file() or path.suffix != ".py":
-                        raise ModelUploadException(
-                            f"{path} is not a valid Python file. Please provide a valid Python file (.py)."
-                        )
-                log_model_variant = mlflow.pytorch.log_model  # TODO explore signatures
             else:
                 raise SerializationFormatException(
                     f"Unsupported serialization format of type {serialization_type} for flavor {flavor}"
                 )
-            metadata = {"garden_load_strategy": "pytorch"}
         else:
             raise ModelUploadException(f"Unsupported model flavor {flavor}")
 
-        if extra_paths and flavor != ModelFlavor.PYTORCH.value:
-            raise ModelUploadException(
-                f"Sorry, extra files are only supported for pytorch models. The {flavor} flavor is not supported."
-            )
-        # Create a folder structure for an experiment called "local" if it doesn't exist
-        # in the user's .garden directory
-        mlflow.set_tracking_uri("file://" + str(MODEL_STAGING_DIR))
-        experiment_name = "local"
-        mlflow.set_experiment(experiment_name)
-        experiment_id = mlflow.get_experiment_by_name(experiment_name).experiment_id
-
-        # The only way to derive the full directory path MLFlow creates is with this context manager.
-        with mlflow.start_run(None, experiment_id) as run:
-            experiment_id = mlflow.active_run().info.experiment_id
-            artifact_path = "model"
-            log_model_variant(
-                loaded_model,
-                artifact_path,
-                registered_model_name=local_model.mlflow_name,
-                code_paths=extra_paths,
-                metadata=metadata,
-            )
-            model_dir = os.path.join(
-                str(MODEL_STAGING_DIR),
-                experiment_id,
-                run.info.run_id,
-                "artifacts",
-                artifact_path,
-            )
     except IOError as e:
         raise ModelUploadException("Could not open file " + local_path) from e
     except (pickle.PickleError, mlflow.MlflowException) as e:
         raise ModelUploadException("Could not parse model at " + local_path) from e
+
+    return stage_model_from_memory(loaded_model, local_model, extra_paths)
+
+
+def stage_model_from_memory(
+    loaded_model: object,
+    model_meta: ModelMetadata,
+    extra_paths: Optional[List[str]] = None,
+) -> str:
+    """
+
+    Parameters
+    ----------
+    loaded_model: a model object from one of the AI libraries we support
+    model_meta: includes what flavor of model we're dealing with and under what name we're saving it
+    extra_paths: optional. Paths of extra files to bundle for pytorch class definitions.
+
+    Returns full path of model directory
+    -------
+
+    """
+    if extra_paths is None:
+        extra_paths = []
+
+    flavor, mlflow_name = (
+        model_meta.flavor,
+        model_meta.mlflow_name,
+    )
+
+    if extra_paths and flavor != ModelFlavor.PYTORCH.value:
+        raise ModelUploadException(
+            f"Sorry, extra files are only supported for pytorch models. The {flavor} flavor is not supported."
+        )
+
+    load_strategy = "pyfunc"
+    if flavor == ModelFlavor.SKLEARN.value:
+        log_model_variant = mlflow.sklearn.log_model
+        load_strategy = "sklearn"
+    elif flavor == ModelFlavor.TENSORFLOW.value:
+        log_model_variant = mlflow.tensorflow.log_model
+        os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+        # ignore cpu guard info on tf import require before tf import
+        from tensorflow import keras  # type: ignore
+    elif flavor == ModelFlavor.PYTORCH.value:
+        log_model_variant = mlflow.pytorch.log_model
+        import torch  # type: ignore
+
+        for file in extra_paths:
+            path = pathlib.Path(file)
+            if not path.exists() or not path.is_file() or path.suffix != ".py":
+                raise ModelUploadException(
+                    f"{path} is not a valid Python file. Please provide a valid Python file (.py)."
+                )
+    else:
+        raise ModelUploadException(f"Unsupported model flavor {flavor}")
+
+    # Create a folder structure for an experiment called "local" if it doesn't exist
+    # in the user's .garden directory
+    mlflow.set_tracking_uri("file://" + str(MODEL_STAGING_DIR))
+    experiment_name = "local"
+    mlflow.set_experiment(experiment_name)
+    experiment_id = mlflow.get_experiment_by_name(experiment_name).experiment_id
+
+    # The only way to derive the full directory path MLFlow creates is with this context manager.
+    with mlflow.start_run(None, experiment_id) as run:
+        experiment_id = mlflow.active_run().info.experiment_id
+        artifact_path = "model"
+        log_model_variant(
+            loaded_model,
+            artifact_path,
+            registered_model_name=mlflow_name,
+            metadata={"garden_load_strategy": load_strategy},
+        )
+        model_dir = os.path.join(
+            str(MODEL_STAGING_DIR),
+            experiment_id,
+            run.info.run_id,
+            "artifacts",
+            artifact_path,
+        )
 
     return model_dir
 

--- a/garden_ai/mlmodel.py
+++ b/garden_ai/mlmodel.py
@@ -268,13 +268,8 @@ def stage_model_from_memory(
         load_strategy = "sklearn"
     elif flavor == ModelFlavor.TENSORFLOW.value:
         log_model_variant = mlflow.tensorflow.log_model
-        os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
-        # ignore cpu guard info on tf import require before tf import
-        from tensorflow import keras  # type: ignore
     elif flavor == ModelFlavor.PYTORCH.value:
         log_model_variant = mlflow.pytorch.log_model
-        import torch  # type: ignore
-
         for file in extra_paths:
             path = pathlib.Path(file)
             if not path.exists() or not path.is_file() or path.suffix != ".py":

--- a/garden_ai/model_file_transfer/upload.py
+++ b/garden_ai/model_file_transfer/upload.py
@@ -4,14 +4,14 @@ import shutil
 import requests
 
 from garden_ai.backend_client import BackendClient, PresignedUrlResponse
-from garden_ai.mlmodel import LocalModel
+from garden_ai.mlmodel import ModelMetadata
 
 
 def upload_mlmodel_to_s3(
-    local_directory: str, local_model: LocalModel, backend_client: BackendClient
+    local_directory: str, model_meta: ModelMetadata, backend_client: BackendClient
 ):
     # Get url from Garden API
-    presigned_url_response = backend_client.get_model_upload_url(local_model.full_name)
+    presigned_url_response = backend_client.get_model_upload_url(model_meta.full_name)
     _upload_directory_to_s3_presigned(local_directory, presigned_url_response)
 
 

--- a/tests/cli/test_model.py
+++ b/tests/cli/test_model.py
@@ -23,7 +23,7 @@ def test_model_upload(mocker, tmp_path):
     result = runner.invoke(app, command)
     assert result.exit_code == 0
 
-    args = mock_client.register_model.call_args.args
+    args = mock_client.register_model_from_disk.call_args.args
     local_model = args[0]
     assert local_model.local_path == str(tmp_path)
     assert local_model.model_name == "unit-test-model"

--- a/tests/integrations/test_mlflow.py
+++ b/tests/integrations/test_mlflow.py
@@ -113,9 +113,9 @@ def test_mlflow_sklearn_register(tmp_path, toy_sklearn_model, serialize_type):
     if serialize_type == "keras":
         # Assert that the 'SerializationFormatException' is raised
         with pytest.raises(SerializationFormatException):
-            client.register_model(local_model)
+            client.register_model_from_disk(local_model)
     else:
-        registered_model = client.register_model(local_model)
+        registered_model = client.register_model_from_disk(local_model)
         # all mlflow models will have a 'predict' method
         downloaded_model = Model(registered_model.full_name)
         assert hasattr(downloaded_model, "predict")
@@ -140,7 +140,7 @@ def test_mlflow_pytorch_register(tmp_path, toy_pytorch_model):
         flavor="pytorch",
         user_email="foo@example.com",
     )
-    registered_model = client.register_model(local_model)
+    registered_model = client.register_model_from_disk(local_model)
 
     # all mlflow models will have a 'predict' method
     downloaded_model = Model(registered_model.full_name)
@@ -194,7 +194,7 @@ def test_mlflow_tensorflow_register(tmp_path, toy_tensorflow_model, save_format)
         flavor="tensorflow",
         user_email="foo@example.com",
     )
-    registered_model = client.register_model(local_model)
+    registered_model = client.register_model_from_disk(local_model)
 
     # all mlflow models will have a 'predict' method
     downloaded_model = Model(registered_model.full_name)

--- a/tests/integrations/test_mlflow.py
+++ b/tests/integrations/test_mlflow.py
@@ -4,7 +4,7 @@ from garden_ai import GardenClient, Model
 from garden_ai.mlmodel import (
     LocalModel,
     SerializationFormatException,
-    stage_model_for_upload,
+    stage_model_from_disk,
 )
 from tests.fixtures.helpers import get_fixture_file_path  # type: ignore
 
@@ -163,7 +163,7 @@ def test_mlflow_pytorch_extra_paths(mocker, local_model, tmp_path):
         user_email="willengler@uchicago.edu",
         extra_paths=[str(file_path)],
     )
-    staged_path = stage_model_for_upload(local_model)
+    staged_path = stage_model_from_disk(local_model)
     assert staged_path.endswith("/artifacts/model")
     expected_call = mocker.call(
         torch.load(model_path),

--- a/tests/integrations/test_mlflow.py
+++ b/tests/integrations/test_mlflow.py
@@ -3,6 +3,7 @@ import pytest
 from garden_ai import GardenClient, Model
 from garden_ai.mlmodel import (
     LocalModel,
+    ModelMetadata,
     SerializationFormatException,
     stage_model_from_disk,
 )
@@ -122,25 +123,33 @@ def test_mlflow_sklearn_register(tmp_path, toy_sklearn_model, serialize_type):
 
 
 @pytest.mark.integration
-def test_mlflow_pytorch_register(tmp_path, toy_pytorch_model):
-    # as if model.pkl already existed on disk
+@pytest.mark.parametrize("register_method", ["disk", "in_memory"])
+def test_mlflow_pytorch_register(tmp_path, toy_pytorch_model, register_method):
     import torch  # type: ignore
 
-    tmp_path.mkdir(exist_ok=True)
-    model_path = tmp_path / "pytorchtest.pth"
-    torch.save(toy_pytorch_model, model_path, _use_new_zipfile_serialization=False)
-
-    # simulate `$ garden-ai model register test-model-name tmp_path/pytorchtest.pt`
     name = "pt-test-model-name"
-    # actually register the model
     client = GardenClient()
-    local_model = LocalModel(
-        local_path=str(model_path),
+    model_meta = ModelMetadata(
         model_name=name,
         flavor="pytorch",
         user_email="foo@example.com",
     )
-    registered_model = client.register_model_from_disk(local_model)
+
+    if register_method == "disk":
+        # as if model.pkl already existed on disk
+        # simulate `$ garden-ai model register test-model-name tmp_path/pytorchtest.pt`
+        tmp_path.mkdir(exist_ok=True)
+        model_path = tmp_path / "pytorchtest.pth"
+        torch.save(toy_pytorch_model, model_path, _use_new_zipfile_serialization=False)
+
+        # actually register the model
+        local_model = LocalModel(local_path=str(model_path), **model_meta.dict())
+        registered_model = client.register_model_from_disk(local_model)
+
+    else:
+        registered_model = client.register_model_from_memory(
+            toy_pytorch_model, model_meta
+        )
 
     # all mlflow models will have a 'predict' method
     downloaded_model = Model(registered_model.full_name)

--- a/tests/test_mlmodel.py
+++ b/tests/test_mlmodel.py
@@ -5,7 +5,7 @@ import pytest
 from tests.fixtures.helpers import get_fixture_file_path  # type: ignore
 from garden_ai import PublishedGarden
 from garden_ai.mlmodel import (
-    stage_model_for_upload,
+    stage_model_from_disk,
     LocalModel,
     _Model,
     ModelUploadException,
@@ -14,7 +14,7 @@ from garden_ai.backend_client import BackendClient, PresignedUrlResponse
 from garden_ai.model_file_transfer.upload import upload_mlmodel_to_s3
 
 
-def test_stage_model_for_upload(mocker, tmp_path):
+def test_stage_model_from_disk(mocker, tmp_path):
     tmp_path.mkdir(parents=True, exist_ok=True)
     mocker.patch("garden_ai.mlmodel.MODEL_STAGING_DIR", new=tmp_path)
     model_path = get_fixture_file_path("fixture_models/iris_model.pkl")
@@ -25,7 +25,7 @@ def test_stage_model_for_upload(mocker, tmp_path):
         local_path=str(model_path),
         user_email="willengler@uchicago.edu",
     )
-    staged_path = stage_model_for_upload(local_model)
+    staged_path = stage_model_from_disk(local_model)
     assert staged_path.endswith("/artifacts/model")
     files_to_check = ["MLmodel", "model.pkl", "requirements.txt"]
 
@@ -72,7 +72,7 @@ def test_invalid_extra_paths(mocker, local_model, tmp_path):
         extra_paths=["invalid-path.py"],
     )
     with pytest.raises(ModelUploadException):
-        stage_model_for_upload(local_model)
+        stage_model_from_disk(local_model)
 
 
 def test_load_model_before_predict(mocker, model_url_env_var, mlflow_metadata):


### PR DESCRIPTION
Closes #232 

## Overview

Adds client method that is meant to be used from a notebook context or similar to upload a model that's in memory without needing to serialize and deserialize it.

## Discussion

As a byproduct this breaks up the monster `stage_model_for_upload` function in mlmodel.py. The original behavior should be exactly preserved though, bar a name change.

## Testing

- Updated existing tests
- Added an integration test that invokes the new client method
- Imported this branch in the context of Hyun/Eliu's notebook to test the new client method "in the wild". Successfully uploaded `willengler@uchicago.edu)torchmdnet-ethanol` model.

## Documentation

Added example to tutorial showing how to use from a notebook or similar context.

<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--259.org.readthedocs.build/en/259/

<!-- readthedocs-preview garden-ai end -->