### PR TITLE
Handle Docker connection issues more gracefully

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,3 +4,5 @@ extend-ignore = E203
 exclude =
     fixtures
     demos
+per-file-ignores =
+    garden_ai/app/docker.py: W605

--- a/garden_ai/app/console.py
+++ b/garden_ai/app/console.py
@@ -1,5 +1,6 @@
 from rich.console import Console
 from rich.table import Table
+import typer
 
 from typing import List, Optional, Any
 
@@ -76,3 +77,10 @@ def get_local_entrypoint_rich_table(
         resource_table_cols=resource_table_cols,
         table_name=table_name,
     )
+
+
+# console.print(message, fg=typer.colors.RED, bold=True)
+
+
+def print_err(message: str):
+    console.print(message, style="bold red")

--- a/garden_ai/app/console.py
+++ b/garden_ai/app/console.py
@@ -1,6 +1,5 @@
 from rich.console import Console
 from rich.table import Table
-import typer
 
 from typing import List, Optional, Any
 
@@ -77,9 +76,6 @@ def get_local_entrypoint_rich_table(
         resource_table_cols=resource_table_cols,
         table_name=table_name,
     )
-
-
-# console.print(message, fg=typer.colors.RED, bold=True)
 
 
 def print_err(message: str):

--- a/garden_ai/app/docker.py
+++ b/garden_ai/app/docker.py
@@ -1,0 +1,50 @@
+import typer
+
+from garden_ai.containers import get_docker_client, DockerStartFailure
+from garden_ai.app.console import print_err
+
+docker_app = typer.Typer(name="docker", no_args_is_help=True)
+
+ASCII_FLOWER = """
+     /\^/`\\
+    | \/   |
+    | |    |
+    \ \    /
+     '\\\\//'
+       ||
+       ||
+       ||
+       ||  ,
+   |\  ||  |\\
+   | | ||  | |
+   | | || / /
+    \ \||/ /
+jgs  `\\//`
+    ^^^^^^^^"""
+
+
+@docker_app.command()
+def check(
+    verbose: bool = typer.Option(False, "-v", "--verbose"),
+):
+    """Check if Garden can access Docker on your computer.
+
+    If Garden can't access Docker and it's not clear what the problem is,
+    using --verbose will print out a full stack trace.
+    """
+    try:
+        client = get_docker_client()
+        client.ping()
+        typer.echo("Docker is running and accessible. Happy Gardening!")
+        typer.secho(ASCII_FLOWER, fg=typer.colors.GREEN)
+    except DockerStartFailure as e:
+        print_err("Garden can't access Docker on your computer.")
+        if e.helpful_explanation:
+            print_err(e.helpful_explanation)
+        else:
+            print_err(
+                "This doesn't look like one of the typical error cases. Printing error from Docker:"
+            )
+            typer.echo(e.original_exception)
+        if verbose:
+            raise e

--- a/garden_ai/app/main.py
+++ b/garden_ai/app/main.py
@@ -8,6 +8,7 @@ import typer
 from garden_ai.app.garden import garden_app
 from garden_ai.app.entrypoint import entrypoint_app
 from garden_ai.app.notebook import notebook_app
+from garden_ai.app.docker import docker_app
 
 from garden_ai import GardenClient, GardenConstants
 from garden_ai._version import __version__
@@ -22,6 +23,7 @@ app = typer.Typer(no_args_is_help=True)
 app.add_typer(garden_app)
 app.add_typer(entrypoint_app)
 app.add_typer(notebook_app)
+app.add_typer(docker_app)
 
 
 def show_version(show: bool):

--- a/garden_ai/app/notebook.py
+++ b/garden_ai/app/notebook.py
@@ -17,6 +17,8 @@ from garden_ai.containers import (
     build_notebook_session_image,
     push_image_to_public_repo,
     start_container_with_notebook,
+    get_docker_client,
+    DockerStartFailure,
 )
 from garden_ai.local_data import _get_notebook_base_image, _put_notebook_base_image
 from garden_ai.utils.notebooks import (
@@ -32,6 +34,39 @@ notebook_app = typer.Typer(name="notebook")
 BASE_IMAGE_NAMES = ", ".join(
     ["'" + image_name + "'" for image_name in GardenConstants.PREMADE_IMAGES.keys()]
 )
+
+
+def print_err(message: str):
+    typer.secho(message, fg=typer.colors.RED, bold=True)
+
+
+class DockerClientSession:
+    def handle_docker_start_failure(self, e: DockerStartFailure):
+        print_err("Garden can't access Docker on your computer.")
+        if e.helpful_explanation:
+            print_err(e.helpful_explanation)
+            print_err(
+                "If that doesn't work, use `garden-ai docker check` to troubleshoot."
+            )
+        else:
+            print_err(
+                "This doesn't look like one of the typical error cases. Printing error from Docker:"
+            )
+            typer.echo(e.original_exception)
+        raise typer.Exit(1)
+
+    # We're most likely to see this error raised from get_docker_client,
+    def __enter__(self):
+        try:
+            return get_docker_client()
+        except DockerStartFailure as e:
+            self.handle_docker_start_failure(e)
+
+    # but if the user's Docker daemon shuts down partway through the session
+    # we'll catch that here.
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is DockerStartFailure:
+            self.handle_docker_start_failure(exc_val)
 
 
 @notebook_app.callback(no_args_is_help=True)
@@ -142,16 +177,16 @@ def start(
         f"If you start this notebook again from the same folder, it will use this image by default."
     )
 
-    docker_client = docker.from_env()
-    # pre-bake local image with garden-ai and additional user requirements
-    local_base_image_id = build_image_with_dependencies(
-        docker_client, base_image_uri, requirements_path
-    )
-    # start container and listen for Ctrl-C
-    container = start_container_with_notebook(
-        docker_client, notebook_path, local_base_image_id, pull=False
-    )
-    _register_container_sigint_handler(container)
+    with DockerClientSession() as docker_client:
+        # pre-bake local image with garden-ai and additional user requirements
+        local_base_image_id = build_image_with_dependencies(
+            docker_client, base_image_uri, requirements_path
+        )
+        # start container and listen for Ctrl-C
+        container = start_container_with_notebook(
+            docker_client, notebook_path, local_base_image_id, pull=False
+        )
+        _register_container_sigint_handler(container)
 
     typer.echo(
         f"Notebook started! Opening http://127.0.0.1:8888/notebooks/{notebook_path.name}?token={JUPYTER_TOKEN} "
@@ -270,29 +305,32 @@ def debug(
     Changes to the notebook file will NOT persist after the container shuts down.
     Quit the process with Ctrl-C or by shutting down jupyter from the browser.
     """
-    docker_client = docker.from_env()
-    base_image = _get_notebook_base_image(path) or "gardenai/base:python-3.10-jupyter"
 
-    if requirements_path is not None:
-        _validate_requirements_path(requirements_path)
+    with DockerClientSession() as docker_client:
+        base_image = (
+            _get_notebook_base_image(path) or "gardenai/base:python-3.10-jupyter"
+        )
 
-    local_base_image_id = build_image_with_dependencies(
-        docker_client, base_image, requirements_path
-    )
+        if requirements_path is not None:
+            _validate_requirements_path(requirements_path)
 
-    image = build_notebook_session_image(docker_client, path, local_base_image_id)
-    if image is None:
-        typer.echo("Failed to build image.")
-        raise typer.Exit(1)
-    image_name = str(image.id)  # str used to guarantee type-check
+        local_base_image_id = build_image_with_dependencies(
+            docker_client, base_image, requirements_path
+        )
 
-    top_level_dir = Path(__file__).parent.parent
-    debug_path = top_level_dir / "notebook_templates" / "debug.ipynb"
+        image = build_notebook_session_image(docker_client, path, local_base_image_id)
+        if image is None:
+            typer.echo("Failed to build image.")
+            raise typer.Exit(1)
+        image_name = str(image.id)  # str used to guarantee type-check
 
-    container = start_container_with_notebook(
-        docker_client, debug_path, image_name, mount=False, pull=False
-    )
-    _register_container_sigint_handler(container)
+        top_level_dir = Path(__file__).parent.parent
+        debug_path = top_level_dir / "notebook_templates" / "debug.ipynb"
+
+        container = start_container_with_notebook(
+            docker_client, debug_path, image_name, mount=False, pull=False
+        )
+        _register_container_sigint_handler(container)
 
     typer.echo(
         f"Notebook started! Opening http://127.0.0.1:8888/notebooks/{debug_path.name}?token={JUPYTER_TOKEN} "
@@ -385,44 +423,48 @@ def publish(
     # Push the notebook to the Garden API
     notebook_url = client.upload_notebook(notebook_contents, notebook_path.name)
 
-    # Build the image
-    docker_client = docker.from_env()
-    if requirements_path:
-        _validate_requirements_path(requirements_path)
+    with DockerClientSession() as docker_client:
+        # Build the image
+        if requirements_path:
+            _validate_requirements_path(requirements_path)
 
-    local_base_image_id = build_image_with_dependencies(
-        docker_client, base_image_uri, requirements_path, print_logs=verbose, pull=True
-    )
-    image = build_notebook_session_image(
-        docker_client,
-        notebook_path,
-        local_base_image_id,
-        print_logs=verbose,
-        pull=False,
-    )
-    if image is None:
-        typer.echo("Failed to build image.")
-        raise typer.Exit(1)
-    typer.echo(f"Built image: {image}")
+        local_base_image_id = build_image_with_dependencies(
+            docker_client,
+            base_image_uri,
+            requirements_path,
+            print_logs=verbose,
+            pull=True,
+        )
+        image = build_notebook_session_image(
+            docker_client,
+            notebook_path,
+            local_base_image_id,
+            print_logs=verbose,
+            pull=False,
+        )
+        if image is None:
+            typer.echo("Failed to build image.")
+            raise typer.Exit(1)
+        typer.echo(f"Built image: {image}")
 
-    # generate tag and push image to ECR
-    auth_config = client._get_auth_config_for_ecr_push()
+        # generate tag and push image to ECR
+        auth_config = client._get_auth_config_for_ecr_push()
 
-    timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-    image_tag = f"{notebook_path.stem}-{timestamp}"
+        timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        image_tag = f"{notebook_path.stem}-{timestamp}"
 
-    typer.echo(f"Pushing image to repository: {GardenConstants.GARDEN_ECR_REPO}")
-    full_image_location = push_image_to_public_repo(
-        docker_client, image, image_tag, auth_config, print_logs=verbose
-    )
-    typer.echo(f"Successfully pushed image to: {full_image_location}")
-    client._register_and_publish_from_user_image(
-        docker_client,
-        image,
-        base_image_uri,
-        full_image_location,
-        notebook_url,
-    )
+        typer.echo(f"Pushing image to repository: {GardenConstants.GARDEN_ECR_REPO}")
+        full_image_location = push_image_to_public_repo(
+            docker_client, image, image_tag, auth_config, print_logs=verbose
+        )
+        typer.echo(f"Successfully pushed image to: {full_image_location}")
+        client._register_and_publish_from_user_image(
+            docker_client,
+            image,
+            base_image_uri,
+            full_image_location,
+            notebook_url,
+        )
 
 
 def _validate_requirements_path(requirements_path: Path):

--- a/garden_ai/app/notebook.py
+++ b/garden_ai/app/notebook.py
@@ -11,6 +11,7 @@ import docker  # type: ignore
 import typer
 
 from garden_ai import GardenClient, GardenConstants
+from garden_ai.app.console import print_err
 from garden_ai.containers import (
     JUPYTER_TOKEN,
     build_image_with_dependencies,
@@ -34,10 +35,6 @@ notebook_app = typer.Typer(name="notebook")
 BASE_IMAGE_NAMES = ", ".join(
     ["'" + image_name + "'" for image_name in GardenConstants.PREMADE_IMAGES.keys()]
 )
-
-
-def print_err(message: str):
-    typer.secho(message, fg=typer.colors.RED, bold=True)
 
 
 class DockerClientSession:

--- a/garden_ai/containers.py
+++ b/garden_ai/containers.py
@@ -52,11 +52,10 @@ def handle_docker_errors(func):
             # If the daemon is running but you don't have permissions, Linux says "Permission denied".
             # This is less common on MacOS.
             elif "PermissionError" in error_message:
-                unix_username = os.getlogin()
                 explanation = (
                     "It looks like your current user does not have permissions to use Docker. "
                     "Try adding your user to your OS's Docker group with the following command: "
-                    f"sudo usermod -aG docker {unix_username}"
+                    "sudo usermod -aG docker ${whoami}"
                 )
 
             raise DockerStartFailure(e, explanation)

--- a/tests/cli/test_notebook.py
+++ b/tests/cli/test_notebook.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch, Mock
 from typer import Exit
-from docker.errors import DockerException
+from docker.errors import DockerException  # type: ignore
 
 from garden_ai.app.notebook import DockerClientSession
 from garden_ai.containers import DockerStartFailure

--- a/tests/cli/test_notebook.py
+++ b/tests/cli/test_notebook.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, Mock
 from typer import Exit
 from docker.errors import DockerException
 
-from garden_ai.app.notebook import DockerClientSession, DockerStartFailure
+from garden_ai.app.notebook import DockerClientSession
 from garden_ai.containers import DockerStartFailure
 
 
@@ -18,7 +18,7 @@ def test_docker_client_session():
         with patch(
             "garden_ai.app.notebook.get_docker_client", side_effect=docker_start_failure
         ):
-            with DockerClientSession() as docker_client:
+            with DockerClientSession():
                 # Just needed to trigger __enter__
                 pass
     assert exc_info.value.exit_code == 1, "Exit code is not 1."

--- a/tests/cli/test_notebook.py
+++ b/tests/cli/test_notebook.py
@@ -1,0 +1,24 @@
+import pytest
+from unittest.mock import patch, Mock
+from typer import Exit
+from docker.errors import DockerException
+
+from garden_ai.app.notebook import DockerClientSession, DockerStartFailure
+from garden_ai.containers import DockerStartFailure
+
+
+def test_docker_client_session():
+    mock_docker_exception = Mock(spec=DockerException)
+    docker_start_failure = DockerStartFailure(
+        mock_docker_exception, "turn it off and back on again"
+    )
+
+    # Does it trigger a clean typer.Exit when we can't connect to Docker?
+    with pytest.raises(Exit) as exc_info:
+        with patch(
+            "garden_ai.app.notebook.get_docker_client", side_effect=docker_start_failure
+        ):
+            with DockerClientSession() as docker_client:
+                # Just needed to trigger __enter__
+                pass
+    assert exc_info.value.exit_code == 1, "Exit code is not 1."

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -264,3 +264,50 @@ def test_build_image_with_dependencies(mock_docker_client, mocker, requirements_
         "sha256:2d6e000f4f63e1234567a1234567890123456789a1234567890b1234567890c1"
     )
     assert image_id == expected_image_id
+
+
+def test_handle_docker_errors():
+    def test_func():
+        return "Hello, World!"
+
+    wrapped_test_func = garden_ai.containers.handle_docker_errors(test_func)
+
+    # Test when no exception is raised
+    assert wrapped_test_func() == "Hello, World!"
+
+    # Test variations on DockerExceptions that are thrown when Garden can't access Docker
+    error_message_output_pairs = [
+        (
+            "Error while fetching server API version: ConnectionRefusedError",
+            "Could not connect to your local Docker daemon. Double check that Docker is running.",
+        ),
+        (
+            "Error while fetching server API version: PermissionError",
+            "It looks like your current user does not have permissions to use Docker.",
+        ),
+        ("Error while fetching server API version: SomeOtherError", "SomeOtherError"),
+    ]
+
+    for error_message, expected_output in error_message_output_pairs:
+        with pytest.raises(garden_ai.containers.DockerStartFailure) as excinfo:
+
+            def test_func_error():
+                raise docker.errors.DockerException(error_message)
+
+            wrapped_test_func_error = garden_ai.containers.handle_docker_errors(
+                test_func_error
+            )
+            wrapped_test_func_error()
+        assert expected_output in str(excinfo.value)
+
+    # Test a Docker error unrelated to startup. The docker.errors.DockerException should be raised as-is.
+    with pytest.raises(docker.errors.DockerException) as excinfo:
+
+        def test_func_error():
+            raise docker.errors.DockerException("Some Docker error")
+
+        wrapped_test_func_error = garden_ai.containers.handle_docker_errors(
+            test_func_error
+        )
+        wrapped_test_func_error()
+    assert "Some Docker error" in str(excinfo.value)


### PR DESCRIPTION
Fixes #376 

## Overview

This PR adds error handling that catches the case when Garden can't invoke Docker at all. The common cases of this we've seen are when the daemon is off and when the user isn't in the right group to use Docker so they get a PermissionDenied.

This PR also adds a new `garden-ai docker check` command. This is a sanity check command that users can run to confirm they have Docker set up correctly. They can also run `garden-ai docker check --verbose` to get the big old stack trace if that helps.

## Discussion

Here's what it looks like.

### Trying to run a `notebook` command but can't connect to Docker.  

<img width="808" alt="Screenshot 2024-01-18 at 3 19 04 PM" src="https://github.com/Garden-AI/garden/assets/6283143/0c45fa6e-2da3-42d2-9f78-e56c95f3b985">

### Running `docker check` when you can't connect.  
  
<img width="677" alt="Screenshot 2024-01-18 at 3 18 32 PM" src="https://github.com/Garden-AI/garden/assets/6283143/7040c3c7-dbce-4cf4-b961-36226e87e05a">

  
### Running `docker check` when you can connect :)
<img width="456" alt="Screenshot 2024-01-18 at 3 19 27 PM" src="https://github.com/Garden-AI/garden/assets/6283143/81445a43-af04-4109-bd54-0afcd555b9a6">


## Testing

I tested the scenarios on my MacOS machine and on a Linux machine to find the error messages that Docker propagates. I tested the logic on my machine by turning the Docker daemon on and off. I also added new unit tests for the error handling utilities.

## Documentation

None yet, but next in line for me is #380. A lot of the use for `garden-ai docker check` will be telling users to run it to make sure they're good to start the tutorial.

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--389.org.readthedocs.build/en/389/

<!-- readthedocs-preview garden-ai end -->