### PR TITLE
Make it more convenient to import code from Hugging Face repos

### DIFF
--- a/garden_ai/model_connectors/hugging_face.py
+++ b/garden_ai/model_connectors/hugging_face.py
@@ -1,14 +1,18 @@
 import huggingface_hub as hfh  # type: ignore
 from garden_ai.mlmodel import ModelMetadata
 import os
+import sys
 
 
 class HFConnector:
-    def __init__(self, repo_id: str, revision=None, local_dir=None):
+    def __init__(
+        self, repo_id: str, revision=None, local_dir=None, enable_imports=True
+    ):
         self.repo_id = repo_id
         self.revision = revision
         self.local_dir = local_dir or "hf_model"
         self.model_card = hfh.ModelCard.load(repo_id)
+        self.enable_imports = enable_imports
         self.metadata = ModelMetadata(
             model_identifier=self.repo_id,
             model_repository="Hugging Face",
@@ -19,6 +23,8 @@ class HFConnector:
         if not os.path.exists(self.local_dir):
             os.mkdir(self.local_dir)
         hfh.snapshot_download(self.repo_id, local_dir=self.local_dir)
+        if self.enable_imports:
+            sys.path.append(self.local_dir)
         return self.local_dir
 
     def _repr_html_(self):


### PR DESCRIPTION
This is quality of life improvement that came up while working on a PyTorch seedling. (https://github.com/Garden-AI/seedlings/issues/14)

## Overview

This PR makes it so that, by default, Hugging Face download paths are added to sys.path, letting users import Python modules from their Hugging Face repos. In practice this is a helpful way to share model class definition files for PyTorch.

## Discussion

Any additional context that you think is important for reviewers or future users/contributors looking at this PR.

## Testing

I co-developed this with the torch seedling and confirmed it worked in that context: https://github.com/Garden-AI/seedlings/pull/17

## Documentation

No docs for this yet

<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--349.org.readthedocs.build/en/349/

<!-- readthedocs-preview garden-ai end -->