### PR TITLE
add user operations to garden CLI

### DIFF
--- a/garden_ai/app/main.py
+++ b/garden_ai/app/main.py
@@ -7,7 +7,9 @@ import typer
 from garden_ai.app.garden import garden_app
 from garden_ai.app.entrypoint import entrypoint_app
 from garden_ai.app.notebook import notebook_app
+from garden_ai import GardenClient
 from garden_ai._version import __version__
+from garden_ai.local_data import _get_user_email
 
 logger = logging.getLogger()
 
@@ -27,11 +29,37 @@ def show_version(show: bool):
         raise typer.Exit()
 
 
+def user_operations(command: Optional[str]):
+    """Handle whoami, login, or logout command then quit."""
+    if command == "whoami":
+        user = _get_user_email()
+        if user != "unknown":
+            rich.print(user)
+        else:
+            # undefined behavior if the user is not actually logged out
+            GardenClient()
+    elif command == "login":
+        # forces the login flow when logged out
+        GardenClient()
+    elif command == "logout":
+        # assumes user is logged in, seems like a safe assumption
+        # otherwise: undefined behavior
+        GardenClient().auth_key_store.clear_garden_data()
+    else:
+        if command is not None:
+            rich.print(f"Unknown command: {command}.")
+    # quit
+    raise typer.Exit()
+
+
 @app.callback()
 def main_info(
+    user_op: Optional[str] = typer.Argument(
+        None, callback=user_operations, is_eager=True
+    ),
     version: Optional[bool] = typer.Option(
         None, "--version", callback=show_version, is_eager=True
-    )
+    ),
 ):
     """
     🌱 Hello, Garden 🌱

--- a/garden_ai/app/main.py
+++ b/garden_ai/app/main.py
@@ -29,37 +29,34 @@ def show_version(show: bool):
         raise typer.Exit()
 
 
-def user_operations(command: Optional[str]):
-    """Handle whoami, login, or logout command then quit."""
-    if command == "whoami":
-        user = _get_user_email()
-        if user != "unknown":
-            rich.print(user)
-        else:
-            # undefined behavior if the user is not actually logged out
-            GardenClient()
-    elif command == "login":
-        # forces the login flow when logged out
-        GardenClient()
-    elif command == "logout":
-        # assumes user is logged in, seems like a safe assumption
-        # otherwise: undefined behavior
-        GardenClient().auth_key_store.clear_garden_data()
+@app.command()
+def whoami():
+    user = _get_user_email()
+    if user != "unknown":
+        rich.print(user)
     else:
-        if command is not None:
-            rich.print(f"Unknown command: {command}.")
-    # quit
-    raise typer.Exit()
+        # undefined behavior if the user is not actually logged out
+        GardenClient()
+
+
+@app.command()
+def login():
+    if GardenClient().auth_key_store.file_exists():
+        rich.print("Already logged in.")
+
+
+@app.command()
+def logout():
+    # assumes user is logged in, seems like a safe assumption
+    # otherwise: undefined behavior
+    GardenClient().auth_key_store.clear_garden_data()
 
 
 @app.callback()
 def main_info(
-    user_op: Optional[str] = typer.Argument(
-        None, callback=user_operations, is_eager=True
-    ),
     version: Optional[bool] = typer.Option(
         None, "--version", callback=show_version, is_eager=True
-    ),
+    )
 ):
     """
     🌱 Hello, Garden 🌱

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -75,9 +75,7 @@ class GardenClient:
     ):
         key_store_path = Path(GardenConstants.GARDEN_DIR)
         key_store_path.mkdir(exist_ok=True)
-        self.garden_key_store = SimpleJSONFileAdapter(
-            os.path.join(key_store_path, "tokens.json")
-        )
+        self.garden_key_store = SimpleJSONFileAdapter(GardenConstants.GARDEN_KEY_STORE)
         self.compute_key_store = get_token_storage_adapter()
         self.auth_key_store = GardenFileAdapter(
             self.garden_key_store, self.compute_key_store

--- a/garden_ai/constants.py
+++ b/garden_ai/constants.py
@@ -10,6 +10,7 @@ _PROD_SEARCH_INDEX = "813d4556-cbd4-4ba9-97f2-a7155f70682f"
 class GardenConstants:
     GARDEN_TEST_EMAIL = "garden-test-runner@email.com"
     GARDEN_DIR = os.path.expanduser("~/.garden")
+    GARDEN_KEY_STORE = os.path.join(GARDEN_DIR, "tokens.json")
     URL_ENV_VAR_NAME = "GARDEN_MODELS"
     GARDEN_ENDPOINT = (
         _PROD_ENDPOINT if os.environ.get("GARDEN_ENV") == "prod" else _DEV_ENDPOINT

--- a/garden_ai/garden_file_adapter.py
+++ b/garden_ai/garden_file_adapter.py
@@ -2,6 +2,7 @@ from globus_sdk.tokenstorage import SimpleJSONFileAdapter, SQLiteAdapter, FileAd
 from globus_sdk.services.auth import OAuthTokenResponse
 
 from typing import Any, Dict, Optional
+from pathlib import Path
 
 
 class GardenFileAdapter(FileAdapter):
@@ -23,6 +24,10 @@ class GardenFileAdapter(FileAdapter):
 
     def on_refresh(self, token_response: OAuthTokenResponse) -> None:
         self.store(token_response)
+
+    def clear_garden_data(self) -> None:
+        # silently ignores the case where the file is already gone
+        Path.unlink(Path(self.garden_key_store.filename), missing_ok=True)
 
     def file_exists(self) -> bool:
         return self.garden_key_store.file_exists()

--- a/garden_ai/garden_file_adapter.py
+++ b/garden_ai/garden_file_adapter.py
@@ -25,9 +25,5 @@ class GardenFileAdapter(FileAdapter):
     def on_refresh(self, token_response: OAuthTokenResponse) -> None:
         self.store(token_response)
 
-    def clear_garden_data(self) -> None:
-        # silently ignores the case where the file is already gone
-        Path.unlink(Path(self.garden_key_store.filename), missing_ok=True)
-
     def file_exists(self) -> bool:
         return self.garden_key_store.file_exists()

--- a/garden_ai/garden_file_adapter.py
+++ b/garden_ai/garden_file_adapter.py
@@ -2,7 +2,6 @@ from globus_sdk.tokenstorage import SimpleJSONFileAdapter, SQLiteAdapter, FileAd
 from globus_sdk.services.auth import OAuthTokenResponse
 
 from typing import Any, Dict, Optional
-from pathlib import Path
 
 
 class GardenFileAdapter(FileAdapter):

--- a/garden_ai/local_data.py
+++ b/garden_ai/local_data.py
@@ -98,6 +98,13 @@ def _store_user_email(email: str) -> None:
     _write_local_db(data)
 
 
+def _clear_user_email() -> None:
+    data = _read_local_db()
+    if "user_email" in data:
+        del data["user_email"]
+        _write_local_db(data)
+
+
 def _get_user_email() -> str:
     data = _read_local_db()
     maybe_email = data.get("user_email")


### PR DESCRIPTION
Fixes #279 

## Overview

Add `whoami`, `login`, and `logout` commands to the CLI.

## Testing

I ran the commands successfully myself.

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--372.org.readthedocs.build/en/372/

<!-- readthedocs-preview garden-ai end -->