### PR TITLE
Make container_uuid a mandatory field 

### DIFF
--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -13,8 +13,9 @@ from pydantic import (
     root_validator,
     validator,
 )
+from pydantic.json import pydantic_encoder
 
-from garden_ai.utils.misc import JSON, garden_json_encoder
+from garden_ai.utils.misc import JSON
 
 from .datacite import (
     Contributor,
@@ -217,7 +218,7 @@ class Garden(BaseModel):
         See: ``Garden.expanded_metadata`` method
         """
         data = self.expanded_metadata()
-        return json.dumps(data, default=garden_json_encoder)
+        return json.dumps(data, default=pydantic_encoder)
 
     def _sync_author_metadata(self):
         """helper: authors and contributors of steps and Pipelines also appear as contributors in their respective Pipeline and Garden's metadata."""

--- a/garden_ai/local_data.py
+++ b/garden_ai/local_data.py
@@ -3,11 +3,11 @@ import logging
 from enum import Enum
 from pathlib import Path
 from typing import Dict, Optional, Union, List
+from pydantic.json import pydantic_encoder
 
 from garden_ai.gardens import Garden
 from garden_ai.pipelines import RegisteredPipeline
 from garden_ai.mlmodel import ModelMetadata
-from garden_ai.utils.misc import garden_json_encoder
 from garden_ai.constants import GardenConstants
 
 LOCAL_STORAGE = Path(GardenConstants.GARDEN_DIR)
@@ -59,7 +59,7 @@ def _read_local_db() -> Dict:
 
 
 def _write_local_db(data: Dict) -> None:
-    contents = json.dumps(data, default=garden_json_encoder)
+    contents = json.dumps(data, default=pydantic_encoder)
     with open(LOCAL_STORAGE / "data.json", "w+") as f:
         f.write(contents)
 

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -130,7 +130,7 @@ class RegisteredPipeline(BaseModel):
 
     doi: str = Field(...)
     func_uuid: UUID = Field(...)
-    container_uuid: Optional[UUID] = Field(None)
+    container_uuid: UUID = Field(...)
     title: str = Field(...)
     authors: List[str] = Field(...)
     short_name: str = Field(...)

--- a/garden_ai/utils/misc.py
+++ b/garden_ai/utils/misc.py
@@ -2,32 +2,14 @@ import base64
 import json
 import logging
 import re
-from inspect import signature
 from keyword import iskeyword
 
 import requests
-from pydantic.json import pydantic_encoder
 from typing_extensions import TypeAlias
 
 JSON: TypeAlias = str
 
 logger = logging.getLogger()
-
-
-def garden_json_encoder(obj):
-    """workaround: pydantic supports custom encoders for all but built-in types.
-
-    In our case, this means we can't specify how to serialize
-    `function`s (like in every Step) in pydantic; there is an open PR to
-    fix this - https://github.com/pydantic/pydantic/pull/2745 - but it's
-    been in limbo for over a year, so this is the least-hacky option in
-    the meantime.
-    """
-    if isinstance(obj, type(lambda: None)):
-        # ^b/c isinstance(obj, function) can't work for ~reasons~ 🐍
-        return f"{obj.__name__}: {signature(obj)}"
-    else:
-        return pydantic_encoder(obj)
 
 
 def requests_to_curl(response: requests.Response) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,7 @@ def registered_pipeline_toy_example(noop_func_uuid):
         short_name="pipeline_toy_example",
         authors=["Brian Jacques"],
         description="A pipeline for perfectly-reproducible soup ratings.",
+        container_uuid="4f5688ac-424d-443e-b525-97c72e4e013f",
         func_uuid=noop_func_uuid,
         doi="10.26311/fake-doi",
     )

--- a/tests/fixtures/database_dumps/one_pipeline_one_garden_connected.txt
+++ b/tests/fixtures/database_dumps/one_pipeline_one_garden_connected.txt
@@ -3,51 +3,11 @@
     "10.23677/jx31-gx98": {
       "doi": "10.23677/jx31-gx98",
       "func_uuid": "9f5688ac-424d-443e-b525-97c72e4e083f",
+      "container_uuid": "4f5688ac-424d-443e-b525-97c72e4e013f",
       "title": "Fixture pipeline",
       "short_name": "fixture_pipeline",
       "authors": [
         "Garden Team"
-      ],
-      "steps": [
-        {
-          "func": "preprocessing_step: (input_data: object) -> object",
-          "authors": [],
-          "contributors": [],
-          "title": "preprocessing_step",
-          "description": " ",
-          "input_info": "{'input_data': <class 'object'>}",
-          "output_info": "return: <class 'object'>",
-          "conda_dependencies": [],
-          "pip_dependencies": [],
-          "python_version": null,
-          "model_full_names": []
-        },
-        {
-          "func": "another_step: (data: object) -> object",
-          "authors": [],
-          "contributors": [],
-          "title": "another_step",
-          "description": null,
-          "input_info": "{'data': <class 'object'>}",
-          "output_info": "return: <class 'object'>",
-          "conda_dependencies": [],
-          "pip_dependencies": [],
-          "python_version": null,
-          "model_full_names": []
-        },
-        {
-          "func": "run_inference: (input_arg: object) -> object",
-          "authors": [],
-          "contributors": [],
-          "title": "run_inference",
-          "description": null,
-          "input_info": "{'input_arg': <class 'object'>}",
-          "output_info": "return: <class 'object'>",
-          "conda_dependencies": [],
-          "pip_dependencies": [],
-          "python_version": null,
-          "model_full_names": ["willengler@uchicago.edu/will-test-model"]
-        }
       ],
       "contributors": [],
       "description": "",
@@ -55,10 +15,6 @@
       "year": "2023",
       "tags": [],
       "python_version": "3.10.10",
-      "pip_dependencies": [
-        "garden-ai@ git+https://github.com/garden-ai/garden.git"
-      ],
-      "conda_dependencies": [],
       "model_full_names": ["willengler@uchicago.edu/will-test-model"]
     }
   },

--- a/tests/fixtures/database_dumps/one_pipeline_one_garden_unconnected.txt
+++ b/tests/fixtures/database_dumps/one_pipeline_one_garden_unconnected.txt
@@ -3,51 +3,11 @@
     "10.23677/jx31-gx98": {
       "doi": "10.23677/jx31-gx98",
       "func_uuid": "9f5688ac-424d-443e-b525-97c72e4e083f",
+      "container_uuid": "4f5688ac-424d-443e-b525-97c72e4e013f",
       "title": "Fixture pipeline",
       "short_name": "fixture_pipeline",
       "authors": [
         "Garden Team"
-      ],
-      "steps": [
-        {
-          "func": "preprocessing_step: (input_data: object) -> object",
-          "authors": [],
-          "contributors": [],
-          "title": "preprocessing_step",
-          "description": " ",
-          "input_info": "{'input_data': <class 'object'>}",
-          "output_info": "return: <class 'object'>",
-          "conda_dependencies": [],
-          "pip_dependencies": [],
-          "python_version": null,
-          "model_full_names": ["willengler@uchicago.edu/will-test-model"]
-        },
-        {
-          "func": "another_step: (data: object) -> object",
-          "authors": [],
-          "contributors": [],
-          "title": "another_step",
-          "description": null,
-          "input_info": "{'data': <class 'object'>}",
-          "output_info": "return: <class 'object'>",
-          "conda_dependencies": [],
-          "pip_dependencies": [],
-          "python_version": null,
-          "model_full_names": ["willengler@uchicago.edu/will-test-model"]
-        },
-        {
-          "func": "run_inference: (input_arg: object) -> object",
-          "authors": [],
-          "contributors": [],
-          "title": "run_inference",
-          "description": null,
-          "input_info": "{'input_arg': <class 'object'>}",
-          "output_info": "return: <class 'object'>",
-          "conda_dependencies": [],
-          "pip_dependencies": [],
-          "python_version": null,
-          "model_full_names": ["willengler@uchicago.edu/will-test-model"]
-        }
       ],
       "contributors": [],
       "description": "",
@@ -55,10 +15,6 @@
       "year": "2023",
       "tags": [],
       "python_version": "3.10.10",
-      "pip_dependencies": [
-        "garden-ai@ git+https://github.com/garden-ai/garden.git"
-      ],
-      "conda_dependencies": [],
       "model_full_names": ["willengler@uchicago.edu/will-test-model"]
     }
   },

--- a/tests/fixtures/search_results/valid_search_by_subject.json
+++ b/tests/fixtures/search_results/valid_search_by_subject.json
@@ -26,48 +26,11 @@
                 "pipelines": [
                     {
                         "func_uuid": "9f5688ac-424d-443e-b525-97c72e4e083f",
+                        "container_uuid": "4f5688ac-424d-443e-b525-97c72e4e013f",
                         "title": "Concept: a pipeline for soup",
                         "short_name": "pea_pipeline",
                         "authors": [
                             "Mendel, Gregor"
-                        ],
-                        "steps": [
-                            {
-                                "func": "split_peas: (ps: List) -> List[tuple]",
-                                "authors": [
-                                    "Sister Constance"
-                                ],
-                                "contributors": [],
-                                "title": "split_peas",
-                                "description": null,
-                                "input_info": null,
-                                "output_info": null
-                            },
-                            {
-                                "func": "make_soup: (splits: List[tuple]) -> __main__.Soup",
-                                "authors": [
-                                    "Friar Hugo"
-                                ],
-                                "contributors": [],
-                                "title": "make_soup",
-                                "description": null,
-                                "input_info": null,
-                                "output_info": null
-                            },
-                            {
-                                "func": "rate_soup: (soup_sample: __main__.Soup) -> float",
-                                "authors": [
-                                    "Abbot Mortimer"
-                                ],
-                                "contributors": [
-                                    "Friar Hugo",
-                                    "Sister Constance"
-                                ],
-                                "title": "rate_soup",
-                                "description": null,
-                                "input_info": "a spoonful of Soup object",
-                                "output_info": null
-                            }
                         ],
                         "contributors": [
                             "Sister Constance",


### PR DESCRIPTION
Fixes #311 

## Overview

We want to make sure that all the fields we need for RegisteredPipeline to work in practice are marked as mandatory in its Pydantic definition. The last one to clean up was container_uuid.

## Discussion

Per comments that Owen left on my last PR, I also took out the `garden_json_encoder`. It could be nice to go even further and replace our use of the UUID class in Pydantic fields and just use a string field with a UUID validator. Then we wouldn't have to specify the Pydantic encoder anywhere. But this is a nice little improvement for now :) 

## Testing

I just relied on the unit tests for this.

## Documentation

Nothing big docs-wise here.

<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--315.org.readthedocs.build/en/315/

<!-- readthedocs-preview garden-ai end -->