### PR TITLE
UX Improvements to `notebook start` command

### DIFF
--- a/garden_ai/app/notebook.py
+++ b/garden_ai/app/notebook.py
@@ -166,7 +166,7 @@ def _get_base_image_uri(
     base_image_name: Optional[str],
     custom_image_uri: Optional[str],
     notebook_path: Optional[Path],
-) -> Optional[str]:
+) -> str:
     # First make sure that we have enough information to get a base image uri
     if base_image_name and custom_image_uri:
         typer.echo(

--- a/garden_ai/app/notebook.py
+++ b/garden_ai/app/notebook.py
@@ -112,8 +112,11 @@ def start(
     if need_to_create_notebook:
         if base_image_name:
             template_file_name = GardenConstants.IMAGES_TO_FLAVOR.get(
-                base_image_name or "", "empty.ipynb"
+                base_image_name, "empty.ipynb"
             )
+        else:
+            template_file_name = "empty.ipynb"
+
         top_level_dir = Path(__file__).parent.parent
         source_path = top_level_dir / "notebook_templates" / template_file_name
         shutil.copy(source_path, notebook_path)

--- a/garden_ai/app/notebook.py
+++ b/garden_ai/app/notebook.py
@@ -29,10 +29,7 @@ logger = logging.getLogger()
 notebook_app = typer.Typer(name="notebook")
 
 BASE_IMAGE_NAMES = ", ".join(
-    [
-        "'" + image_name + "'"
-        for image_name in list(GardenConstants.PREMADE_IMAGES.keys())
-    ]
+    ["'" + image_name + "'" for image_name in GardenConstants.PREMADE_IMAGES.keys()]
 )
 
 

--- a/garden_ai/app/notebook.py
+++ b/garden_ai/app/notebook.py
@@ -86,8 +86,7 @@ def start(
         need_to_create_notebook = True
         new_notebook_name = generate_botanical_filename()
         notebook_path = Path.cwd() / new_notebook_name
-
-    if path is not None:
+    else:
         notebook_path = path.resolve()
         if notebook_path.suffix != ".ipynb":
             typer.echo("File must be a jupyter notebook (.ipynb)")
@@ -111,9 +110,10 @@ def start(
     typer.confirm(message, abort=True)
 
     if need_to_create_notebook:
-        template_file_name = GardenConstants.IMAGES_TO_FLAVOR.get(
-            base_image_name, "empty.ipynb"
-        )
+        if base_image_name:
+            template_file_name = GardenConstants.IMAGES_TO_FLAVOR.get(
+                base_image_name or "", "empty.ipynb"
+            )
         top_level_dir = Path(__file__).parent.parent
         source_path = top_level_dir / "notebook_templates" / template_file_name
         shutil.copy(source_path, notebook_path)
@@ -165,7 +165,7 @@ def start(
 def _get_base_image_uri(
     base_image_name: Optional[str],
     custom_image_uri: Optional[str],
-    notebook_path: Optional[str],
+    notebook_path: Optional[Path],
 ) -> Optional[str]:
     # First make sure that we have enough information to get a base image uri
     if base_image_name and custom_image_uri:

--- a/garden_ai/app/notebook.py
+++ b/garden_ai/app/notebook.py
@@ -120,7 +120,8 @@ def start(
 
     _put_notebook_base_image(notebook_path, base_image_uri)
     print(
-        f"Starting notebook inside base image with full name {base_image_uri}. If you start this notebook again from the same folder, it will use this image by default."
+        f"Starting notebook inside base image with full name {base_image_uri}. "
+        f"If you start this notebook again from the same folder, it will use this image by default."
     )
 
     # start container and listen for Ctrl-C
@@ -195,7 +196,8 @@ def _get_base_image_uri(
             return GardenConstants.PREMADE_IMAGES[base_image_name]
         else:
             typer.echo(
-                f"The image you specified ({base_image_name}) is not one of the Garden base images. The current Garden base images are: \n{BASE_IMAGE_NAMES}"
+                f"The image you specified ({base_image_name}) is not one of the Garden base images. "
+                f"The current Garden base images are: \n{BASE_IMAGE_NAMES}"
             )
             raise typer.Exit(1)
 

--- a/garden_ai/app/notebook.py
+++ b/garden_ai/app/notebook.py
@@ -3,7 +3,7 @@ import logging
 import shutil
 import webbrowser
 from pathlib import Path
-from typing import Optional
+from typing import Optional, cast
 import json
 import time
 
@@ -203,6 +203,9 @@ def _get_base_image_uri(
                 f"The current Garden base images are: \n{BASE_IMAGE_NAMES}"
             )
             raise typer.Exit(1)
+
+    # last_used_image_uri is definitely non-None at this point
+    last_used_image_uri = cast(str, last_used_image_uri)
 
     # 3: If the user didn't specify an image explicitly, use the last image they used for this notebook.
     return last_used_image_uri

--- a/garden_ai/constants.py
+++ b/garden_ai/constants.py
@@ -40,3 +40,23 @@ class GardenConstants:
         "3.11-torch": "gardenai/base:python-3.11-jupyter-torch",
         "3.10-all-extras": "gardenai/base:python-3.10-jupyter-all",
     }
+
+    IMAGES_TO_FLAVOR = {
+        "3.8-base": "empty.ipynb",
+        "3.9-base": "empty.ipynb",
+        "3.10-base": "empty.ipynb",
+        "3.11-base": "empty.ipynb",
+        "3.8-sklearn": "sklearn.ipynb",
+        "3.9-sklearn": "sklearn.ipynb",
+        "3.10-sklearn": "sklearn.ipynb",
+        "3.11-sklearn": "sklearn.ipynb",
+        "3.8-tensorflow": "tensorflow.ipynb",
+        "3.9-tensorflow": "tensorflow.ipynb",
+        "3.10-tensorflow": "tensorflow.ipynb",
+        "3.11-tensorflow": "tensorflow.ipynb",
+        "3.8-torch": "torch.ipynb",
+        "3.9-torch": "torch.ipynb",
+        "3.10-torch": "torch.ipynb",
+        "3.11-torch": "torch.ipynb",
+        "3.10-all-extras": "empty.ipynb",
+    }

--- a/garden_ai/notebook_templates/empty.ipynb
+++ b/garden_ai/notebook_templates/empty.ipynb
@@ -1,0 +1,31 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "vscode": {
+          "languageId": "plaintext"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "### Blank 🌱Garden🌱 Execution Environment"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/garden_ai/notebook_templates/sklearn.ipynb
+++ b/garden_ai/notebook_templates/sklearn.ipynb
@@ -84,7 +84,7 @@
       "source": [
         "my_pipeline_meta = PipelineMetadata(\n",
         "    title=\"My Inference Function\",\n",
-        "    description=\"Write a longer description here so that people know what your it does.\",\n",
+        "    description=\"Write a longer description here so that people know what your pipeline does.\",\n",
         "    authors=[\"you\", \"your collaborator\"],\n",
         "    tags=[\"materials science\", \"your actual field\"]\n",
         ")"

--- a/garden_ai/notebook_templates/tensorflow.ipynb
+++ b/garden_ai/notebook_templates/tensorflow.ipynb
@@ -1,0 +1,206 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "H24yDUiVP5-n"
+      },
+      "source": [
+        "## Your Model 🌱Garden🌱 Execution Environment\n",
+        "\n",
+        "Use this notebook to write a function that executes your model(s). Tag that function with the `@garden_pipeline` decorator.\n",
+        "\n",
+        "Garden will take this notebook and build a container with it. When Garden executes your `@garden_pipeline`, it will be like like you have just run all the cells of this notebook once. So you can install libraries with `!pip install` and your function can use those libraries. You can also define helper functions and constants to use in your `@garden_pipeline`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "qww1_jOzP5S9"
+      },
+      "outputs": [],
+      "source": [
+        "from garden_ai.model_connectors import HFConnector\n",
+        "from garden_ai import PipelineMetadata, garden_pipeline"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "b0s7Bealdp8M"
+      },
+      "outputs": [],
+      "source": [
+        "import tensorflow as tf\n",
+        "from tensorflow.keras.models import load_model"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3aikfsCRdrEZ"
+      },
+      "source": [
+        "### Model connectors\n",
+        "\n",
+        "Model connectors let Garden import metadata about your model.\n",
+        "They also have a `stage` method that you can use to download your model weights."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "H7em6SwMdvkt"
+      },
+      "outputs": [],
+      "source": [
+        "my_hugging_face_repo = HFConnector(\"garden-ai/sample_tensorflow_model\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FTziKOq7d1Qs"
+      },
+      "source": [
+        "### Pipeline metadata\n",
+        "\n",
+        "\n",
+        "To publish your function, Garden needs metadata so that other users can discover it.\n",
+        "Edit this PipelineMetadata object to describe your function.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "PHtZD33NhCEF"
+      },
+      "outputs": [],
+      "source": [
+        "my_pipeline_meta = PipelineMetadata(\n",
+        "    title=\"My Inference Function\",\n",
+        "    description=\"Write a longer description here so that people know what your it does.\",\n",
+        "    authors=[\"you\", \"your collaborator\"],\n",
+        "    tags=[\"materials science\", \"your actual field\"]\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gnNDYs4PhKKO"
+      },
+      "source": [
+        "### Helper Functions\n",
+        "\n",
+        "Define any helper functions you need and use them in the function you want to let people run remotely"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "hhd9FNB9hN0a"
+      },
+      "outputs": [],
+      "source": [
+        "def preprocess(input_tensor):\n",
+        "    min_val, max_val = 0, 1\n",
+        "    min_tensor = tf.reduce_min(input_tensor)\n",
+        "    max_tensor = tf.reduce_max(input_tensor)\n",
+        "    scaled_tensor = (input_tensor - min_tensor) / (max_tensor - min_tensor)\n",
+        "    scaled_tensor = scaled_tensor * (max_val - min_val) + min_val\n",
+        "    return scaled_tensor"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bDPkWjAShSKr"
+      },
+      "source": [
+        "### Write your pipeline function that will run remotely\n",
+        "\n",
+        "The `@garden_pipeline` decorator makes this function available to run in your garden when you publish the notebook.\n",
+        "Download your model weights and call your model in this function.\n",
+        "\n",
+        "In the decorator be sure to include:\n",
+        "- your pipeline metadata,\n",
+        "- connectors for any models you're using,\n",
+        "- the DOI of the garden you want this pipeline to be found in. (Check `garden-ai garden list` for the DOIs of your gardens.)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6ls-44Wehec9"
+      },
+      "outputs": [],
+      "source": [
+        "@garden_pipeline(metadata=my_pipeline_meta,  model_connectors=[my_hugging_face_repo], garden_doi=\"10.23677/my-garden-doi\")\n",
+        "def run_my_model(input_tensor):\n",
+        "    scaled_tensor = preprocess(input_tensor)\n",
+        "    download_path = my_hugging_face_repo.stage()\n",
+        "    model = load_model(f\"{download_path}/model.keras\")\n",
+        "    return model.predict(scaled_tensor)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dK3PHq2fhgxp"
+      },
+      "source": [
+        "### Test your pipeline function\n",
+        "\n",
+        "Finally, make sure your `@garden_pipeline` works!\n",
+        "When Garden makes a container from your notebook, it runs all the cells in order and saves the notebook. Then users invoke your `@garden_pipeline` in the context of the notebook.\n",
+        "\n",
+        "If you can hit \"Kernel\" -> \"Restart and run all cells\" and your test below works, your `@garden_pipeline` will work in your garden!\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "pn2aa8wnhu2u"
+      },
+      "outputs": [],
+      "source": [
+        "# Replace with input that is relevant for your garden_pipeline\n",
+        "example_input = tf.constant([[1, 2],\n",
+        "                             [3, 4],\n",
+        "                             [5, 6]], dtype=tf.float16)\n",
+        "run_my_model(example_input)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "A9-UTFHAmCEq"
+      },
+      "outputs": [],
+      "source": []
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/garden_ai/notebook_templates/tensorflow.ipynb
+++ b/garden_ai/notebook_templates/tensorflow.ipynb
@@ -83,7 +83,7 @@
       "source": [
         "my_pipeline_meta = PipelineMetadata(\n",
         "    title=\"My Inference Function\",\n",
-        "    description=\"Write a longer description here so that people know what your it does.\",\n",
+        "    description=\"Write a longer description here so that people know what your pipeline does.\",\n",
         "    authors=[\"you\", \"your collaborator\"],\n",
         "    tags=[\"materials science\", \"your actual field\"]\n",
         ")"

--- a/garden_ai/notebook_templates/torch.ipynb
+++ b/garden_ai/notebook_templates/torch.ipynb
@@ -82,7 +82,7 @@
       "source": [
         "my_pipeline_meta = PipelineMetadata(\n",
         "    title=\"My Inference Function\",\n",
-        "    description=\"Write a longer description here so that people know what your it does.\",\n",
+        "    description=\"Write a longer description here so that people know what your pipeline does.\",\n",
         "    authors=[\"you\", \"your collaborator\"],\n",
         "    tags=[\"materials science\", \"your actual field\"]\n",
         ")"

--- a/garden_ai/notebook_templates/torch.ipynb
+++ b/garden_ai/notebook_templates/torch.ipynb
@@ -1,0 +1,212 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "H24yDUiVP5-n"
+      },
+      "source": [
+        "## Your Model 🌱Garden🌱 Execution Environment\n",
+        "\n",
+        "Use this notebook to write a function that executes your model(s). Tag that function with the `@garden_pipeline` decorator.\n",
+        "\n",
+        "Garden will take this notebook and build a container with it. When Garden executes your `@garden_pipeline`, it will be like like you have just run all the cells of this notebook once. So you can install libraries with `!pip install` and your function can use those libraries. You can also define helper functions and constants to use in your `@garden_pipeline`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "qww1_jOzP5S9"
+      },
+      "outputs": [],
+      "source": [
+        "from garden_ai.model_connectors import HFConnector\n",
+        "from garden_ai import PipelineMetadata, garden_pipeline"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "b0s7Bealdp8M"
+      },
+      "outputs": [],
+      "source": [
+        "import torch"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3aikfsCRdrEZ"
+      },
+      "source": [
+        "### Model connectors\n",
+        "\n",
+        "Model connectors let Garden import metadata about your model.\n",
+        "They also have a `stage` method that you can use to download your model weights."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "H7em6SwMdvkt"
+      },
+      "outputs": [],
+      "source": [
+        "my_hugging_face_repo = HFConnector(\"garden-ai/sample_sklearn_model\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FTziKOq7d1Qs"
+      },
+      "source": [
+        "### Pipeline metadata\n",
+        "\n",
+        "\n",
+        "To publish your function, Garden needs metadata so that other users can discover it.\n",
+        "Edit this PipelineMetadata object to describe your function.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "PHtZD33NhCEF"
+      },
+      "outputs": [],
+      "source": [
+        "my_pipeline_meta = PipelineMetadata(\n",
+        "    title=\"My Inference Function\",\n",
+        "    description=\"Write a longer description here so that people know what your it does.\",\n",
+        "    authors=[\"you\", \"your collaborator\"],\n",
+        "    tags=[\"materials science\", \"your actual field\"]\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gnNDYs4PhKKO"
+      },
+      "source": [
+        "### Helper Functions\n",
+        "\n",
+        "Define any helper functions you need and use them in the function you want to let people run remotely"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "hhd9FNB9hN0a"
+      },
+      "outputs": [],
+      "source": [
+        "def preprocess(input_tensor):\n",
+        "    min_val, max_val = 0, 1\n",
+        "    min_tensor = torch.min(input_tensor)\n",
+        "    max_tensor = torch.max(input_tensor)\n",
+        "    scaled_tensor = (input_tensor - min_tensor) / (max_tensor - min_tensor)\n",
+        "    scaled_tensor = scaled_tensor * (max_val - min_val) + min_val\n",
+        "    return scaled_tensor"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bDPkWjAShSKr"
+      },
+      "source": [
+        "### Write your pipeline function that will run remotely\n",
+        "\n",
+        "The `@garden_pipeline` decorator makes this function available to run in your garden when you publish the notebook.\n",
+        "Download your model weights and call your model in this function.\n",
+        "\n",
+        "In the decorator be sure to include:\n",
+        "- your pipeline metadata,\n",
+        "- connectors for any models you're using,\n",
+        "- the DOI of the garden you want this pipeline to be found in. (Check `garden-ai garden list` for the DOIs of your gardens.)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6ls-44Wehec9"
+      },
+      "outputs": [],
+      "source": [
+        "@garden_pipeline(metadata=my_pipeline_meta,  model_connectors=[my_hugging_face_repo], garden_doi=\"10.23677/my-garden-doi\")\n",
+        "def run_my_model(input_tensor):\n",
+        "    download_path = my_hugging_face_repo.stage()\n",
+        "    from model_definition_module_in_the_hf_repo import MyModel\n",
+        "    model = MyModel()\n",
+        "    model.load_state_dict(torch.load(download_path + \"/my_model.pt\"))\n",
+        "    model.eval()\n",
+        "\n",
+        "    scaled_tensor = preprocess(input_tensor)\n",
+        "    with torch.no_grad():\n",
+        "        output = model(scaled_tensor)\n",
+        "    \n",
+        "    return output"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dK3PHq2fhgxp"
+      },
+      "source": [
+        "### Test your pipeline function\n",
+        "\n",
+        "Finally, make sure your `@garden_pipeline` works!\n",
+        "When Garden makes a container from your notebook, it runs all the cells in order and saves the notebook. Then users invoke your `@garden_pipeline` in the context of the notebook.\n",
+        "\n",
+        "If you can hit \"Kernel\" -> \"Restart and run all cells\" and your test below works, your `@garden_pipeline` will work in your garden!\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "pn2aa8wnhu2u"
+      },
+      "outputs": [],
+      "source": [
+        "# Replace with input that is relevant for your garden_pipeline\n",
+        "example_input = torch.tensor([\n",
+        "    [1, -1], [3, 2]\n",
+        "])\n",
+        "run_my_model(example_input)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "A9-UTFHAmCEq"
+      },
+      "outputs": [],
+      "source": []
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/garden_ai/utils/notebooks.py
+++ b/garden_ai/utils/notebooks.py
@@ -1,4 +1,5 @@
 import json
+import random
 
 MAX_BYTES = 5 * 1024 * 1024
 
@@ -21,3 +22,68 @@ def clear_cells(notebook_json: dict) -> dict:
         if "outputs" in cell:
             cell["outputs"] = []
     return new_nb
+
+
+def generate_botanical_filename(extension="ipynb"):
+    number = random.randint(1, 10000)
+    colors = [
+        "Emerald",
+        "Jade",
+        "Green",
+        "Pink",
+        "Red",
+        "Teal",
+        "Indigo",
+        "Ochre",
+        "Cerulean",
+        "Crimson",
+        "Amber",
+        "Azure",
+        "Magenta",
+        "Maroon",
+        "Mauve",
+        "Purple",
+    ]
+    adjectives = [
+        "Blooming",
+        "Flourishing",
+        "Lush",
+        "Verdant",
+        "Fragrant",
+        "Prickly",
+        "Rustling",
+        "Dappled",
+        "Shimmering",
+        "Dewy",
+        "Sun-kissed",
+        "Whispering",
+        "Serene",
+        "Bountiful",
+        "Wild",
+    ]
+    nouns = [
+        "Blossoms",
+        "Petals",
+        "Potatoes",
+        "Vines",
+        "Leaves",
+        "Twigs",
+        "Roots",
+        "Blooms",
+        "Flowers",
+        "Seeds",
+        "Sprouts",
+        "Stems",
+        "Ferns",
+        "Cacti",
+        "Berries",
+        "Orchids",
+        "Turnips",
+    ]
+
+    color = random.choice(colors)
+    adjective = random.choice(adjectives)
+    noun = random.choice(nouns)
+
+    filename = f"{number}-{color}-{adjective}-{noun}.{extension}"
+    return filename


### PR DESCRIPTION
Closes #360

## Overview

This PR adds a bunch of improvements to `notebook start`:
- You'll get a templated notebook that matches the base image you picked. (eg, picking 3.10-torch means you get a templated notebook that uses torch.)
- You don't have to specify a notebook name if you're starting a new notebook. We will generate a random botanically inspired default name for the notebook.
- Wait a beat after spinning up the container so that when we redirect to the user's browser, they don't get a 404.
- More intuitive behavior for the `--base-image` flag. If you mistype we don't try to pull an image that doesn't exist, we abort and tell you the valid names.
- Before pulling and starting the image or making a new notebook file, we tell the user what we're about to do and let them accept or deny it.
- There is a new `--custom-image` flag. We hide it in the CLI help, but it's useful for developers.

## Discussion

The new template notebook varieties I added were pretty quick and dirty. But the new torch and tensorflow content they add could be of interest for #341 

## Testing

Just manual testing on this one. I basically ran the variants of notebook start. I particularly looked to confirm that the template <-> framework flavor mapping was working. I also made sure that saving and loading the notebook <-> image mapping was working as expected.

## Documentation

No docs additions/changes yet. But I'm definitely going to address it in #361 