### PR TITLE
speed up your cold imports 1.6x with One Weird Trick 

### DIFF
--- a/garden_ai/containers.py
+++ b/garden_ai/containers.py
@@ -8,7 +8,6 @@ from tempfile import TemporaryDirectory
 from typing import Optional
 
 import docker  # type: ignore
-import nbconvert  # type: ignore
 
 from garden_ai.constants import GardenConstants
 
@@ -195,6 +194,8 @@ def build_notebook_session_image(
         temp_notebook_path = temp_dir_path / notebook_path.name
         with temp_notebook_path.open("w+") as f:
             f.write(notebook_path.read_text())
+
+        import nbconvert  # lazy import to speed up garden cold start
 
         # convert notebook to sister script in temp dir
         exporter = nbconvert.PythonExporter()


### PR DESCRIPTION
## Overview

😤 Scientists HATE him 😤! see how this **One Weird Trick** can save you _countless_ (~4.5) seconds whenever you  `import garden_ai`* 

\* for the first time
** in a new, completely isolated virtual environment 
*** only noticeable on apple silicon

## Discussion

Turns out that nearly all of the ~10-15s cold start delay we've noticed in our study halls can be traced to our big dependencies with C extension modules: `pydantic`, which is the majority of the slowdown but too difficult to lazy import everywhere; and `nbconvert`, which was trivial to lazy import since it's only used once in `containers.py`. Pretty consistent 60/40 split in terms of total contribution to import time on my machine. 


## Testing

I have a little profiling script that sets up a new environment, installs a package, and then profiles how long that package & its dependencies take to import with `python -X importtime -c 'import garden_ai'`. I also used `tuna` to visualize the import profiles, but I think `snakeviz` can handle that too. Manually running stuff like `python -c 'import pydantic' && python -X importtime -c 'import garden_ai'` helped sanity check, too 

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--390.org.readthedocs.build/en/390/

<!-- readthedocs-preview garden-ai end -->