### PR TITLE
154 prod dev environment toggle

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,4 @@ max-line-length = 150
 extend-ignore = E203
 exclude =
     fixtures
+    demos

--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -11,9 +11,9 @@ from rich.prompt import Prompt
 from garden_ai import local_data
 from garden_ai.client import GardenClient
 from garden_ai.globus_search.garden_search import (
-    GARDEN_INDEX_UUID,
     RemoteGardenException,
 )
+from garden_ai.constants import GardenConstants
 from garden_ai.gardens import Garden
 from garden_ai.pipelines import RegisteredPipeline
 from garden_ai.app.console import console, get_local_garden_rich_table
@@ -215,7 +215,9 @@ def search(
     try:
         results = client.search(query)
     except SearchAPIError as e:
-        logger.fatal(f"Could not query search index {GARDEN_INDEX_UUID}")
+        logger.fatal(
+            f"Could not query search index {GardenConstants.GARDEN_INDEX_UUID}"
+        )
         logger.fatal(e.error_data)
         raise typer.Exit(code=1) from e
 

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -54,12 +54,6 @@ from garden_ai.pipelines import Pipeline, RegisteredPipeline, Paper, Repository
 from garden_ai.steps import step
 from garden_ai.utils.misc import extract_email_from_globus_jwt, get_cache_tag
 
-
-GARDEN_ENDPOINT = os.environ.get(
-    "GARDEN_ENDPOINT",
-    "https://nu3cetwc84.execute-api.us-east-1.amazonaws.com/garden_prod",
-)
-
 COMPUTE_RESOURCE_SERVER_NAME = "funcx_service"
 
 logger = logging.getLogger()
@@ -401,25 +395,8 @@ class GardenClient:
         model.dataset = dataset
         local_data.put_local_model(model)
 
-    def _mint_draft_doi(self, test: bool = True) -> str:
-        """Register a new draft DOI with DataCite via Garden backend.
-
-        Expects environment variable GARDEN_ENDPOINT to be set (not including `/doi`).
-
-        Parameters
-        ----------
-        test : bool
-            toggle which garden backend endpoint to hit; we do not yet have a
-            test endpoint so test=False raises NotImplementedError.
-
-        Raises
-        ------
-        NotImplementedError
-            see `test`
-        """
-
-        if not test:
-            raise NotImplementedError
+    def _mint_draft_doi(self) -> str:
+        """Register a new draft DOI with DataCite via Garden backend."""
 
         logger.info("Requesting draft DOI")
         payload = {

--- a/garden_ai/constants.py
+++ b/garden_ai/constants.py
@@ -13,9 +13,7 @@ class GardenConstants:
     GARDEN_DIR = os.path.expanduser("~/.garden")
     URL_ENV_VAR_NAME = "GARDEN_MODELS"
     GARDEN_ENDPOINT = (
-        os.environ.get("GARDEN_ENDPOINT") or _PROD_ENDPOINT
-        if os.environ.get("GARDEN_ENV") == "prod"
-        else _DEV_ENDPOINT
+        _PROD_ENDPOINT if os.environ.get("GARDEN_ENV") == "prod" else _DEV_ENDPOINT
     )
     GARDEN_INDEX_UUID = (
         _PROD_SEARCH_INDEX

--- a/garden_ai/constants.py
+++ b/garden_ai/constants.py
@@ -1,13 +1,25 @@
 import os
 
+_PROD_ENDPOINT = "https://nu3cetwc84.execute-api.us-east-1.amazonaws.com/garden_prod"
+_DEV_ENDPOINT = "https://y0ipq1bueb.execute-api.us-east-1.amazonaws.com/garden_dev"
+
+_DEV_SEARCH_INDEX = "58e4df29-4492-4e7d-9317-b27eba62a911"
+_PROD_SEARCH_INDEX = "813d4556-cbd4-4ba9-97f2-a7155f70682f"
+
 
 class GardenConstants:
     SCAFFOLDED_MODEL_NAME = "YOUR MODEL'S NAME HERE"
     GARDEN_TEST_EMAIL = "garden-test-runner@email.com"
     GARDEN_DIR = os.path.expanduser("~/.garden")
     URL_ENV_VAR_NAME = "GARDEN_MODELS"
-    GARDEN_ENDPOINT = os.environ.get(
-        "GARDEN_ENDPOINT",
-        "https://nu3cetwc84.execute-api.us-east-1.amazonaws.com/garden_prod",
+    GARDEN_ENDPOINT = (
+        os.environ.get("GARDEN_ENDPOINT") or _PROD_ENDPOINT
+        if os.environ.get("GARDEN_ENV") == "prod"
+        else _DEV_ENDPOINT
+    )
+    GARDEN_INDEX_UUID = (
+        _PROD_SEARCH_INDEX
+        if os.environ.get("GARDEN_ENV") == "prod"
+        else _DEV_SEARCH_INDEX
     )
     DLHUB_ENDPOINT = "86a47061-f3d9-44f0-90dc-56ddc642c000"

--- a/garden_ai/globus_search/garden_search.py
+++ b/garden_ai/globus_search/garden_search.py
@@ -1,12 +1,11 @@
 import json
 
-from garden_ai.gardens import PublishedGarden
-from globus_sdk import SearchClient, GlobusAPIError
+from globus_sdk import GlobusAPIError, SearchClient
 from pydantic import ValidationError
 from rich.traceback import install
 
-# garden-dev index
-GARDEN_INDEX_UUID = "58e4df29-4492-4e7d-9317-b27eba62a911"
+from garden_ai.constants import GardenConstants
+from garden_ai.gardens import PublishedGarden
 
 install()
 
@@ -18,14 +17,15 @@ class RemoteGardenException(Exception):
 
 
 def get_remote_garden_by_doi(doi: str, search_client: SearchClient) -> PublishedGarden:
+    index_uuid = GardenConstants.GARDEN_INDEX_UUID
     try:
-        res = search_client.get_subject(GARDEN_INDEX_UUID, doi)
+        res = search_client.get_subject(index_uuid, doi)
     except GlobusAPIError as e:
         if e.http_status == 404:
             raise RemoteGardenException(f"Could not find Garden with DOI {doi}") from e
         else:
             raise RemoteGardenException(
-                f"Could not reach Globus Search Index {GARDEN_INDEX_UUID}"
+                f"Could not reach Globus Search Index {index_uuid}"
             ) from e
     try:
         garden_meta = json.loads(res.text)["entries"][0]["content"]
@@ -38,5 +38,6 @@ def get_remote_garden_by_doi(doi: str, search_client: SearchClient) -> Published
 
 
 def search_gardens(query: str, search_client: SearchClient) -> str:
-    res = search_client.search(GARDEN_INDEX_UUID, query, advanced=True)
+    index_uuid = GardenConstants.GARDEN_INDEX_UUID
+    res = search_client.search(index_uuid, query, advanced=True)
     return res.text


### PR DESCRIPTION
closes #154 and its children #282 and #283. I'm leaving #284 as open but blocked until we're ready to actually switch over to production datacite 

## Overview

This PR is the last of the productionizing PRs for now. It cleans up a handful `GARDEN_*` constants that weren't namespaced under the `garden_ai.constants.GardenConstants` class, which is also now responsible for reading the `GARDEN_ENV` environment variable and setting constants appropriately. 

## Discussion

The default behavior is still to hit the dev resources. The only way to hit prod resources from the CLI is to set `GARDEN_ENV=prod`. 

Also, it's still impossible to mint true dois programmatically (since we're leaving #284 open). For any "production seedlings" we might want to bless with a real DOI in the meantime, I think the easiest thing to do is to mint one by hand and hardcode it in the constructor `client.create_garden(..., doi='10.bespoke/doi')`

## Testing

Tested by retracing my footsteps with the BraggNN seedling against the dev environment, and by sanity checking CLI commands with and without the environment variable set. 

## Documentation

It doesn't, but probably should. I'll add a note in the developer docs 


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--297.org.readthedocs.build/en/297/

<!-- readthedocs-preview garden-ai end -->