### PR TITLE
336 pre install garden in base images

### DIFF
--- a/garden_ai/app/notebook.py
+++ b/garden_ai/app/notebook.py
@@ -13,6 +13,7 @@ import typer
 from garden_ai import GardenClient, GardenConstants
 from garden_ai.containers import (
     JUPYTER_TOKEN,
+    build_image_with_dependencies,
     build_notebook_session_image,
     push_image_to_public_repo,
     start_container_with_notebook,
@@ -64,6 +65,14 @@ def start(
             "To see all the available Garden base images, use 'garden-ai notebook list-premade-images'"
         ),
     ),
+    requirements_path: Optional[Path] = typer.Option(
+        None,
+        "--requirements",
+        help=(
+            "Path to a requirements.txt or a conda environment.yml containing "
+            "additional dependencies to install in the base image."
+        ),
+    ),
     custom_image_uri: Optional[str] = typer.Option(
         None,
         "--custom-image",
@@ -102,11 +111,29 @@ def start(
         None if need_to_create_notebook else notebook_path,
     )
 
+    # validate requirements file
+    if requirements_path:
+        requirements_path.resolve()
+        if not requirements_path.exists():
+            typer.echo(f"Could not find file: {requirements_path}")
+            raise typer.Exit(1)
+        if requirements_path.suffix not in {".txt", ".yml", ".yaml"}:
+            typer.echo(
+                "Requirements file in unexpected format. "
+                f"Expected one of: .txt, .yml, .yaml; got {requirements_path.name}."
+            )
+            raise typer.Exit(1)
+
     # Now we have all we need to prompt the user to proceed
     if need_to_create_notebook:
-        message = f"This will create a new notebook {notebook_path.name} and open it in Docker image {base_image_uri}. Do you want to proceed?"
+        message = f"This will create a new notebook {notebook_path.name} and open it in Docker image {base_image_uri}. "
     else:
-        message = f"This will open existing notebook {notebook_path.name} in Docker image {base_image_uri}. Do you want to proceed?"
+        message = f"This will open existing notebook {notebook_path.name} in Docker image {base_image_uri}. "
+
+    if requirements_path:
+        message += f"Additional dependencies specified in {requirements_path.name} will also be installed in {base_image_uri}. "
+    message += "Do you want to proceed?"
+
     typer.confirm(message, abort=True)
 
     if need_to_create_notebook:
@@ -121,6 +148,11 @@ def start(
         source_path = top_level_dir / "notebook_templates" / template_file_name
         shutil.copy(source_path, notebook_path)
 
+    docker_client = docker.from_env()
+    # pre-bake image with garden-ai and additional user requirements
+    base_image_uri = build_image_with_dependencies(
+        docker_client, base_image_uri, requirements_path
+    )
     _put_notebook_base_image(notebook_path, base_image_uri)
     print(
         f"Starting notebook inside base image with full name {base_image_uri}. "
@@ -128,9 +160,8 @@ def start(
     )
 
     # start container and listen for Ctrl-C
-    docker_client = docker.from_env()
     container = start_container_with_notebook(
-        docker_client, notebook_path, base_image_uri
+        docker_client, notebook_path, base_image_uri, pull=False
     )
     _register_container_sigint_handler(container)
 

--- a/garden_ai/containers.py
+++ b/garden_ai/containers.py
@@ -107,6 +107,7 @@ def build_notebook_session_image(
     base_image: str,
     platform: str = "linux/x86_64",
     print_logs: bool = True,
+    pull: bool = True,
 ) -> Optional[docker.models.images.Image]:
     """
     Build the docker image to register with Globus Compute locally.
@@ -124,6 +125,7 @@ def build_notebook_session_image(
         base_image: The name of the base Docker image to use.
         platform: The target platform for the Docker build (default is "linux/x86_64").
         print_logs: Flag to enable streaming build logs to the console (default is True).
+        pull: Whether to pull the base image before building the notebook session image over it (default True).
 
     Returns:
         The docker `Image` object if the build succeeds, otherwise None.
@@ -153,7 +155,8 @@ def build_notebook_session_image(
         script_path = temp_notebook_path.with_suffix(".py")
         script_path.write_text(script_contents)
 
-        client.images.pull(base_image, platform=platform)
+        if pull:
+            client.images.pull(base_image, platform=platform)
 
         # easier to grok than pure docker sdk equivalent (if one exists)
         dockerfile_content = f"""
@@ -264,13 +267,14 @@ def build_image_with_dependencies(
     dependencies_path: Optional[pathlib.Path] = None,
     platform: str = "linux/x86_64",
     print_logs: bool = True,
+    pull: bool = True,
 ) -> str:
     """
     Build a "pre-baked" image from the base image with optional additional dependencies installed.
 
     This always installs at least the latest version of garden-ai.
 
-    The dependencies can be either a pip requirements.txt or a conda environment.yml file.
+    If included, the dependencies can be either a pip requirements.txt or a conda environment.yml file.
 
     Args:
         client: A Docker client instance to manage Docker resources.
@@ -278,17 +282,16 @@ def build_image_with_dependencies(
         dependencies_path: Optional; A Path object to the requirements.txt or environment.yml file.
         platform: The target platform for the Docker build (default is "linux/x86_64").
         print_logs: Enable streaming build logs to the console (default is True).
+        pull: Whether to pull the base image before building on top of it (default is True).
 
     Returns:
-        The tag of the freshly-built Docker image
+        The ID of the freshly-built Docker image
 
     Raises:
         docker.errors.BuildError: If the build fails.
     """
-    timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-    new_image_tag = f"{base_image.replace(':', '_')}-local-{timestamp}"
 
-    # always install garden
+    # always install garden first
     dockerfile_content = f"""
     FROM {base_image}
     RUN pip install garden-ai
@@ -296,9 +299,10 @@ def build_image_with_dependencies(
     with TemporaryDirectory() as temp_dir:
         temp_dir_path = pathlib.Path(temp_dir)
 
-        client.images.pull(base_image, platform=platform)
+        if pull:
+            client.images.pull(base_image, platform=platform)
 
-        # Create Dockerfile based on whether dependencies are provided
+        # append to Dockerfile based on whether dependencies are provided
         if dependencies_path is not None:
             dockerfile_content += (
                 f"\nCOPY {dependencies_path.name} /garden/{dependencies_path.name}"
@@ -327,7 +331,7 @@ def build_image_with_dependencies(
         # Build the image
         print("Preparing image ...")
         stream = client.api.build(
-            path=str(temp_dir_path), tag=new_image_tag, platform=platform, decode=True
+            path=str(temp_dir_path), platform=platform, decode=True
         )
         image = None
         for chunk in stream:
@@ -345,6 +349,6 @@ def build_image_with_dependencies(
                 raise docker.errors.BuildError(reason=error_message, build_log=stream)
 
         if image is None:
-            raise docker.errors.BuildError("Failed to build image")
+            raise docker.errors.BuildError
         else:
-            return new_image_tag
+            return image_id


### PR DESCRIPTION
closes #336, plus addresses Logan's gripe about including requirements.txt or conda environment.yml files. 
## Overview

The new functionality is all in `build_image_with_dependencies`, and all of the `garden-ai notebook` commands now accept an optional `--requirements` path to either a pip- or conda-style requirements file. 

local data still only tracks the most recently selected `--base-image` instead of storing the bespoke local images generated by the new function

## Discussion 
My first few stabs at this I had the CLI either remember the most-recently-used requirements file along with the base image and/or caching the pre-baked image instead, but it felt pretty unwieldy for not a lot of benefit; the layer caching we get for free with docker is basically just as good as caching the custom image in local data. 

The potential downside of this is that users need to specify the `--requirement` argument for both `notebook start` and `notebook publish` every time, which might be surprising because it's different to the `--base-image` behavior. 

## Testing
I tested this manually end-to-end with a dummy entrypoint that just reports the version of a given package in `sys.modules` and sanity-checked with packages installed via a `requirements.txt` and an `environment.yml`. 

I also had chatgpt write me a few happy path unit tests.

## Documentation

No docs updates besides CLI help text / docstrings 


<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--373.org.readthedocs.build/en/373/

<!-- readthedocs-preview garden-ai end -->