### PR TITLE
Attach notebook URL to metadata instead of full notebook contents

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -16,6 +16,8 @@ security: # configuration for the `safety check` command
             reason: this is a vulnerability of a dependency of mlflow. We don't use the subset of mlflow that uses this
         60841: # Vulnerability ID
             reason: this is a vulnerability of a dependency of mlflow. We don't use the subset of mlflow that uses this
+        62044:
+            reason: This doesn't affect us and Owen has resolved this on another branch.
     continue-on-vulnerability-error: False # Suppress non-zero exit codes when vulnerabilities are found. Enable this in pipelines and CI/CD processes if you want to pass builds that have vulnerabilities. We recommend you set this to False.
 alert: # configuration for the `safety alert` command
     security:

--- a/garden_ai/backend_client.py
+++ b/garden_ai/backend_client.py
@@ -51,7 +51,7 @@ class BackendClient:
         payload = json.loads(garden.json())
         self._post("/garden-search-record", payload)
 
-    def upload_garden_metadata(
+    def upload_notebook(
         self, notebook_contents: dict, username: str, notebook_name: str
     ):
         payload = {

--- a/garden_ai/backend_client.py
+++ b/garden_ai/backend_client.py
@@ -50,3 +50,14 @@ class BackendClient:
     def publish_garden_metadata(self, garden: PublishedGarden):
         payload = json.loads(garden.json())
         self._post("/garden-search-record", payload)
+
+    def upload_garden_metadata(
+        self, notebook_contents: dict, username: str, notebook_name: str
+    ):
+        payload = {
+            "notebook_json": notebook_contents,
+            "notebook_name": notebook_name,
+            "folder": username,
+        }
+        resp = self._post("/notebook", payload)
+        return resp["notebook_url"]

--- a/garden_ai/backend_client.py
+++ b/garden_ai/backend_client.py
@@ -55,7 +55,7 @@ class BackendClient:
         self, notebook_contents: dict, username: str, notebook_name: str
     ):
         payload = {
-            "notebook_json": notebook_contents,
+            "notebook_json": json.dumps(notebook_contents),
             "notebook_name": notebook_name,
             "folder": username,
         }

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -448,6 +448,21 @@ class GardenClient:
                 f"Request to Garden backend to publish garden failed with error: {str(e)}"
             )
 
+    def upload_notebook(self, notebook_contents: dict, notebook_name: str) -> str:
+        """
+        POSTs a notebook's contents to the backend /notebook route
+        so that we can store a link to the full notebook contents in the pipeline metadata.
+        """
+        username = self.get_email()
+        try:
+            return self.backend_client.upload_garden_metadata(
+                notebook_contents, username, notebook_name
+            )
+        except Exception as e:
+            raise Exception(
+                f"Request to Garden backend to publish notebook failed with error: {str(e)}"
+            )
+
     def search(self, query: str) -> str:
         """
         Given a Globus Search advanced query, returns JSON Globus Search result string with gardens as entries.
@@ -509,7 +524,7 @@ class GardenClient:
         image: docker.models.images.Image,
         base_image_uri: str,
         full_image_uri: str,
-        notebook_contents: str,
+        notebook_url: str,
     ):
         """Register pipelines and (re-)publish affected gardens from a user's finished notebook session image.
 
@@ -524,8 +539,8 @@ class GardenClient:
             The public location of the base image that the user image was built on top of.
         - full_image_uri: str
             The public location of the full user image built by running the notebook.
-        - notebook_contents: str
-            The raw JSON contents of the Jupyter notebook used to construct the image.
+        - notebook_url: str
+            URL that points to the full contents of the notebook.
 
         Raises:
         - ValueError
@@ -558,7 +573,7 @@ class GardenClient:
             record["steps"] = all_steps
             record["doi"] = record.get("doi") or self._mint_draft_doi()
             record["short_name"] = record.get("short_name") or key
-            record["notebook"] = notebook_contents
+            record["notebook_url"] = notebook_url
             record["base_image_uri"] = base_image_uri
             record["full_image_uri"] = full_image_uri
 

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -455,7 +455,7 @@ class GardenClient:
         """
         username = self.get_email()
         try:
-            return self.backend_client.upload_garden_metadata(
+            return self.backend_client.upload_notebook(
                 notebook_contents, username, notebook_name
             )
         except Exception as e:

--- a/garden_ai/pipelines.py
+++ b/garden_ai/pipelines.py
@@ -140,7 +140,7 @@ class RegisteredPipeline(PipelineMetadata):
         container_uuid: ID returned from Globus Compute's register_container.
         base_image_uri: Name and location of the base image used by this pipeline. eg docker://index.docker.io/maxtuecke/garden-ai:python-3.9-jupyter
         full_image_uri: The name and location of the complete image used by this pipeline.
-        notebook: Full JSON string of the notebook used to define this pipeline's environment.
+        notebook_url: Link to the notebook used to build this pipeline.
         steps: Ordered list of Python functions that the pipeline author wants to highlight.
     """
 
@@ -151,7 +151,7 @@ class RegisteredPipeline(PipelineMetadata):
     container_uuid: UUID = Field(...)
     base_image_uri: Optional[str] = Field(None)
     full_image_uri: Optional[str] = Field(None)
-    notebook: Optional[str] = Field(None)
+    notebook_url: Optional[str] = Field(None)
     steps: List[Step] = Field(default_factory=list)
 
     def __call__(

--- a/garden_ai/utils/notebooks.py
+++ b/garden_ai/utils/notebooks.py
@@ -1,0 +1,23 @@
+import json
+
+MAX_BYTES = 5 * 1024 * 1024
+
+
+def is_over_size_limit(notebook_json: dict) -> bool:
+    """
+    Return True if notebook contents is over 5MB.
+    """
+    # Convert to byte string to account for longer unicode characters
+    as_byte_string = json.dumps(notebook_json).encode("utf-8")
+    return len(as_byte_string) > MAX_BYTES
+
+
+def clear_cells(notebook_json: dict) -> dict:
+    """
+    Returns new notebook with all cell outputs cleared.
+    """
+    new_nb = notebook_json.copy()
+    for cell in new_nb["cells"]:
+        if "outputs" in cell:
+            cell["outputs"] = []
+    return new_nb

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 from garden_ai.utils.misc import extract_email_from_globus_jwt
+from garden_ai.utils.notebooks import clear_cells, is_over_size_limit
 
 
 def test_extract_email_from_globus_jwt_happy_path(identity_jwt):
@@ -13,3 +14,53 @@ def test_extract_email_from_globus_jwt_malformed(identity_jwt):
     malformed_jwt = ".".join(jwt_segments)
     with pytest.raises(Exception):
         extract_email_from_globus_jwt(malformed_jwt)
+
+
+notebook_with_outputs = {
+    "cells": [
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {"text/plain": ["Hello"]},
+                    "execution_count": 1,
+                    "metadata": {},
+                    "output_type": "execute_result",
+                }
+            ],
+            "source": ["print('Hello')"],
+        }
+    ],
+    "metadata": {},
+    "nbformat": 4,
+    "nbformat_minor": 4,
+}
+cleared_notebook = {
+    "cells": [
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "metadata": {},
+            "outputs": [],
+            "source": ["print('Hello')"],
+        }
+    ],
+    "metadata": {},
+    "nbformat": 4,
+    "nbformat_minor": 4,
+}
+
+
+def test_clear_cells():
+    assert clear_cells(notebook_with_outputs) == cleared_notebook
+
+
+def test_is_over_size_limit():
+    assert not is_over_size_limit(cleared_notebook)
+
+    # 6MB worth of "a"s
+    big_notebook = cleared_notebook.copy()
+    big_notebook["cells"][0]["source"] = ["a" * 1024 * 1024 * 6]
+    assert is_over_size_limit(big_notebook)


### PR DESCRIPTION
This is the SDK/CLI portion of #345 

## Overview

This PR uses the new POST /notebook endpoint to upload the contents of the user's notebook to S3 and attach a public URL to a new `notebook_url` field on the pipeline metadata.

## Discussion

This PR is pretty by the book, but one interesting part is how we treat outputs in notebooks. For both uploading and downloading notebooks, we want to try and keep the file size sane. The most likely way that notebook file size gets out of control is `outputs`. So now we nondestructively clear the user's outputs by default before uploading. If the user has some visualization or output they really want to show, they can provide the --keep-outputs flag.

## Testing

I added new unit tests for the notebook helpers. I also tested this end to end against the backend dev instance and confirmed that `notebook_url` was getting included as expected, with a valid URL that points to the notebook contents.

## Documentation

No docs changes

<!-- readthedocs-preview garden-ai start -->
----
:books: Documentation preview :books:: https://garden-ai--354.org.readthedocs.build/en/354/

<!-- readthedocs-preview garden-ai end -->