### PR TITLE
383 don't run tests during publication

### DIFF
--- a/garden_ai/app/notebook.py
+++ b/garden_ai/app/notebook.py
@@ -315,7 +315,9 @@ def debug(
             docker_client, base_image, requirements_path
         )
 
-        image = build_notebook_session_image(docker_client, path, local_base_image_id)
+        image = build_notebook_session_image(
+            docker_client, path, local_base_image_id, pull=False
+        )
         if image is None:
             typer.echo("Failed to build image.")
             raise typer.Exit(1)

--- a/garden_ai/containers.py
+++ b/garden_ai/containers.py
@@ -191,7 +191,8 @@ def build_notebook_session_image(
     """
     # build lines of 'ENV VAR=value\n' commands for dockerfile below
     env_vars = env_vars or {}
-    env_vars["GARDEN_SKIP_TESTS"] = True
+    if "GARDEN_SKIP_TESTS" not in env_vars:
+        env_vars["GARDEN_SKIP_TESTS"] = True
     env_commands = "\n".join(f"ENV {k}={v}" for (k, v) in env_vars.items())
 
     with TemporaryDirectory() as temp_dir:

--- a/garden_ai/entrypoints.py
+++ b/garden_ai/entrypoints.py
@@ -280,7 +280,7 @@ def entrypoint_test(entrypoint_func: Callable):
 
             # this flag is set during publication time in
             # containers.build_notebook_session_image
-            if "GARDEN_SKIP_TESTS" in os.environ:
+            if os.environ.get("GARDEN_SKIP_TESTS") == str(True):
                 return None
             else:
                 return test_func(*args, **kwargs)

--- a/garden_ai/entrypoints.py
+++ b/garden_ai/entrypoints.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 import logging
 from datetime import datetime
+from functools import wraps
 from typing import Any, List, Optional, Union, Callable
 from uuid import UUID
 
@@ -245,14 +246,46 @@ def garden_entrypoint(
 
 
 def entrypoint_test(entrypoint_func: Callable):
-    def decorate(test_func):
-        if not entrypoint_func or not entrypoint_func._garden_entrypoint:
-            raise ValueError("Please pass in a valid entrypoint function")
+    """Mark a function as a 'test function' of an entrypoint.
 
+    Marked test functions won't run at publication time, so they can be safely
+    called at the top-level of a notebook without causing unintended side-effects.
+
+    Example:
+
+        ```python
+        @garden_entrypoint(...)
+        def my_entrypoint(*args, **kwargs):
+            ...
+
+        @entrypoint_test(my_entrypoint)
+        def test_my_entrypoint():
+            ...
+            results = my_entrypoint(...)
+            ...
+            return results
+
+        ```
+    """
+    if not entrypoint_func or not entrypoint_func._garden_entrypoint:  # type: ignore
+        raise ValueError("Please pass in a valid entrypoint function")
+
+    def decorate(test_func):
         test_function_text = inspect.getsource(test_func)
         entrypoint_func._garden_entrypoint._test_functions.append(test_function_text)
 
-        return test_func
+        @wraps(test_func)
+        def inner(*args, **kwargs):
+            import os
+
+            # this flag is set during publication time in
+            # containers.build_notebook_session_image
+            if "GARDEN_SKIP_TESTS" in os.environ:
+                return None
+            else:
+                return test_func(*args, **kwargs)
+
+        return inner
 
     return decorate
 

--- a/garden_ai/notebook_templates/sklearn.ipynb
+++ b/garden_ai/notebook_templates/sklearn.ipynb
@@ -1,206 +1,215 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "H24yDUiVP5-n"
-      },
-      "source": [
-        "## Your Model 🌱Garden🌱 Execution Environment\n",
-        "\n",
-        "Use this notebook to write a function that executes your model(s). Tag that function with the `@garden_entrypoint` decorator.\n",
-        "\n",
-        "Garden will take this notebook and build a container with it. When Garden executes your `@garden_entrypoint`, it will be like like you have just run all the cells of this notebook once. So you can install libraries with `!pip install` and your function can use those libraries. You can also define helper functions and constants to use in your `@garden_entrypoint`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "qww1_jOzP5S9"
-      },
-      "outputs": [],
-      "source": [
-        "from garden_ai.model_connectors import HFConnector\n",
-        "from garden_ai import EntrypointMetadata, garden_entrypoint"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "b0s7Bealdp8M"
-      },
-      "outputs": [],
-      "source": [
-        "import pandas as pd\n",
-        "import sklearn\n",
-        "import joblib"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "3aikfsCRdrEZ"
-      },
-      "source": [
-        "### Model connectors\n",
-        "\n",
-        "Model connectors let Garden import metadata about your model.\n",
-        "They also have a `stage` method that you can use to download your model weights."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "H7em6SwMdvkt"
-      },
-      "outputs": [],
-      "source": [
-        "my_hugging_face_repo = HFConnector(\"garden-ai/sample_sklearn_model\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "FTziKOq7d1Qs"
-      },
-      "source": [
-        "### Entrypoint metadata\n",
-        "\n",
-        "\n",
-        "To publish your function, Garden needs metadata so that other users can discover it.\n",
-        "Edit this EntrypointMetadata object to describe your function.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "PHtZD33NhCEF"
-      },
-      "outputs": [],
-      "source": [
-        "my_entrypoint_meta = EntrypointMetadata(\n",
-        "    title=\"My Inference Function\",\n",
-        "    description=\"Write a longer description here so that people know what your entrypoint does.\",\n",
-        "    authors=[\"you\", \"your collaborator\"],\n",
-        "    tags=[\"materials science\", \"your actual field\"]\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gnNDYs4PhKKO"
-      },
-      "source": [
-        "### Helper Functions\n",
-        "\n",
-        "Define any helper functions you need and use them in the function you want to let people run remotely"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "hhd9FNB9hN0a"
-      },
-      "outputs": [],
-      "source": [
-        "def preprocess(input_df: pd.DataFrame) -> pd.DataFrame:\n",
-        "    input_df.fillna(0, inplace=True)\n",
-        "    return input_df"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bDPkWjAShSKr"
-      },
-      "source": [
-        "### Write your entrypoint function that will run remotely\n",
-        "\n",
-        "The `@garden_entrypoint` decorator makes this function available to run in your garden when you publish the notebook.\n",
-        "Download your model weights and call your model in this function.\n",
-        "\n",
-        "In the decorator be sure to include:\n",
-        "- your entrypoint metadata,\n",
-        "- connectors for any models you're using,\n",
-        "- the DOI of the garden you want this entrypoint to be found in. (Check `garden-ai garden list` for the DOIs of your gardens.)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "6ls-44Wehec9"
-      },
-      "outputs": [],
-      "source": [
-        "@garden_entrypoint(metadata=my_entrypoint_meta,  model_connectors=[my_hugging_face_repo], garden_doi=\"10.23677/my-garden-doi\")\n",
-        "def run_my_model(input_df: pd.DataFrame) -> pd.DataFrame:\n",
-        "    cleaned_df = preprocess(input_df)\n",
-        "    download_path = my_hugging_face_repo.stage()\n",
-        "    model = joblib.load(f\"{download_path}/model.pkl\")\n",
-        "    return model.predict(cleaned_df)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dK3PHq2fhgxp"
-      },
-      "source": [
-        "### Test your entrypoint function\n",
-        "\n",
-        "Finally, make sure your `@garden_entrypoint` works!\n",
-        "When Garden makes a container from your notebook, it runs all the cells in order and saves the notebook. Then users invoke your `@garden_entrypoint` in the context of the notebook.\n",
-        "\n",
-        "If you can hit \"Kernel\" -> \"Restart and run all cells\" and your test below works, your `@garden_entrypoint` will work in your garden!\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "pn2aa8wnhu2u"
-      },
-      "outputs": [],
-      "source": [
-        "# Replace with input that is relevant for your garden_entrypoint\n",
-        "example_input = pd.DataFrame({\n",
-        "    'A': [1, 2, None, 4],\n",
-        "    'B': [None, 2, 3, 4],\n",
-        "    'C': [1, 2, 3, 4]\n",
-        "})\n",
-        "run_my_model(example_input)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "A9-UTFHAmCEq"
-      },
-      "outputs": [],
-      "source": []
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.10.9"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "H24yDUiVP5-n"
+   },
+   "source": [
+    "## Your Model 🌱Garden🌱 Execution Environment\n",
+    "\n",
+    "Use this notebook to write a function that executes your model(s). Tag that function with the `@garden_entrypoint` decorator.\n",
+    "\n",
+    "Garden will take this notebook and build a container with it. When Garden executes your `@garden_entrypoint`, it will be like like you have just run all the cells of this notebook once. So you can install libraries with `!pip install` and your function can use those libraries. You can also define helper functions and constants to use in your `@garden_entrypoint`."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "qww1_jOzP5S9"
+   },
+   "outputs": [],
+   "source": [
+    "from garden_ai.model_connectors import HFConnector\n",
+    "from garden_ai import EntrypointMetadata, garden_entrypoint, entrypoint_test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "b0s7Bealdp8M"
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import sklearn\n",
+    "import joblib"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3aikfsCRdrEZ"
+   },
+   "source": [
+    "### Model connectors\n",
+    "\n",
+    "Model connectors let Garden import metadata about your model.\n",
+    "They also have a `stage` method that you can use to download your model weights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "H7em6SwMdvkt"
+   },
+   "outputs": [],
+   "source": [
+    "my_hugging_face_repo = HFConnector(\"garden-ai/sample_sklearn_model\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "FTziKOq7d1Qs"
+   },
+   "source": [
+    "### Entrypoint metadata\n",
+    "\n",
+    "\n",
+    "To publish your function, Garden needs metadata so that other users can discover it.\n",
+    "Edit this EntrypointMetadata object to describe your function.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "PHtZD33NhCEF"
+   },
+   "outputs": [],
+   "source": [
+    "my_entrypoint_meta = EntrypointMetadata(\n",
+    "    title=\"My Inference Function\",\n",
+    "    description=\"Write a longer description here so that people know what your entrypoint does.\",\n",
+    "    authors=[\"you\", \"your collaborator\"],\n",
+    "    tags=[\"materials science\", \"your actual field\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gnNDYs4PhKKO"
+   },
+   "source": [
+    "### Helper Functions\n",
+    "\n",
+    "Define any helper functions you need and use them in the function you want to let people run remotely"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "hhd9FNB9hN0a"
+   },
+   "outputs": [],
+   "source": [
+    "def preprocess(input_df: pd.DataFrame) -> pd.DataFrame:\n",
+    "    input_df.fillna(0, inplace=True)\n",
+    "    return input_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bDPkWjAShSKr"
+   },
+   "source": [
+    "### Write your entrypoint function that will run remotely\n",
+    "\n",
+    "The `@garden_entrypoint` decorator makes this function available to run in your garden when you publish the notebook.\n",
+    "Download your model weights and call your model in this function.\n",
+    "\n",
+    "In the decorator be sure to include:\n",
+    "- your entrypoint metadata,\n",
+    "- connectors for any models you're using,\n",
+    "- the DOI of the garden you want this entrypoint to be found in. (Check `garden-ai garden list` for the DOIs of your gardens.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "6ls-44Wehec9"
+   },
+   "outputs": [],
+   "source": [
+    "@garden_entrypoint(metadata=my_entrypoint_meta,  model_connectors=[my_hugging_face_repo], garden_doi=\"10.23677/my-garden-doi\")\n",
+    "def run_my_model(input_df: pd.DataFrame) -> pd.DataFrame:\n",
+    "    cleaned_df = preprocess(input_df)\n",
+    "    download_path = my_hugging_face_repo.stage()\n",
+    "    model = joblib.load(f\"{download_path}/model.pkl\")\n",
+    "    return model.predict(cleaned_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dK3PHq2fhgxp"
+   },
+   "source": [
+    "### Test your entrypoint function\n",
+    "\n",
+    "Finally, make sure your `@garden_entrypoint` works!\n",
+    "When Garden makes a container from your notebook, it runs all the cells in order and saves the notebook. Then users invoke your `@garden_entrypoint` in the context of the notebook.\n",
+    "\n",
+    "If you can hit \"Kernel\" -> \"Restart and run all cells\" and your test below works, your `@garden_entrypoint` will work in your garden!\n",
+    "\n",
+    "\n",
+    "Note on testing: any test functions that call your entrypoint (like the one below) should be marked with `@entrypoint_test(<entrypoint_being_tested>)`. This is because calling an entrypoint typically causes side-effects (such as downloading your model weights to disk) that shouldn't be \"baked in\" to the environment of the final published notebook. \n",
+    "\n",
+    "Anything marked with `@entrypoint_test` won't be run at publication time, so you don't need to remember to comment out your test code before publishing. We'll also use `@entrypoint_test` functions as example code for others to see how your entrypoint expects to be called. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "A9-UTFHAmCEq"
+   },
+   "outputs": [],
+   "source": [
+    "@entrypoint_test(run_my_model)\n",
+    "def test_run_my_model():\n",
+    "    # Replace with input that is relevant for your garden_entrypoint\n",
+    "    example_input = pd.DataFrame({\n",
+    "        'A': [1, 2, None, 4],\n",
+    "        'B': [None, 2, 3, 4],\n",
+    "        'C': [1, 2, 3, 4]\n",
+    "    })\n",
+    "    return run_my_model(example_input)\n",
+    "    \n",
+    "test_run_my_model()"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/garden_ai/notebook_templates/tensorflow.ipynb
+++ b/garden_ai/notebook_templates/tensorflow.ipynb
@@ -1,206 +1,213 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "H24yDUiVP5-n"
-      },
-      "source": [
-        "## Your Model 🌱Garden🌱 Execution Environment\n",
-        "\n",
-        "Use this notebook to write a function that executes your model(s). Tag that function with the `@garden_entrypoint` decorator.\n",
-        "\n",
-        "Garden will take this notebook and build a container with it. When Garden executes your `@garden_entrypoint`, it will be like like you have just run all the cells of this notebook once. So you can install libraries with `!pip install` and your function can use those libraries. You can also define helper functions and constants to use in your `@garden_entrypoint`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "qww1_jOzP5S9"
-      },
-      "outputs": [],
-      "source": [
-        "from garden_ai.model_connectors import HFConnector\n",
-        "from garden_ai import EntrypointMetadata, garden_entrypoint"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "b0s7Bealdp8M"
-      },
-      "outputs": [],
-      "source": [
-        "import tensorflow as tf\n",
-        "from tensorflow.keras.models import load_model"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "3aikfsCRdrEZ"
-      },
-      "source": [
-        "### Model connectors\n",
-        "\n",
-        "Model connectors let Garden import metadata about your model.\n",
-        "They also have a `stage` method that you can use to download your model weights."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "H7em6SwMdvkt"
-      },
-      "outputs": [],
-      "source": [
-        "my_hugging_face_repo = HFConnector(\"garden-ai/sample_tensorflow_model\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "FTziKOq7d1Qs"
-      },
-      "source": [
-        "### Entrypoint metadata\n",
-        "\n",
-        "\n",
-        "To publish your function, Garden needs metadata so that other users can discover it.\n",
-        "Edit this EntrypointMetadata object to describe your function.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "PHtZD33NhCEF"
-      },
-      "outputs": [],
-      "source": [
-        "my_entrypoint_meta = EntrypointMetadata(\n",
-        "    title=\"My Inference Function\",\n",
-        "    description=\"Write a longer description here so that people know what your entrypoint does.\",\n",
-        "    authors=[\"you\", \"your collaborator\"],\n",
-        "    tags=[\"materials science\", \"your actual field\"]\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gnNDYs4PhKKO"
-      },
-      "source": [
-        "### Helper Functions\n",
-        "\n",
-        "Define any helper functions you need and use them in the function you want to let people run remotely"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "hhd9FNB9hN0a"
-      },
-      "outputs": [],
-      "source": [
-        "def preprocess(input_tensor):\n",
-        "    min_val, max_val = 0, 1\n",
-        "    min_tensor = tf.reduce_min(input_tensor)\n",
-        "    max_tensor = tf.reduce_max(input_tensor)\n",
-        "    scaled_tensor = (input_tensor - min_tensor) / (max_tensor - min_tensor)\n",
-        "    scaled_tensor = scaled_tensor * (max_val - min_val) + min_val\n",
-        "    return scaled_tensor"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bDPkWjAShSKr"
-      },
-      "source": [
-        "### Write your entrypoint function that will run remotely\n",
-        "\n",
-        "The `@garden_entrypoint` decorator makes this function available to run in your garden when you publish the notebook.\n",
-        "Download your model weights and call your model in this function.\n",
-        "\n",
-        "In the decorator be sure to include:\n",
-        "- your entrypoint metadata,\n",
-        "- connectors for any models you're using,\n",
-        "- the DOI of the garden you want this entrypoint to be found in. (Check `garden-ai garden list` for the DOIs of your gardens.)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "6ls-44Wehec9"
-      },
-      "outputs": [],
-      "source": [
-        "@garden_entrypoint(metadata=my_entrypoint_meta,  model_connectors=[my_hugging_face_repo], garden_doi=\"10.23677/my-garden-doi\")\n",
-        "def run_my_model(input_tensor):\n",
-        "    scaled_tensor = preprocess(input_tensor)\n",
-        "    download_path = my_hugging_face_repo.stage()\n",
-        "    model = load_model(f\"{download_path}/model.keras\")\n",
-        "    return model.predict(scaled_tensor)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dK3PHq2fhgxp"
-      },
-      "source": [
-        "### Test your entrypoint function\n",
-        "\n",
-        "Finally, make sure your `@garden_entrypoint` works!\n",
-        "When Garden makes a container from your notebook, it runs all the cells in order and saves the notebook. Then users invoke your `@garden_entrypoint` in the context of the notebook.\n",
-        "\n",
-        "If you can hit \"Kernel\" -> \"Restart and run all cells\" and your test below works, your `@garden_entrypoint` will work in your garden!\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "pn2aa8wnhu2u"
-      },
-      "outputs": [],
-      "source": [
-        "# Replace with input that is relevant for your garden_entrypoint\n",
-        "example_input = tf.constant([[1, 2],\n",
-        "                             [3, 4],\n",
-        "                             [5, 6]], dtype=tf.float16)\n",
-        "run_my_model(example_input)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "A9-UTFHAmCEq"
-      },
-      "outputs": [],
-      "source": []
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "H24yDUiVP5-n"
+   },
+   "source": [
+    "## Your Model 🌱Garden🌱 Execution Environment\n",
+    "\n",
+    "Use this notebook to write a function that executes your model(s). Tag that function with the `@garden_entrypoint` decorator.\n",
+    "\n",
+    "Garden will take this notebook and build a container with it. When Garden executes your `@garden_entrypoint`, it will be like like you have just run all the cells of this notebook once. So you can install libraries with `!pip install` and your function can use those libraries. You can also define helper functions and constants to use in your `@garden_entrypoint`."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "qww1_jOzP5S9"
+   },
+   "outputs": [],
+   "source": [
+    "from garden_ai.model_connectors import HFConnector\n",
+    "from garden_ai import EntrypointMetadata, garden_entrypoint, entrypoint_test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "b0s7Bealdp8M"
+   },
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "from tensorflow.keras.models import load_model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3aikfsCRdrEZ"
+   },
+   "source": [
+    "### Model connectors\n",
+    "\n",
+    "Model connectors let Garden import metadata about your model.\n",
+    "They also have a `stage` method that you can use to download your model weights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "H7em6SwMdvkt"
+   },
+   "outputs": [],
+   "source": [
+    "my_hugging_face_repo = HFConnector(\"garden-ai/sample_tensorflow_model\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "FTziKOq7d1Qs"
+   },
+   "source": [
+    "### Entrypoint metadata\n",
+    "\n",
+    "\n",
+    "To publish your function, Garden needs metadata so that other users can discover it.\n",
+    "Edit this EntrypointMetadata object to describe your function.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "PHtZD33NhCEF"
+   },
+   "outputs": [],
+   "source": [
+    "my_entrypoint_meta = EntrypointMetadata(\n",
+    "    title=\"My Inference Function\",\n",
+    "    description=\"Write a longer description here so that people know what your entrypoint does.\",\n",
+    "    authors=[\"you\", \"your collaborator\"],\n",
+    "    tags=[\"materials science\", \"your actual field\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gnNDYs4PhKKO"
+   },
+   "source": [
+    "### Helper Functions\n",
+    "\n",
+    "Define any helper functions you need and use them in the function you want to let people run remotely"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "hhd9FNB9hN0a"
+   },
+   "outputs": [],
+   "source": [
+    "def preprocess(input_tensor):\n",
+    "    min_val, max_val = 0, 1\n",
+    "    min_tensor = tf.reduce_min(input_tensor)\n",
+    "    max_tensor = tf.reduce_max(input_tensor)\n",
+    "    scaled_tensor = (input_tensor - min_tensor) / (max_tensor - min_tensor)\n",
+    "    scaled_tensor = scaled_tensor * (max_val - min_val) + min_val\n",
+    "    return scaled_tensor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bDPkWjAShSKr"
+   },
+   "source": [
+    "### Write your entrypoint function that will run remotely\n",
+    "\n",
+    "The `@garden_entrypoint` decorator makes this function available to run in your garden when you publish the notebook.\n",
+    "Download your model weights and call your model in this function.\n",
+    "\n",
+    "In the decorator be sure to include:\n",
+    "- your entrypoint metadata,\n",
+    "- connectors for any models you're using,\n",
+    "- the DOI of the garden you want this entrypoint to be found in. (Check `garden-ai garden list` for the DOIs of your gardens.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "6ls-44Wehec9"
+   },
+   "outputs": [],
+   "source": [
+    "@garden_entrypoint(metadata=my_entrypoint_meta,  model_connectors=[my_hugging_face_repo], garden_doi=\"10.23677/my-garden-doi\")\n",
+    "def run_my_model(input_tensor):\n",
+    "    scaled_tensor = preprocess(input_tensor)\n",
+    "    download_path = my_hugging_face_repo.stage()\n",
+    "    model = load_model(f\"{download_path}/model.keras\")\n",
+    "    return model.predict(scaled_tensor)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dK3PHq2fhgxp"
+   },
+   "source": [
+    "### Test your entrypoint function\n",
+    "\n",
+    "Finally, make sure your `@garden_entrypoint` works!\n",
+    "When Garden makes a container from your notebook, it runs all the cells in order and saves the notebook. Then users invoke your `@garden_entrypoint` in the context of the notebook.\n",
+    "\n",
+    "Note on testing: any test functions that call your entrypoint (like the one below) should be marked with `@entrypoint_test(<entrypoint_being_tested>)`. This is because calling an entrypoint typically causes side-effects (such as downloading your model weights to disk) that shouldn't be \"baked in\" to the environment of the final published notebook. \n",
+    "\n",
+    "Anything marked with `@entrypoint_test` won't be run at publication time, so you don't need to remember to comment out your test code before publishing. We'll also use `@entrypoint_test` functions as example code for others to see how your entrypoint expects to be called. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "pn2aa8wnhu2u"
+   },
+   "outputs": [],
+   "source": [
+    "@entrypoint_test(run_my_model)\n",
+    "def test_run_my_model():\n",
+    "    # Replace with input that is relevant for your garden_entrypoint\n",
+    "    example_input = tf.constant([[1, 2],\n",
+    "                                 [3, 4],\n",
+    "                                 [5, 6]], dtype=tf.float16)\n",
+    "    return run_my_model(example_input)\n",
+    "    \n",
+    "test_run_my_model()"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/garden_ai/notebook_templates/torch.ipynb
+++ b/garden_ai/notebook_templates/torch.ipynb
@@ -1,212 +1,228 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "H24yDUiVP5-n"
-      },
-      "source": [
-        "## Your Model 🌱Garden🌱 Execution Environment\n",
-        "\n",
-        "Use this notebook to write a function that executes your model(s). Tag that function with the `@garden_entrypoint` decorator.\n",
-        "\n",
-        "Garden will take this notebook and build a container with it. When Garden executes your `@garden_entrypoint`, it will be like like you have just run all the cells of this notebook once. So you can install libraries with `!pip install` and your function can use those libraries. You can also define helper functions and constants to use in your `@garden_entrypoint`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "qww1_jOzP5S9"
-      },
-      "outputs": [],
-      "source": [
-        "from garden_ai.model_connectors import HFConnector\n",
-        "from garden_ai import EntrypointMetadata, garden_entrypoint"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "b0s7Bealdp8M"
-      },
-      "outputs": [],
-      "source": [
-        "import torch"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "3aikfsCRdrEZ"
-      },
-      "source": [
-        "### Model connectors\n",
-        "\n",
-        "Model connectors let Garden import metadata about your model.\n",
-        "They also have a `stage` method that you can use to download your model weights."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "H7em6SwMdvkt"
-      },
-      "outputs": [],
-      "source": [
-        "my_hugging_face_repo = HFConnector(\"garden-ai/sample_sklearn_model\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "FTziKOq7d1Qs"
-      },
-      "source": [
-        "### Entrypoint metadata\n",
-        "\n",
-        "\n",
-        "To publish your function, Garden needs metadata so that other users can discover it.\n",
-        "Edit this EntrypointMetadata object to describe your function.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "PHtZD33NhCEF"
-      },
-      "outputs": [],
-      "source": [
-        "my_entrypoint_meta = EntrypointMetadata(\n",
-        "    title=\"My Inference Function\",\n",
-        "    description=\"Write a longer description here so that people know what your entrypoint does.\",\n",
-        "    authors=[\"you\", \"your collaborator\"],\n",
-        "    tags=[\"materials science\", \"your actual field\"]\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gnNDYs4PhKKO"
-      },
-      "source": [
-        "### Helper Functions\n",
-        "\n",
-        "Define any helper functions you need and use them in the function you want to let people run remotely"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "hhd9FNB9hN0a"
-      },
-      "outputs": [],
-      "source": [
-        "def preprocess(input_tensor):\n",
-        "    min_val, max_val = 0, 1\n",
-        "    min_tensor = torch.min(input_tensor)\n",
-        "    max_tensor = torch.max(input_tensor)\n",
-        "    scaled_tensor = (input_tensor - min_tensor) / (max_tensor - min_tensor)\n",
-        "    scaled_tensor = scaled_tensor * (max_val - min_val) + min_val\n",
-        "    return scaled_tensor"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bDPkWjAShSKr"
-      },
-      "source": [
-        "### Write your entrypoint function that will run remotely\n",
-        "\n",
-        "The `@garden_entrypoint` decorator makes this function available to run in your garden when you publish the notebook.\n",
-        "Download your model weights and call your model in this function.\n",
-        "\n",
-        "In the decorator be sure to include:\n",
-        "- your entrypoint metadata,\n",
-        "- connectors for any models you're using,\n",
-        "- the DOI of the garden you want this entrypoint to be found in. (Check `garden-ai garden list` for the DOIs of your gardens.)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "6ls-44Wehec9"
-      },
-      "outputs": [],
-      "source": [
-        "@garden_entrypoint(metadata=my_entrypoint_meta,  model_connectors=[my_hugging_face_repo], garden_doi=\"10.23677/my-garden-doi\")\n",
-        "def run_my_model(input_tensor):\n",
-        "    download_path = my_hugging_face_repo.stage()\n",
-        "    from model_definition_module_in_the_hf_repo import MyModel\n",
-        "    model = MyModel()\n",
-        "    model.load_state_dict(torch.load(download_path + \"/my_model.pt\"))\n",
-        "    model.eval()\n",
-        "\n",
-        "    scaled_tensor = preprocess(input_tensor)\n",
-        "    with torch.no_grad():\n",
-        "        output = model(scaled_tensor)\n",
-        "    \n",
-        "    return output"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dK3PHq2fhgxp"
-      },
-      "source": [
-        "### Test your entrypoint function\n",
-        "\n",
-        "Finally, make sure your `@garden_entrypoint` works!\n",
-        "When Garden makes a container from your notebook, it runs all the cells in order and saves the notebook. Then users invoke your `@garden_entrypoint` in the context of the notebook.\n",
-        "\n",
-        "If you can hit \"Kernel\" -> \"Restart and run all cells\" and your test below works, your `@garden_entrypoint` will work in your garden!\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "pn2aa8wnhu2u"
-      },
-      "outputs": [],
-      "source": [
-        "# Replace with input that is relevant for your garden_entrypoint\n",
-        "example_input = torch.tensor([\n",
-        "    [1, -1], [3, 2]\n",
-        "])\n",
-        "run_my_model(example_input)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "A9-UTFHAmCEq"
-      },
-      "outputs": [],
-      "source": []
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "H24yDUiVP5-n"
+   },
+   "source": [
+    "## Your Model 🌱Garden🌱 Execution Environment\n",
+    "\n",
+    "Use this notebook to write a function that executes your model(s). Tag that function with the `@garden_entrypoint` decorator.\n",
+    "\n",
+    "Garden will take this notebook and build a container with it. When Garden executes your `@garden_entrypoint`, it will be like like you have just run all the cells of this notebook once. So you can install libraries with `!pip install` and your function can use those libraries. You can also define helper functions and constants to use in your `@garden_entrypoint`."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "qww1_jOzP5S9"
+   },
+   "outputs": [],
+   "source": [
+    "from garden_ai.model_connectors import HFConnector\n",
+    "from garden_ai import EntrypointMetadata, garden_entrypoint, entrypoint_test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "b0s7Bealdp8M"
+   },
+   "outputs": [],
+   "source": [
+    "import torch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3aikfsCRdrEZ"
+   },
+   "source": [
+    "### Model connectors\n",
+    "\n",
+    "Model connectors let Garden import metadata about your model.\n",
+    "They also have a `stage` method that you can use to download your model weights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "H7em6SwMdvkt"
+   },
+   "outputs": [],
+   "source": [
+    "my_hugging_face_repo = HFConnector(\"garden-ai/sample_sklearn_model\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "FTziKOq7d1Qs"
+   },
+   "source": [
+    "### Entrypoint metadata\n",
+    "\n",
+    "\n",
+    "To publish your function, Garden needs metadata so that other users can discover it.\n",
+    "Edit this EntrypointMetadata object to describe your function.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "PHtZD33NhCEF"
+   },
+   "outputs": [],
+   "source": [
+    "my_entrypoint_meta = EntrypointMetadata(\n",
+    "    title=\"My Inference Function\",\n",
+    "    description=\"Write a longer description here so that people know what your entrypoint does.\",\n",
+    "    authors=[\"you\", \"your collaborator\"],\n",
+    "    tags=[\"materials science\", \"your actual field\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gnNDYs4PhKKO"
+   },
+   "source": [
+    "### Helper Functions\n",
+    "\n",
+    "Define any helper functions you need and use them in the function you want to let people run remotely"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "hhd9FNB9hN0a"
+   },
+   "outputs": [],
+   "source": [
+    "def preprocess(input_tensor):\n",
+    "    min_val, max_val = 0, 1\n",
+    "    min_tensor = torch.min(input_tensor)\n",
+    "    max_tensor = torch.max(input_tensor)\n",
+    "    scaled_tensor = (input_tensor - min_tensor) / (max_tensor - min_tensor)\n",
+    "    scaled_tensor = scaled_tensor * (max_val - min_val) + min_val\n",
+    "    return scaled_tensor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bDPkWjAShSKr"
+   },
+   "source": [
+    "### Write your entrypoint function that will run remotely\n",
+    "\n",
+    "The `@garden_entrypoint` decorator makes this function available to run in your garden when you publish the notebook.\n",
+    "Download your model weights and call your model in this function.\n",
+    "\n",
+    "In the decorator be sure to include:\n",
+    "- your entrypoint metadata,\n",
+    "- connectors for any models you're using,\n",
+    "- the DOI of the garden you want this entrypoint to be found in. (Check `garden-ai garden list` for the DOIs of your gardens.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "6ls-44Wehec9"
+   },
+   "outputs": [],
+   "source": [
+    "@garden_entrypoint(metadata=my_entrypoint_meta,  model_connectors=[my_hugging_face_repo], garden_doi=\"10.23677/my-garden-doi\")\n",
+    "def run_my_model(input_tensor):\n",
+    "    download_path = my_hugging_face_repo.stage()\n",
+    "    from model_definition_module_in_the_hf_repo import MyModel\n",
+    "    model = MyModel()\n",
+    "    model.load_state_dict(torch.load(download_path + \"/my_model.pt\"))\n",
+    "    model.eval()\n",
+    "\n",
+    "    scaled_tensor = preprocess(input_tensor)\n",
+    "    with torch.no_grad():\n",
+    "        output = model(scaled_tensor)\n",
+    "    \n",
+    "    return output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dK3PHq2fhgxp"
+   },
+   "source": [
+    "### Test your entrypoint function\n",
+    "\n",
+    "Finally, make sure your `@garden_entrypoint` works!\n",
+    "When Garden makes a container from your notebook, it runs all the cells in order and saves the notebook. Then users invoke your `@garden_entrypoint` in the context of the notebook.\n",
+    "\n",
+    "Note on testing: any test functions that call your entrypoint (like the one below) should be marked with `@entrypoint_test(<entrypoint_being_tested>)`. This is because calling an entrypoint typically causes side-effects (such as downloading your model weights to disk) that shouldn't be \"baked in\" to the environment of the final published notebook. \n",
+    "\n",
+    "Anything marked with `@entrypoint_test` won't be run at publication time, so you don't need to remember to comment out your test code before publishing. We'll also use `@entrypoint_test` functions as example code for others to see how your entrypoint expects to be called. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "pn2aa8wnhu2u"
+   },
+   "outputs": [],
+   "source": [
+    "@entrypoint_test(run_my_model)\n",
+    "def test_run_my_model():\n",
+    "    # Replace with input that is relevant for your garden_entrypoint\n",
+    "    example_input = torch.tensor([\n",
+    "        [1, -1], [3, 2]\n",
+    "    ])\n",
+    "    return run_my_model(example_input)\n",
+    "    \n",
+    "test_run_my_model()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "A9-UTFHAmCEq"
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Closes #383 

## Overview

functions decorated with `@entrypoint_test` now become no-ops at publication (and `notebook debug`) time, so users don't need to remember to comment out tests before they publish. 

## Discussion

`containers.build_notebook_session_image` can now set environment variables in the docker image it builds. This currently just sets a `GARDEN_SKIP_TESTS=True` flag by default, which the `entrypoint_test` decorator now checks for before calling the underlying test function.  

## Testing

Just manual tests so far -- I wasn't sure how useful a unit test would be since this only changes behavior in containers, but I'm happy to add one

As a bonus though, manual testing actually turned up a lil bug in `notebook debug` (we were attempting to pull images by an id which would only exist locally) 🪲 

## Documentation

Updated the template notebooks with a little explanation/usage of the decorator, but no actual docs changes otherwise.

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--393.org.readthedocs.build/en/393/

<!-- readthedocs-preview garden-ai end -->