### PR TITLE
Make some docs changes to reflect new features and fixes

### DIFF
--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -23,7 +23,7 @@ The Garden project is structured around two "proper noun" concepts: `Garden` and
 
     - An `Entrypoint` is a plain Python function, enriched with citation metadata and registered with our service for reproducibility and remote execution (via Globus Compute).
     - Users can execute an `Entrypoint` remotely via any `Garden` it has been published to.
-    - An `Entrypoint` is typically defined in a regular Jupyter/ipynb notebook, and functions like an "entrypoint" to a saved notebook session when registered and published to a `Garden`.
+    - An `Entrypoint` is typically defined in a regular Jupyter notebook, and functions like an "entrypoint" to a saved notebook session when registered and published to a `Garden`.
     - An `Entrypoint` is registered when its notebook is published.
     - When a notebook is published, all the `Entrypoint`s in the notebook are published to their respective gardens -- `Entrypoint`s defined in the same notebook need not be published to the same `Garden`.
 
@@ -39,9 +39,9 @@ The Garden project is structured around two "proper noun" concepts: `Garden` and
 
 ### Notebook Workflow - Defining and Developing Entrypoints
 
-1. **Development in IPython Notebooks:**
+1. **Development in Jupyter Notebooks:**
 
-    - The process begins by writing an IPython notebook containing functions marked as entrypoints using the `@garden_entrypoint` decorator.
+    - The process begins by writing a Jupyter notebook containing functions marked as entrypoints using the `@garden_entrypoint` decorator.
     - The `garden-ai` CLI provides a `garden-ai notebook start path/to/my.ipynb` command to open a notebook in an isolated local Docker container (conceptually similar to a Google Colab notebook, but running locally and with a choice of prebuilt base images).
 	- See [installation](user_guide/installation.md) for Docker-specific prerequisites
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,5 +3,6 @@
 Docs are WIP, but in the meantime here are good places to start:
 - [Overview](architecture_overview.md) - High-level explanation of key concepts
 - [Tutorial](user_guide/tutorial.md) - A short end-to-end example using the CLI. See also: ["seedlings" repository](https://github.com/Garden-AI/seedlings)
+- [FAQs](user_guide/faqs.md) - Troubleshooting tips
 - [contributing](developer_guide/contributing.md) - Getting started as a contributor
 - [Garden's GitHub repository](https://github.com/Garden-AI/garden) - Where all the magic happens

--- a/docs/user_guide/faqs.md
+++ b/docs/user_guide/faqs.md
@@ -1,0 +1,23 @@
+# Frequently Asked Questions
+
+### My entrypoint isn't working how I expect. How can I debug it?
+
+If you're finding that an entrypoint function works correctly following a "restart kernel and run all cells" when run from within a `garden-ai notebook start` session but fails on remote execution, the `garden-ai notebook debug` command is the best place to start troubleshooting.
+
+Garden does its best to recreate your notebook environment exactly when running remotely. But there are a few ways this process can go awry:
+	- The remote execution context is a session which has been saved and reloaded. If there is a serialization or deserialization bug, the session could get corrupted.
+	- Your notebook is converted to a plain python script before being executed, and there may be unexpected discrepancies between the notebook and the notebook-as-script causing problems.
+
+The `garden-ai notebook debug` command accepts the same arguments as `garden-ai notebook start`, but instead of opening the notebook in a base image, it opens a debugging notebook in an image with your saved notebook session (i.e. the one that remote inference will use).
+
+The debugging notebook only has a snippet of code to reload your saved session -- this is as close to the remote execution context as possible without actually executing remotely.
+
+If calling your entrypoint function in the `garden-ai notebook debug` session behaves the same as calling your entrypoint function in a `garden-ai notebook start` session, that likely indicates a problem with the remote endpoint.
+
+If calling your entrypoint function in the `garden-ai notebook debug` session behaves differently than in a `garden-ai notebook start` session, that indicates a problem with serializing or deserializing your notebook state. If this is the case, please open an issue on our [Github](https://github.com/Garden-AI/garden/issues), including the notebook and any additional context that might be useful so we can reproduce the bug.
+
+### I have an M1/M2 Mac and I want to publish an entrypoint that uses tensorflow. I can't get it to work locally. How can I?
+
+Alas, you can't. Garden aways spins up Linux container, so you can't install the `tensorflow-macos` variant. And the normal `tensorflow` doesn't run on Apple silicon. (Yes, even if you have Rosetta )
+
+To work around this, we recommend using a VPS. Spin up a temporary EC2 instance (or equivalent on different cloud providers) running Linux where you can work on your notebook. When you ssh into your remote workstation, forward the port the notebook runs on so that you can still work on the notebook in your local browser. Like `ssh -L 8888:localhost:8888 my-remote-user@my-remote-workstation`.

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -1,10 +1,10 @@
 # Prerequisites
 
-Garden makes your AI/ML work reproducible by using [Docker](https://www.docker.com/) containers to fully encapsulate your code and its dependencies. This helps ensure consistency across different machines, making it easier for anyone to reproduce your results. Before you get started with Garden, there are two key Docker-specific prerequisites:
+Garden makes your AI/ML work reproducible by using [Docker](https://www.docker.com/) containers to fully encapsulate your code and its dependencies. This helps ensure consistency across different machines, making it easier for anyone to reproduce your results.
 
-### Docker Desktop
+### Docker
 
-1. **Install Docker Desktop:** To use Garden, you need to have Docker Desktop installed on your system. You can download it from the [official Docker website](https://www.docker.com/products/docker-desktop). Follow the installation instructions specific to your operating system (Windows, macOS, or Linux).
+1. **Install Docker:** To publish with Garden, you need to have Docker installed and running on your system. An easy way to install and manage Docker is through [Docker desktop](https://www.docker.com/products/docker-desktop). Follow the installation instructions specific to your operating system (Windows, macOS, or Linux).
 
 2. **Verify Docker Installation:** Once installed, you can verify that Docker Desktop is running correctly by opening a terminal or command prompt and typing:
 ```bash
@@ -12,20 +12,9 @@ docker --version
 ```
 This command should return the version of Docker installed on your system.
 
-### Docker Hub Account
-
-1. **Create a Docker Hub Account:** Garden uses Docker Hub, a cloud-based repository for Docker images, to store and manage containers. You need to create a free account on [Docker Hub](https://hub.docker.com/signup) if you don't already have one.
-
-2. **Create a Public Repository:** After setting up your Docker Hub account, create a public repository where you can push your Docker images. This repository will be used to store and share the Docker images of your projects.
-
-3. **Configure Docker Credentials:** Make sure to configure your Docker credentials on your system. This allows `garden-ai` to push and pull images to and from Docker Hub on your behalf. You can do this by running:
-```bash
-docker login
-```
-and entering your Docker Hub username and password when prompted.
 # Installation
 
-Installing the `garden-ai` python package contains both our SDK and our CLI. We _highly_ recommend installing the CLI with a virtual environment, using venv or conda.
+Installing the `garden-ai` python package contains both our SDK and our CLI. We _highly_ recommend installing the CLI with a virtual environment, using venv or conda. [pipx](https://pipx.pypa.io/stable/) works well too.
 
 Below are instructions for installing with venv.
 

--- a/docs/user_guide/tutorial.md
+++ b/docs/user_guide/tutorial.md
@@ -7,7 +7,6 @@ This means doing the following:
 - Create a new Garden using the CLI (`garden-ai garden create`)
 - Open a notebook using the CLI (`garden-ai notebook start`)
 - Define and decorate a function in the notebook to make it an `Entrypoint`
-	- Optional: debug the completed notebook (`garden-ai notebook debug`)
 - Publish the notebook using the CLI, attaching the `Entrypoint` to the `Garden` in the process (`garden-ai notebook publish`)
 - Test remote execution on our tutorial endpoint
 #### Prerequisites


### PR DESCRIPTION
Some docs fixes and tweaks.

## Overview

The biggest changes are:
- Remove lingering DockerHub mentions
- Mention `--requirements` and recommend it for specifying package versions.
- Move the debugging discussion to a FAQs page. Also include a tip on tensorflow with MacOS there.

## Discussion

I still want to take a proper crack at a second draft of the docs (#361 ) from a flow/pedagogy perspective. But this PR is just to make sure there's nothing glaringly missing/out of date for ambitious early adopters over the holidays.

## Testing

N/A. I did look over the preview and make sure formatting still looked normal.

## Documentation

All docs


<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--374.org.readthedocs.build/en/374/

<!-- readthedocs-preview garden-ai end -->