### PR TITLE
Add steps to the new publishing flow with @garden_step decorator

### DIFF
--- a/garden_ai/__init__.py
+++ b/garden_ai/__init__.py
@@ -2,7 +2,12 @@ from ._version import __version__  # noqa  # type: ignore
 from .constants import GardenConstants
 from .client import GardenClient
 from .gardens import Garden, PublishedGarden
-from .pipelines import PipelineMetadata, RegisteredPipeline, garden_pipeline
+from .pipelines import (
+    PipelineMetadata,
+    RegisteredPipeline,
+    garden_pipeline,
+    garden_step,
+)
 
 __all__ = [
     "GardenConstants",
@@ -12,4 +17,5 @@ __all__ = [
     "PipelineMetadata",
     "RegisteredPipeline",
     "garden_pipeline",
+    "garden_step",
 ]

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -539,10 +539,11 @@ class GardenClient:
         )
 
         metadata = extract_metadata_from_image(docker_client, image)
+        common_steps = metadata.pop("steps")
 
         for key, record in metadata.items():
             if "." in key:
-                # skip "{key}.garden_doi" and "{key}.connectors" for now
+                # skip "{key}.garden_doi" and "{key}.pipeline_step" for now
                 continue
 
             # register function & populate RegisteredPipeline fields
@@ -551,6 +552,10 @@ class GardenClient:
             record["func_uuid"] = self.compute_client.register_function(
                 to_register, container_uuid=str(container_uuid), public=True
             )
+            pipeline_step = metadata.get(f"{key}.pipeline_step")
+            all_steps = common_steps[:]
+            all_steps.append(pipeline_step)
+            record["steps"] = all_steps
             record["doi"] = record.get("doi") or self._mint_draft_doi()
             record["short_name"] = record.get("short_name") or key
             record["notebook"] = notebook_contents

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,6 +5,7 @@ from garden_ai import (
     RegisteredPipeline,
     local_data,
     garden_pipeline,
+    garden_step,
     PipelineMetadata,
 )
 from garden_ai.model_connectors import HFConnector
@@ -68,8 +69,26 @@ def test_garden_pipeline_decorator():
     def my_pipeline():
         pass
 
-    assert my_pipeline._pipeline_meta["title"] == "My Pipeline"
-    models = my_pipeline._pipeline_meta["models"]
+    assert my_pipeline._garden_pipeline.title == "My Pipeline"
+    models = my_pipeline._garden_pipeline.models
     assert len(models) == 1
-    assert models[0]["model_identifier"] == "willengler-uc/iris-classifier"
-    assert my_pipeline._garden_doi == "10.23677/fake-doi"
+    assert models[0].model_identifier == "willengler-uc/iris-classifier"
+    assert my_pipeline._garden_pipeline._target_garden_doi == "10.23677/fake-doi"
+
+
+def test_garden_step_decorator():
+    pipeline_meta = PipelineMetadata(
+        title="My Pipeline",
+        authors=["Willie", "Waylon", "Johnny", "Kris"],
+        description="A garden pipeline",
+        tags=["garden_ai"],
+    )
+
+    model_connector = HFConnector("willengler-uc/iris-classifier")
+
+    @garden_step(description="My nifty step")
+    def my_step():
+        pass
+
+    assert my_step._garden_step.function_name == "my_step"
+    assert my_step._garden_step.description == "My nifty step"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -77,15 +77,6 @@ def test_garden_pipeline_decorator():
 
 
 def test_garden_step_decorator():
-    pipeline_meta = PipelineMetadata(
-        title="My Pipeline",
-        authors=["Willie", "Waylon", "Johnny", "Kris"],
-        description="A garden pipeline",
-        tags=["garden_ai"],
-    )
-
-    model_connector = HFConnector("willengler-uc/iris-classifier")
-
     @garden_step(description="My nifty step")
     def my_step():
         pass


### PR DESCRIPTION
Closes #334 

## Overview

This PR re-introduces steps to the new publishing flow. Users can decorate functions in their notebook with `@garden_step` and that will expose the function as a step in their pipeline's metadata so that the UI can feature it. Pipeline functions (the ones with `@garden_pipeline`) are also steps by default.

For now there is no way to specify the order of your steps. The order is always the order they are defined in your notebook, with the pipeline function always the final step. If there is more than one pipeline in a notebook, all the steps apply to both pipelines. If this idea takes off we'll probably want to let users specify which apply to which, but the intention here is to cover the simple case first so we can see it working end to end and go from there.

## Discussion

I made some light changes to how the decorators store data on the functions they decorate. To make names and attributes easier to keep track of, I tried to get it down to just sticking a Step or Pipeline object on decorated functions. To do this I added private Pydantic attributes to PipelineMetadata that won't show up in the documentation or the serialized JSON.

## Testing

I added a simple unit test for the new decorator. But the bulk of the testing came from publishing a bunch of pipelines and confirming that steps were serializing how I expected. (Including for multi-pipeline notebooks.)

## Documentation

No docs on this yet

<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--346.org.readthedocs.build/en/346/

<!-- readthedocs-preview garden-ai end -->