### PR TITLE
Fix big docs gripes

### DIFF
--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -1,39 +1,18 @@
 # Installation
 
-Installing the `garden-ai` python package contains both our SDK and our CLI. We _highly_ recommend installing the CLI with `pipx` over plain `pip`.
+Installing the `garden-ai` python package contains both our SDK and our CLI. We _highly_ recommend installing the CLI with a virtual environment, using venv or conda.
 
-If you don't have `pipx` installed, please follow the instructions in the [pipx documentation](https://pypa.github.io/pipx/installation/) to install it.
-
-Once `pipx` is installed and configured, you can install the Garden package. The simplest installation is done by:
+Below are instructions for installing with venv.
 
 ```bash
-pipx install garden-ai
-pipx ensurepath
+mkdir my_garden_project
+cd my_garden_project
+python3 -m venv garden-env
+source myenv/bin/activate
+pip install garden-ai
 ```
 
-> [!NOTE] Note
-> To be able to `import garden_ai` in a notebook or other python session, you likely need to do a plain `pip install garden-ai` with the appropriate active virtual environment. Doing so won't interfere with the `pipx`-installed CLI.
-
-
-The base package includes support for sklearn by default. If you want to use Garden with PyTorch or TensorFlow, you need to specify additional "extras". For PyTorch, use:
-
-```bash
-pipx install garden-ai[pytorch]
-```
-
-For TensorFlow, use:
-
-```bash
-pipx install garden-ai[tensorflow]
-```
-
-If you want to use Garden with all the supported ML frameworks (sklearn, PyTorch, TensorFlow), you can install it with the `all` extra:
-
-```bash
-pipx install garden-ai[all]
-```
-
-This will ensure all necessary dependencies for all supported ML frameworks are installed.
+The base package includes support for sklearn by default. If you want to use Garden with PyTorch, TensorFlow, or other packages you will need to install them in your virtual environment as well.
 
 To verify your installation, you can check the version of Garden:
 

--- a/docs/user_guide/introduction.md
+++ b/docs/user_guide/introduction.md
@@ -1,7 +1,7 @@
 # 🌱 Welcome to Garden 🌱
 
 Docs are WIP, but in the meantime here are good places to start:
-- [Overview](architecture_overview.md) - High-level explanation of key concepts
-- [Tutorial](user_guide/tutorial.md) - A short end-to-end example using the CLI. See also: ["seedlings" repository](https://github.com/Garden-AI/seedlings)
-- [contributing](developer_guide/contributing.md) - Getting started as a contributor
+- [Overview](../architecture_overview.md) - High-level explanation of key concepts
+- [Tutorial](../user_guide/tutorial.md) - A short end-to-end example using the CLI. See also: ["seedlings" repository](https://github.com/Garden-AI/seedlings)
+- [contributing](../developer_guide/contributing.md) - Getting started as a contributor
 - [Garden's GitHub repository](https://github.com/Garden-AI/garden) - Where all the magic happens

--- a/docs/user_guide/serialization.md
+++ b/docs/user_guide/serialization.md
@@ -6,13 +6,13 @@ In this tutorial, we will demonstrate how to serialize machine learning models u
 
 ## Table of Contents
 
-1. [Serialization with scikit-learn](#serialization-with-scikit-learn)
-   1.1. [Using pickle](#using-pickle)
-   1.2. [Using joblib](#using-joblib)
+1. [Serialization with scikit-learn](#1-serialization-with-scikit-learn)
+   1.1. [Using pickle](#11-using-pickle)
+   1.2. [Using joblib](#12-using-joblib)
 
-2. [Serialization with TensorFlow](#serialization-with-tensorflow)
+2. [Serialization with TensorFlow](#2-serialization-with-tensorflow)
 
-3. [Serialization with PyTorch](#serialization-with-pytorch)
+3. [Serialization with PyTorch](#3-serialization-with-pytorch)
 
 ## 1. Serialization with scikit-learn
 

--- a/docs/user_guide/tutorial.md
+++ b/docs/user_guide/tutorial.md
@@ -6,7 +6,7 @@ This tutorial will guide you through developing a Garden from scratch: registeri
 #### Prerequisites
 
 1. A pre-trained machine learning model saved in a format compatible with the SDK, i.e., `sklearn`, `pytorch`, or `tensorflow`.
-2. The Garden CLI [installed](user_guide/installation) on your system.
+2. The Garden CLI [installed](../installation) on your system.
 
 
 ### Create a Pipeline

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,6 @@ nav:
     - Steps: Steps.md
     - Pipelines: Pipelines.md
     - Gardens: Gardens.md
-  - Changelog: changelog.md
 theme: material
 plugins:
   - search


### PR DESCRIPTION
Fixes #276 and #275

## Overview

Just docs changes. Fixes broken links and recommends using venv instead of pipx for installation.

## Discussion

🤷 

## Testing

Ran the docs generator locally and inspected. Clicked every link and adjusted the ones that weren't working.

## Documentation

Oh yeah 😎 


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--286.org.readthedocs.build/en/286/

<!-- readthedocs-preview garden-ai end -->