### PR TITLE
Base image error handling

### DIFF
--- a/garden_ai/app/notebook.py
+++ b/garden_ai/app/notebook.py
@@ -60,7 +60,14 @@ def start(
         readable=True,
         help=("Path to a .ipynb notebook to open in a fresh, isolated container. "),
     ),
-    base_image: Optional[str] = typer.Option(None),
+    base_image: Optional[str] = typer.Option(
+        default=None,
+        help=(
+            "A Garden base image to boot the notebook in. "
+            "For example, to boot your notebook with the default Garden python 3.8 image, use --base-image 3.8-base. "
+            "To see all the available Garden base images, use 'garden-ai notebook list-premade-images'"
+        ),
+    ),
 ):
     """Open a notebook file in a sandboxed environment. Optionally, specify a different base docker image.
 
@@ -80,6 +87,16 @@ def start(
     # check/update local data for base image choice
     if base_image in list(GardenConstants.PREMADE_IMAGES.keys()):
         base_image = GardenConstants.PREMADE_IMAGES[base_image]
+    else:
+        premade_images = ", ".join(
+            [
+                "'" + image_name + "'"
+                for image_name in list(GardenConstants.PREMADE_IMAGES.keys())
+            ]
+        )
+        raise Exception(
+            f"The image '{base_image}' is not one of the Garen base images. The current Garden base images are: \n{premade_images}"
+        )
 
     base_image = (
         base_image or _get_notebook_base_image(notebook_path) or "gardenai/test:latest"

--- a/garden_ai/containers.py
+++ b/garden_ai/containers.py
@@ -30,7 +30,6 @@ def start_container_with_notebook(
       and is exposed to the host on the same port.
     - The token for accessing the notebook is still the JUPYTER_TOKEN variable.
     """
-
     with console.status(f"[bold green] Pulling image: {base_image}"):
         client.images.pull(base_image, platform="linux/x86_64")
     container = client.containers.run(

--- a/garden_ai/containers.py
+++ b/garden_ai/containers.py
@@ -30,6 +30,7 @@ def start_container_with_notebook(
       and is exposed to the host on the same port.
     - The token for accessing the notebook is still the JUPYTER_TOKEN variable.
     """
+
     with console.status(f"[bold green] Pulling image: {base_image}"):
         client.images.pull(base_image, platform="linux/x86_64")
     container = client.containers.run(


### PR DESCRIPTION
## Overview

Updates help text for `garden-ai notebook start` to show example use of `--base-image` and shows the user the command `garden-ai notebook list-premade-images` so they can see all the available base images.

Adds exception to `garden-ai notebook start` showing all the available base images when the user tries to reference a base image that does not exist.




<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--323.org.readthedocs.build/en/323/

<!-- readthedocs-preview garden-ai end -->