### PR TITLE
Auth flow link fixes

### DIFF
--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -204,7 +204,7 @@ class GardenClient:
             self._display_notebook_link(
                 authorize_url
             )  # Must display url as html to render properly in notebooks
-        except NameError as e:
+        except NameError:
             print(
                 f"Authenticating with Globus in your default web browser: \n\n{authorize_url}"
             )

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -189,9 +189,17 @@ class GardenClient:
         )
         authorize_url = self.auth_client.oauth2_get_authorize_url()
 
-        print(
-            f"Authenticating with Globus in your default web browser: \n\n{authorize_url}"
-        )
+        try:
+            __IPYTHON__  # Only defined if running in notebook
+            print("Authenticating with Globus in your default web browser: \n\n")
+            _display_notebook_link(
+                authorize_url
+            )  # Must display link as html to render properly in notebook
+        except NameError:
+            print(
+                f"Authenticating with Globus in your default web browser: \n\n{authorize_url}"
+            )
+
         time.sleep(2)
         typer.launch(authorize_url)
 
@@ -203,6 +211,12 @@ class GardenClient:
         except AuthAPIError:
             logger.fatal("Invalid Globus auth token received. Exiting")
             return None
+
+    def _display_notebook_link(link):
+        from IPython.display import display, HTML
+
+        url = "<a href={}>{}</a>".format(link, link)
+        display(HTML(url))
 
     def _create_authorizer(self, resource_server: str):
         if not self.auth_key_store.file_exists():

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -175,6 +175,12 @@ class GardenClient:
             code_serialization_strategy=DillCode(),
         )
 
+    def _display_notebook_link(self, link):
+        from IPython.display import display, HTML
+
+        url = "<a href={}>{}</a>".format(link, link)
+        display(HTML(url))
+
     def _do_login_flow(self):
         self.auth_client.oauth2_start_flow(
             requested_scopes=[
@@ -190,12 +196,12 @@ class GardenClient:
         authorize_url = self.auth_client.oauth2_get_authorize_url()
 
         try:
-            __IPYTHON__  # Only defined if running in notebook
+            __IPYTHON__  # Check if running in notebook. Will only be defined if in one.
             print("Authenticating with Globus in your default web browser: \n\n")
-            _display_notebook_link(
+            self._display_notebook_link(
                 authorize_url
-            )  # Must display link as html to render properly in notebook
-        except NameError:
+            )  # Must display link as html to render properly in notebooks
+        except NameError as e:
             print(
                 f"Authenticating with Globus in your default web browser: \n\n{authorize_url}"
             )
@@ -211,12 +217,6 @@ class GardenClient:
         except AuthAPIError:
             logger.fatal("Invalid Globus auth token received. Exiting")
             return None
-
-    def _display_notebook_link(link):
-        from IPython.display import display, HTML
-
-        url = "<a href={}>{}</a>".format(link, link)
-        display(HTML(url))
 
     def _create_authorizer(self, resource_server: str):
         if not self.auth_key_store.file_exists():

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -178,8 +178,7 @@ class GardenClient:
     def _display_notebook_link(self, link):
         from IPython.display import display, HTML
 
-        url = "<a href={}>{}</a>".format(link, link)
-        display(HTML(url))
+        display(HTML(f"<a href={link}>{link}</a>"))
 
     def _do_login_flow(self):
         self.auth_client.oauth2_start_flow(
@@ -196,11 +195,11 @@ class GardenClient:
         authorize_url = self.auth_client.oauth2_get_authorize_url()
 
         try:
-            __IPYTHON__  # Check if running in notebook. Will only be defined if in one.
+            __IPYTHON__  # Check if running in notebook. '__IPYTHON__' is defined if in one.
             print("Authenticating with Globus in your default web browser: \n\n")
             self._display_notebook_link(
                 authorize_url
-            )  # Must display link as html to render properly in notebooks
+            )  # Must display url as html to render properly in notebooks
         except NameError as e:
             print(
                 f"Authenticating with Globus in your default web browser: \n\n{authorize_url}"

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -178,7 +178,11 @@ class GardenClient:
     def _display_notebook_link(self, link):
         from IPython.display import display, HTML
 
-        display(HTML(f"<a href={link}>{link}</a>"))
+        display(
+            HTML(
+                f'<a href="{link}" rel="noopener noreferrer" target="_blank">{link}</a>'
+            )
+        )
 
     def _do_login_flow(self):
         self.auth_client.oauth2_start_flow(


### PR DESCRIPTION
Fixes #287

## Overview

Makes the Globus auth flow links clickable in notebooks and Google Colabs.

## Description

During the Globus auth flow, adds a check to see if Garden is running in a notebook and if it is, displays url as HTML with `IPython.display` instead of printing it. Also fixes Safari mangling the url as it is not printing the url anymore.


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--290.org.readthedocs.build/en/290/

<!-- readthedocs-preview garden-ai end -->