### PR TITLE
359 error if `stage()` called during publish

### DIFF
--- a/garden_ai/model_connectors/hugging_face.py
+++ b/garden_ai/model_connectors/hugging_face.py
@@ -1,5 +1,6 @@
 import huggingface_hub as hfh  # type: ignore
 from garden_ai.mlmodel import ModelMetadata
+from garden_ai.utils.misc import trackcalls
 import os
 import sys
 
@@ -19,6 +20,7 @@ class HFConnector:
             model_version=self.revision,
         )
 
+    @trackcalls
     def stage(self) -> str:
         if not os.path.exists(self.local_dir):
             os.mkdir(self.local_dir)

--- a/garden_ai/scripts/save_session_and_metadata.py
+++ b/garden_ai/scripts/save_session_and_metadata.py
@@ -21,6 +21,7 @@ if __name__ == "__main__":
     import json
 
     from pydantic.json import pydantic_encoder
+    from garden_ai.model_connectors import HFConnector
 
     entrypoint_fns, step_fns, steps = [], [], []
     global_vars = list(globals().values())
@@ -31,6 +32,16 @@ if __name__ == "__main__":
 
         if hasattr(obj, "_garden_step"):
             step_fns.append(obj)
+
+        if isinstance(obj, HFConnector):
+            if obj.stage.has_been_called:
+                import logging
+
+                logger = logging.getLogger()
+                logger.warning(
+                    f"WARNING: {obj}'s `.stage()` method was called unexpectedly during the build process, which is probably not intentional. "
+                    "Anything downloaded (such as model weights) by this method will be 'baked in' to the final image, increasing its size. "
+                )
 
     if len(entrypoint_fns) == 0:
         raise ValueError("No functions marked with garden_entrypoint decorator.")

--- a/garden_ai/scripts/save_session_and_metadata.py
+++ b/garden_ai/scripts/save_session_and_metadata.py
@@ -35,12 +35,8 @@ if __name__ == "__main__":
 
         if isinstance(obj, HFConnector):
             if obj.stage.has_been_called:
-                import logging
-
-                logger = logging.getLogger()
-                logger.warning(
-                    f"WARNING: {obj}'s `.stage()` method was called unexpectedly during the build process, which is probably not intentional. "
-                    "Anything downloaded (such as model weights) by this method will be 'baked in' to the final image, increasing its size. "
+                raise RuntimeWarning(
+                    f"{obj}'s `.stage()` method was called unexpectedly during the build process. "
                 )
 
     if len(entrypoint_fns) == 0:

--- a/garden_ai/scripts/save_session_and_metadata.py
+++ b/garden_ai/scripts/save_session_and_metadata.py
@@ -36,7 +36,9 @@ if __name__ == "__main__":
         if isinstance(obj, HFConnector):
             if obj.stage.has_been_called:
                 raise RuntimeWarning(
-                    f"{obj}'s `.stage()` method was called unexpectedly during the build process. "
+                    f"{obj}'s `.stage()` method was called unexpectedly during "
+                    "the build process. Double check that no top-level code "
+                    "calls your entrypoint in the final version of your notebook. "
                 )
 
     if len(entrypoint_fns) == 0:

--- a/garden_ai/utils/misc.py
+++ b/garden_ai/utils/misc.py
@@ -2,6 +2,7 @@ import base64
 import json
 import logging
 import re
+import functools
 from keyword import iskeyword
 
 import requests
@@ -78,3 +79,13 @@ def clean_identifier(name: str) -> str:
         logger.info(f'Generated valid short_name "{name}" from "{orig}".')
 
     return name.lower()
+
+
+def trackcalls(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        wrapper.has_been_called = True
+        return func(*args, **kwargs)
+
+    wrapper.has_been_called = False
+    return wrapper


### PR DESCRIPTION
closes #359 

## Overview

This decorates the `HFConnector.stage` method so that we can raise an error if it's been called during an image build, but not anywhere else.

## Discussion

Originally we wanted this to be just a warning, but that turned out to be pretty poor UX -- a warning wouldn't appear at all unless running `notebook publish --verbose`; even when verbose, the warning was hard to find in the output among the various safe-to-ignore `WARNING: Running pip as the 'root' user can result ... ` messages.

I spent a while trying to come up with a clean way to provide an option for power users to do this anyway, but after hitting a couple dead-ends I think it makes more sense for those users to just not use `.stage()` than it does for me to spend much more time on this ticket.

tldr: turned out more opinionated than I'd like, but I think it's innocent until proven gripe 

## Testing

Published the tutorial notebook (with this branch installed) a few times with/-out problematic code and the `--verbose` flag 

## Documentation

no new docs 

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--370.org.readthedocs.build/en/370/

<!-- readthedocs-preview garden-ai end -->