### PR TITLE
Add additional fields to RegisteredPipeline

### DIFF
--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -116,7 +116,7 @@ class RegisteredPipeline(PipelineMetadata):
         func_uuid: The ID of the Globus Compute function registered for this pipeline.
         container_uuid: ID returned from Globus Compute's register_container.
         base_image_name: The name of the base image selected by the user. eg, "3.9-base"
-        base_image_uri: The name and location of the base image used by this pipeline. eg, docker://index.docker.io/maxtuecke/garden-ai:python-3.9-jupyter
+        base_image_uri: Name and location of the base image used by this pipeline. eg docker://index.docker.io/maxtuecke/garden-ai:python-3.9-jupyter
         full_image_uri: The name and location of the complete image used by this pipeline.
         notebook: Full JSON string of the notebook used to define this pipeline's environment.
     """

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -121,6 +121,7 @@ class RegisteredPipeline(PipelineMetadata):
         notebook: Full JSON string of the notebook used to define this pipeline's environment.
     """
 
+    doi: str = Field(...)
     func_uuid: UUID = Field(...)
     container_uuid: UUID = Field(...)
     base_image_name: Optional[str] = Field(None)

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -121,7 +121,9 @@ class RegisteredPipeline(PipelineMetadata):
         notebook: Full JSON string of the notebook used to define this pipeline's environment.
     """
 
-    doi: str = Field(...)
+    doi: str = Field(
+        ...
+    )  # Repeating this field from base class because DOI is mandatory for RegisteredPipeline
     func_uuid: UUID = Field(...)
     container_uuid: UUID = Field(...)
     base_image_name: Optional[str] = Field(None)

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -105,39 +105,28 @@ class PipelineMetadata(BaseModel):
     papers: List[Paper] = Field(default_factory=list)
 
 
-class RegisteredPipeline(BaseModel):
+class RegisteredPipeline(PipelineMetadata):
     """Metadata of a completed and registered pipeline.
     Can be added to a Garden and executed on a remote Globus Compute endpoint.
 
-    `RegisteredPipeline` objects can be described completely by JSON.
+    Has all the user-given metadata from PipelineMetadata plus extra fields added by Garden
+    during publication.
 
     Attributes:
-        doi:
-        func_uuid:
-        container_uuid:
-        title:
-        authors:
-        short_name:
-        description:
-        year:
-        tags:
-        model_full_names:
-        repositories:
-        papers:
+        func_uuid: The ID of the Globus Compute function registered for this pipeline.
+        container_uuid: ID returned from Globus Compute's register_container.
+        base_image_name: The name of the base image selected by the user. eg, "3.9-base"
+        base_image_uri: The name and location of the base image used by this pipeline. eg, docker://index.docker.io/maxtuecke/garden-ai:python-3.9-jupyter
+        full_image_uri: The name and location of the complete image used by this pipeline.
+        notebook: Full JSON string of the notebook used to define this pipeline's environment.
     """
 
-    doi: str = Field(...)
     func_uuid: UUID = Field(...)
     container_uuid: UUID = Field(...)
-    title: str = Field(...)
-    authors: List[str] = Field(...)
-    short_name: str = Field(...)
-    description: Optional[str] = Field(None)
-    year: str = Field(default_factory=lambda: str(datetime.now().year))
-    tags: List[str] = Field(default_factory=list, unique_items=True)
-    models: List[ModelMetadata] = Field(default_factory=list)
-    repositories: List[Repository] = Field(default_factory=list)
-    papers: List[Paper] = Field(default_factory=list)
+    base_image_name: Optional[str] = Field(None)
+    base_image_uri: Optional[str] = Field(None)
+    full_image_uri: Optional[str] = Field(None)
+    notebook: Optional[str] = Field(None)
 
     def __call__(
         self,


### PR DESCRIPTION
Part 2/2 of #294

## Overview

This PR adds new fields to the `RegisteredMetadata` class that will allow us to add more details about the container used in the pipeline, plus the raw text of the notebook for pipelines made with notebooks.

## Discussion

This just adds new fields but doesn't populate them yet. I'll follow up on that once Owen's publishing PR is in.

## Testing

Again, just relied on unit tests. This just adds optional fields so not much risk here.

## Documentation

No docs changes yet

<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--330.org.readthedocs.build/en/330/

<!-- readthedocs-preview garden-ai end -->