### PR TITLE
Fix/propagate model code paths

### DIFF
--- a/garden_ai/app/model.py
+++ b/garden_ai/app/model.py
@@ -76,7 +76,9 @@ def register(
         writable=True,
         readable=True,
         resolve_path=True,
-        help=("The extra Python files that your model may require. Pytorch specific"),
+        help=(
+            "The extra python files or directories required to load your model (e.g. pytorch class definitions)."
+        ),
     ),
 ):
     """Register a model in Garden. Outputs a full model identifier that you can reference in a Pipeline."""


### PR DESCRIPTION
## Overview
This tweaks the behavior of the `garden-ai model register --extra-path ...` option. 

Currently, only individual python files can be included with model registration and only for pytorch models. This relaxes the constraint so that either python files or python package dirs (containing an `__init__.py`) can be included and removes the pytorch-only restriction.

## Discussion

The logic to determine whether a directory constitutes a valid python package is pretty naive, and any non-python files make it invalid. This is stricter than python actually is, but I think that it's the simplest way to make sure we don't end up with users dumping their entire repository in the model registration step. 

## Documentation

No updates for actual docs but yes updates to a few error/help messages


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--261.org.readthedocs.build/en/261/

<!-- readthedocs-preview garden-ai end -->