### PR TITLE
Fix TensorFlow base images

### DIFF
--- a/garden_ai/base_image_dockerfiles/Dockerfile_jupyter_tf_3.10
+++ b/garden_ai/base_image_dockerfiles/Dockerfile_jupyter_tf_3.10
@@ -7,9 +7,7 @@ RUN conda create -y --name env
 RUN pip install "dill==0.3.5.1"
 RUN pip install jupyter notebook
 
-RUN pip install "tensorflow==2.14.0"
 RUN pip install "tensorboard==2.15.0"
-RUN pip install "tensorboard-data-server==0.7.1"
 RUN pip install "tensorflow-datasets==4.9.3"
 RUN pip install "tensorflow-estimator==2.14.0"
 RUN pip install "tensorflow-gcs-config==2.14.0"
@@ -18,5 +16,6 @@ RUN pip install "tensorflow-io-gcs-filesystem==0.34.0"
 RUN pip install "tensorflow-metadata==1.14.0"
 RUN pip install "tensorflow-probability==0.22.0"
 RUN pip install "tensorstore==0.1.46"
+RUN pip install "tensorflow==2.14.0"
 
 ENTRYPOINT ["jupyter", "notebook", "--notebook-dir=/garden", "--ServerApp.token=791fb91ea2175a1bbf15e1c9606930ebdf6c5fe6a0c3d5bd", "--ip", "0.0.0.0", "--no-browser", "--allow-root"]

--- a/garden_ai/base_image_dockerfiles/Dockerfile_jupyter_tf_3.11
+++ b/garden_ai/base_image_dockerfiles/Dockerfile_jupyter_tf_3.11
@@ -7,9 +7,7 @@ RUN conda create -y --name env
 RUN pip install "dill==0.3.5.1"
 RUN pip install jupyter notebook
 
-RUN pip install "tensorflow==2.14.0"
 RUN pip install "tensorboard==2.15.0"
-RUN pip install "tensorboard-data-server==0.7.1"
 RUN pip install "tensorflow-datasets==4.9.3"
 RUN pip install "tensorflow-estimator==2.14.0"
 RUN pip install "tensorflow-gcs-config==2.14.0"
@@ -18,5 +16,6 @@ RUN pip install "tensorflow-io-gcs-filesystem==0.34.0"
 RUN pip install "tensorflow-metadata==1.14.0"
 RUN pip install "tensorflow-probability==0.22.0"
 RUN pip install "tensorstore==0.1.46"
+RUN pip install "tensorflow==2.14.0"
 
 ENTRYPOINT ["jupyter", "notebook", "--notebook-dir=/garden", "--ServerApp.token=791fb91ea2175a1bbf15e1c9606930ebdf6c5fe6a0c3d5bd", "--ip", "0.0.0.0", "--no-browser", "--allow-root"]

--- a/garden_ai/base_image_dockerfiles/Dockerfile_jupyter_tf_3.9
+++ b/garden_ai/base_image_dockerfiles/Dockerfile_jupyter_tf_3.9
@@ -7,9 +7,7 @@ RUN conda create -y --name env
 RUN pip install "dill==0.3.5.1"
 RUN pip install jupyter notebook
 
-RUN pip install "tensorflow==2.14.0"
 RUN pip install "tensorboard==2.15.0"
-RUN pip install "tensorboard-data-server==0.7.1"
 RUN pip install "tensorflow-datasets==4.9.3"
 RUN pip install "tensorflow-estimator==2.14.0"
 RUN pip install "tensorflow-gcs-config==2.14.0"
@@ -18,5 +16,6 @@ RUN pip install "tensorflow-io-gcs-filesystem==0.34.0"
 RUN pip install "tensorflow-metadata==1.14.0"
 RUN pip install "tensorflow-probability==0.22.0"
 RUN pip install "tensorstore==0.1.46"
+RUN pip install "tensorflow==2.14.0"
 
 ENTRYPOINT ["jupyter", "notebook", "--notebook-dir=/garden", "--ServerApp.token=791fb91ea2175a1bbf15e1c9606930ebdf6c5fe6a0c3d5bd", "--ip", "0.0.0.0", "--no-browser", "--allow-root"]


### PR DESCRIPTION
Fixes #350 

## Overview

This PR tweaks some Dockerfiles so that when you boot up a TensorFlow base image, you can do `import tensorflow as tf` right away.

## Discussion

I tested all 4 of the tensorflow base images. The 3.8 variant worked already. 3.9-3.11 didn't. I tried out the tweak in this PR and it did the trick for those 3 variants. I've already pushed up the fixed images to the `gardenai` DockerHub account.

## Testing

I tested this on an EC2 ubuntu workstation. I tested all 3 variants and ran a simple test notebook on top of them.

## Documentation

No docs changes.


<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--352.org.readthedocs.build/en/352/

<!-- readthedocs-preview garden-ai end -->