### PR TITLE
Add ability for publishers to tag an `@entrypoint_test`

### DIFF
--- a/garden_ai/__init__.py
+++ b/garden_ai/__init__.py
@@ -7,6 +7,7 @@ from .entrypoints import (
     RegisteredEntrypoint,
     garden_entrypoint,
     garden_step,
+    entrypoint_test,
 )
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "RegisteredEntrypoint",
     "garden_entrypoint",
     "garden_step",
+    "entrypoint_test",
 ]

--- a/garden_ai/app/notebook.py
+++ b/garden_ai/app/notebook.py
@@ -305,7 +305,6 @@ def publish(
         ),
         hidden=True,
     ),
-    # base_image: Optional[str] = typer.Option(None),
     image_repo: Optional[str] = typer.Option(
         None,
         "--repo",

--- a/garden_ai/entrypoints.py
+++ b/garden_ai/entrypoints.py
@@ -245,14 +245,16 @@ def garden_entrypoint(
 
 
 def entrypoint_test(entrypoint_func: callable):
-    def decorate(func):
+    def decorate(test_func):
         if not entrypoint_func or not entrypoint_func._garden_entrypoint:
             raise ValueError("Please pass in a valid entrypoint function")
 
-        test_function_text = inspect.getsource(entrypoint_func)
+        test_function_text = inspect.getsource(test_func)
+        print(test_function_text)
         entrypoint_func._garden_entrypoint._test_functions.append(test_function_text)
+        print(entrypoint_func._garden_entrypoint._test_functions)
 
-        return func
+        return test_func
 
     return decorate
 

--- a/garden_ai/entrypoints.py
+++ b/garden_ai/entrypoints.py
@@ -122,10 +122,10 @@ class EntrypointMetadata(BaseModel):
     models: List[ModelMetadata] = Field(default_factory=list)
     repositories: List[Repository] = Field(default_factory=list)
     papers: List[Paper] = Field(default_factory=list)
-    _target_garden_doi: Optional[str] = PrivateAttr(
-        None
-    )  # Used internally for publishing.
-    _as_step: Optional[Step] = PrivateAttr(None)  # Used internally for publishing.
+    # The PrivateAttrs below are used internally for publishing.
+    _test_functions: List[str] = PrivateAttr(default_factory=list)
+    _target_garden_doi: Optional[str] = PrivateAttr(None)
+    _as_step: Optional[Step] = PrivateAttr(None)
 
 
 class RegisteredEntrypoint(EntrypointMetadata):
@@ -237,6 +237,19 @@ def garden_entrypoint(
         metadata._target_garden_doi = garden_doi
         # let func carry its own metadata
         func._garden_entrypoint = metadata
+        return func
+
+    return decorate
+
+
+def entrypoint_test(entrypoint_func: callable):
+    def decorate(func):
+        if not entrypoint_func or not entrypoint_func._garden_entrypoint:
+            raise ValueError("Please pass in a valid entrypoint function")
+
+        test_function_text = inspect.getsource(entrypoint_func)
+        entrypoint_func._garden_entrypoint._test_functions.append(test_function_text)
+
         return func
 
     return decorate

--- a/garden_ai/entrypoints.py
+++ b/garden_ai/entrypoints.py
@@ -250,9 +250,7 @@ def entrypoint_test(entrypoint_func: callable):
             raise ValueError("Please pass in a valid entrypoint function")
 
         test_function_text = inspect.getsource(test_func)
-        print(test_function_text)
         entrypoint_func._garden_entrypoint._test_functions.append(test_function_text)
-        print(entrypoint_func._garden_entrypoint._test_functions)
 
         return test_func
 

--- a/garden_ai/entrypoints.py
+++ b/garden_ai/entrypoints.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 import logging
 from datetime import datetime
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Union, Callable
 from uuid import UUID
 
 import globus_compute_sdk  # type: ignore
@@ -244,7 +244,7 @@ def garden_entrypoint(
     return decorate
 
 
-def entrypoint_test(entrypoint_func: callable):
+def entrypoint_test(entrypoint_func: Callable):
     def decorate(test_func):
         if not entrypoint_func or not entrypoint_func._garden_entrypoint:
             raise ValueError("Please pass in a valid entrypoint function")

--- a/garden_ai/entrypoints.py
+++ b/garden_ai/entrypoints.py
@@ -142,6 +142,7 @@ class RegisteredEntrypoint(EntrypointMetadata):
         full_image_uri: The name and location of the complete image used by this entrypoint.
         notebook_url: Link to the notebook used to build this entrypoint.
         steps: Ordered list of Python functions that the entrypoint author wants to highlight.
+        test_functions: List of test functions that exercise the entrypoint.
     """
 
     doi: str = Field(
@@ -153,6 +154,7 @@ class RegisteredEntrypoint(EntrypointMetadata):
     full_image_uri: Optional[str] = Field(None)
     notebook_url: Optional[str] = Field(None)
     steps: List[Step] = Field(default_factory=list)
+    test_functions: List[str] = Field(default_factory=list)
 
     def __call__(
         self,

--- a/garden_ai/scripts/save_session_and_metadata.py
+++ b/garden_ai/scripts/save_session_and_metadata.py
@@ -41,14 +41,13 @@ if __name__ == "__main__":
         key_name = entrypoint_fn.__name__
         doi_key = f"{key_name}.garden_doi"
         step_key = f"{key_name}.entrypoint_step"
-        test_functions_key = f"{key_name}.test_functions"
         entrypoint_meta = entrypoint_fn._garden_entrypoint
 
         total_meta[key_name] = entrypoint_meta.dict()
+        total_meta[key_name]["test_functions"] = entrypoint_meta._test_functions
         if entrypoint_meta._target_garden_doi:
             total_meta[doi_key] = entrypoint_meta._target_garden_doi
         total_meta[step_key] = entrypoint_meta._as_step
-        total_meta[test_functions_key] = entrypoint_meta._test_functions
 
     for step_fn in step_fns:
         # Relying on insertion order being maintained in dicts in Python 3.8 forward 🤠

--- a/garden_ai/scripts/save_session_and_metadata.py
+++ b/garden_ai/scripts/save_session_and_metadata.py
@@ -41,12 +41,14 @@ if __name__ == "__main__":
         key_name = entrypoint_fn.__name__
         doi_key = f"{key_name}.garden_doi"
         step_key = f"{key_name}.entrypoint_step"
+        test_functions_key = f"{key_name}.test_functions"
         entrypoint_meta = entrypoint_fn._garden_entrypoint
 
         total_meta[key_name] = entrypoint_meta.dict()
         if entrypoint_meta._target_garden_doi:
             total_meta[doi_key] = entrypoint_meta._target_garden_doi
         total_meta[step_key] = entrypoint_meta._as_step
+        total_meta[test_functions_key] = entrypoint_meta._test_functions
 
     for step_fn in step_fns:
         # Relying on insertion order being maintained in dicts in Python 3.8 forward 🤠


### PR DESCRIPTION
Closes #342 

## Overview

Inside a notebook, you can tag a function that tests an entrypoint like this:

```
@entrypoint_test(classify_irises)
def test_the_classifier():
    example_input = [[5.1, 3.5, 1.4, 0.2]]
    result = classify_irises(example_input)
    return result
```

And then that function's text will be available in the entrypoint's metadata object in the `test_functions` list. This will let us display an example of how to use the entrypoint on the UI or in an autogenerated "Try it in Colab" notebook.

## Discussion

I deliberately kept this first draft of this super simple. There is no validation of the test function's contents or anything like that. And this just passes along the raw text of the test function. Enough to display the example in the UI and no more.

Also I was getting some weird behavior with container selection on `publish` so I went ahead and refactored so that it shares the same helper for selecting the base container with `start`.

## Testing

I tested this with the sklearn seedling. I confirmed that the new metadata made it up in the JSON response in the expected place in the frontend.

## Documentation

None yet. This would be good to add to the template notebooks if we like it.

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--369.org.readthedocs.build/en/369/

<!-- readthedocs-preview garden-ai end -->