### PR TITLE
340 docs update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,8 +30,9 @@ jobs:
           poetry-version: 1.2.2
       - name: Install dependencies
         run: |
-          poetry config virtualenvs.create false && \
-          poetry install --no-interaction --no-ansi --with=test
+         pip install --upgrade pip && \
+         poetry config virtualenvs.create false && \
+         poetry install --no-interaction --no-ansi --with=test
       - name: black lint
         uses: psf/black@stable
         with:

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -1,60 +1,64 @@
 ---
 alias: Architecture Overview
 ---
-## Overview
+## Garden Project Conceptual Overview
 
-The Garden project is structured around two core concepts: `Gardens` and `Pipelines`. Each of these is represented by one or more classes in our SDK.
+The Garden project is structured around two "proper noun" concepts: `Garden` and `Pipeline`.
 
-`Garden` and `Pipeline` objects define the *citable* and *reproducible* end products, and enable users to discover/share scientific work.
+`Garden` and `Pipeline` objects define the *citable* and *reproducible* end products, and enable users to discover and share each other's scientific work.
+### Core Concepts
+1. **Gardens:**
 
-### [Pipelines](Pipelines.md)
+    - A `Garden` is a user-curated collection or portfolio of related `Pipeline`s, aimed at promoting discoverability.
+    - `Garden`s are the primary way to discover and run published `Pipeline`s.
+    - A `Pipeline` from a different `Garden` can be added to your `Garden` simply by adding the other `Pipeline`'s DOI to your `Garden` and publishing.
+    - A `Garden` is typically created and published from the CLI, e.g.:
+    ```bash
+	garden-ai garden create \
+		--title "Garden of Live Flowers" \
+		--author "The Red Queen" --year 1871
+	```
 
-The primary purpose of a Pipeline in the Garden framework is to make the code and models it contains _citable_ and _reproducible_. Pipelines collect enough metadata for us to do two things: mint a DOI, and build a container spec in which its code could run.
+2. **Pipelines:**
 
-#### Creating a Pipeline
-
-
-> [!NOTE] Note
-> Pipeline creation is currently under construction. Check back soon. 👷🏽
-
-#### Registering a Pipeline
-
-> [!NOTE] Note
-> Pipeline registration is currently under construction. Check back soon. 👷🏽o
-
-### [Gardens](Gardens.md)
-
-Finally, a `Garden` is how we make all this work _discoverable_: a garden is user-curated collection of related pipelines, each potentially associated with a scientific ML model. All that a `Garden` "really is" is a set of `Pipeline` citations (more specifically, `RegisteredPipeline` DOIs) that you can conveniently run.
-
+    - A `Pipeline` is a plain Python function, enriched with citation metadata and registered with our service for reproducibility and remote execution (via Globus Compute).
+    - Users can execute a `Pipeline` remotely via any `Garden` it has been published to.
+    - A `Pipeline` is typically defined in a regular Jupyter/ipynb notebook, and functions like an "entrypoint" to a saved notebook session when registered and published to a `Garden`.
+    - A `Pipeline` is registered when its notebook is published.
+    - When a notebook is published, all the `Pipeline`s in the notebook are published to their respective gardens -- `Pipeline`s defined in the same notebook need not be published to the same `Garden`.
 
 > [!NOTE]
-> A garden's pipelines are still callable, and are accessible as attributes - for example, if I've registered `my_pipeline` and added it to `my_garden`, I can execute it remotely like `my_garden.my_pipeline(*args, endpoint="...")`
+> The `Pipeline`s attached to a `Garden` are callable and accessible like attributes -- for example, if I've registered `my_pipeline` and added it to `some_garden`, executing it remotely might look like `some_garden.my_pipeline(*args, endpoint="...")`.
 
 
-Here's how a `Garden` is typically created using the Garden CLI:
+### The `@garden_pipeline` Decorator:
 
-```bash
-garden-ai garden create \
-	--title "Garden of Live Flowers" \
-	--author "The Red Queen" --year 1871
-```
+- This decorator is used to designate which functions in the notebook should be registered as public/published `Pipeline`s.
+- It distinguishes between functions meant for public use and those that are simply part of the execution context.
+- This is also how users attach citation metadata to a `Pipeline`, such as authors or other related published work like papers or datasets
 
+### Notebook Workflow - Defining and Developing Pipelines
 
+1. **Development in IPython Notebooks:**
 
-Also note that `RegisteredPipeline` can only be executed remotely on Globus Compute -- it's still callable, but needs to be called with the keyword argument `endpoint=...` specifying a valid Globus Compute endpoint, like: `garden_instance.pipeline_name(*args, endpoint=...)`.
+    - The process begins by writing an IPython notebook containing functions marked as pipelines using the `@garden_pipeline` decorator.
+    - The `garden-ai` CLI provides a `garden-ai notebook start path/to/my.ipynb` command to open a notebook in an isolated local Docker container (conceptually similar to a Google Colab notebook, but running locally and with a choice of prebuilt base images).
+	- See [installation](user_guide/installation.md) for Docker-specific prerequisites
 
-Finally, a `Garden` can be published with the CLI, minting its DOI and making it findable/accessible to others. After completing the development of a Garden and adding any number of pipelines, it can be published like so:
+2. **Publishing Notebooks:**
 
-```bash
-garden-ai garden publish --garden='10.garden/doi'
-```
+    - Once the notebook is complete and defines one or more `Pipeline`s, the `garden-ai notebook publish path/to/my.ipynb` command is used to finalize and register each `Pipeline` in the notebook for remote execution with Globus Compute.
 
-Which enables other users to fetch that garden and call any of its pipelines with their own input and on their own Globus Compute endpoint. This might look like:
+See the [tutorial](user_guide/tutorial.md) for a more detailed walkthrough of the notebook publication flow.
+### Containerization and Execution Context:
 
-```python
->>> gc = GardenClient()
->>> other_garden = gc.get_garden_by_doi('10.garden/doi') # someone else's doi
->>> my_data = pd.DataFrame(...)
->>> results = other_garden.their_pipeline_name(my_data, endpoint="...")
->>> print(results)  # neat!
-```
+- Upon publishing with the `garden-ai notebook publish` command, the entire notebook is run like a script in the specified base image, and the Python interpreter state is "baked in" to the final registered container using the `dill` library.
+
+- On the remote end, executing a registered `Pipeline` entails spinning up its respective container, loading the saved interpreter session, then calling the decorated function.
+
+### Publishing
+
+1. **Garden Publishing:**
+    - A `Garden` is created, manipulated, and published using the CLI, making it accessible to other users.
+2. **Pipeline Publishing:**
+    - A `Pipeline` is published by attaching it to a published `Garden`. This can be done either manually from the CLI, or automatically by specifying a particular `Garden` DOI in the `@garden_pipeline` decorator.

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -45,7 +45,8 @@ garden-ai --version
 
 You should see the version of your installed Garden package printed to the console.
 
-Garden also supports tab completion in the CLI to show options of local models, pipelines, and gardens.
+The Garden CLI also supports tab completion to show options of local pipelines and gardens.
+
 If you want to use Garden with tab completion, run:
 ```bash
 garden-ai --install-completion

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -1,3 +1,28 @@
+# Prerequisites
+
+Garden makes your AI/ML work reproducible by using [Docker](https://www.docker.com/) containers to fully encapsulate your code and its dependencies. This helps ensure consistency across different machines, making it easier for anyone to reproduce your results. Before you get started with Garden, there are two key Docker-specific prerequisites:
+
+### Docker Desktop
+
+1. **Install Docker Desktop:** To use Garden, you need to have Docker Desktop installed on your system. You can download it from the [official Docker website](https://www.docker.com/products/docker-desktop). Follow the installation instructions specific to your operating system (Windows, macOS, or Linux).
+
+2. **Verify Docker Installation:** Once installed, you can verify that Docker Desktop is running correctly by opening a terminal or command prompt and typing:
+```bash
+docker --version
+```
+This command should return the version of Docker installed on your system.
+
+### Docker Hub Account
+
+1. **Create a Docker Hub Account:** Garden uses Docker Hub, a cloud-based repository for Docker images, to store and manage containers. You need to create a free account on [Docker Hub](https://hub.docker.com/signup) if you don't already have one.
+
+2. **Create a Public Repository:** After setting up your Docker Hub account, create a public repository where you can push your Docker images. This repository will be used to store and share the Docker images of your projects.
+
+3. **Configure Docker Credentials:** Make sure to configure your Docker credentials on your system. This allows `garden-ai` to push and pull images to and from Docker Hub on your behalf. You can do this by running:
+```bash
+docker login
+```
+and entering your Docker Hub username and password when prompted.
 # Installation
 
 Installing the `garden-ai` python package contains both our SDK and our CLI. We _highly_ recommend installing the CLI with a virtual environment, using venv or conda.
@@ -37,6 +62,3 @@ garden-ai --install-completion
 > Now, autocompletion can work such as: ```garden-ai garden publish -g [TAB] [TAB]```
 
 Now you're ready to start Gardening!
-
-> [!NOTE] Note
-> Especially when installing with additional flavors, the CLI might be very slow to respond the first time it is invoked (or the first time the SDK is imported), but it should be much snappier every time after the first.

--- a/docs/user_guide/introduction.md
+++ b/docs/user_guide/introduction.md
@@ -1,6 +1,7 @@
 # 🌱 Welcome to Garden 🌱
 
 Docs are WIP, but in the meantime here are good places to start:
+- [Installation](installation.md) - getting your local machine set up for gardening
 - [Overview](../architecture_overview.md) - High-level explanation of key concepts
 - [Tutorial](../user_guide/tutorial.md) - A short end-to-end example using the CLI. See also: ["seedlings" repository](https://github.com/Garden-AI/seedlings)
 - [contributing](../developer_guide/contributing.md) - Getting started as a contributor

--- a/docs/user_guide/tutorial.md
+++ b/docs/user_guide/tutorial.md
@@ -17,6 +17,8 @@ This means doing the following:
 ### Step 0: Train Your Model
 Garden is geared towards publishing and sharing models which have already been trained. If you don't have one handy, we'd recommend training a small model using one of the scikit-learn [toy datasets](https://scikit-learn.org/stable/datasets/toy_dataset.html) and uploading the weights to a public huggingface repo in order to follow along.
 
+The code to train the toy model used in this tutorial is available [here](https://huggingface.co/Garden-AI/sklearn-seedling/blob/main/Train_Model.ipynb).
+
 ### Step 1: Creating a New Garden
 First, we're going to make a new `Garden` using the CLI so that we can eventually share our `Pipeline` with others. Before we've added any `Pipeline`s, a brand new `Garden` is going to be nothing more than some citation metadata, which is at least a title, one or more authors, and a year (the minimum needed mint a DOI).
 
@@ -166,7 +168,7 @@ The debugging notebook only has a snippet of code to reload your saved session -
 
 If calling your pipeline function in the `garden-ai notebook debug` session behaves the same as calling your pipeline function in a `garden-ai notebook start` session, that likely indicates a problem with the remote endpoint.
 
-If calling your pipeline function in the `garden-ai notebook debug` session behaves differently than in a `garden-ai notebook start` session, that indicates a problem with serializing or deserializing your notebook state. If this is the case, please open an issue on our [Github](https://github.com/Garden-AI/garden/issues), including the notebook so we can reproduce the bug.
+If calling your pipeline function in the `garden-ai notebook debug` session behaves differently than in a `garden-ai notebook start` session, that indicates a problem with serializing or deserializing your notebook state. If this is the case, please open an issue on our [Github](https://github.com/Garden-AI/garden/issues), including the notebook and any additional context that might be useful so we can reproduce the bug.
 
 #### Step 5: Publishing the Notebook
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,6 @@ nav:
       - Tutorial: user_guide/tutorial.md
   - Developer Guide:
       - Contributing: developer_guide/contributing.md
-      - Remote Pipelines without garden-ai: developer_guide/Remote_pipelines_without_garden_dependency.md
   - API Reference:
     - Pipelines: Pipelines.md
     - Gardens: Gardens.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,6 @@ nav:
       - Introduction: user_guide/introduction.md
       - Installation: user_guide/installation.md
       - Tutorial: user_guide/tutorial.md
-      - Serialization: user_guide/serialization.md
   - Developer Guide:
       - Contributing: developer_guide/contributing.md
       - Remote Pipelines without garden-ai: developer_guide/Remote_pipelines_without_garden_dependency.md


### PR DESCRIPTION
closes #340 

This includes updated user docs for installation, overview, and tutorial sections. I'm leaving the "limitations" page for another PR that will close #301 and #338

<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--353.org.readthedocs.build/en/353/

<!-- readthedocs-preview garden-ai end -->