### PR TITLE
Let users opt in to when their DOIs are registered

### DIFF
--- a/garden_ai/app/console.py
+++ b/garden_ai/app/console.py
@@ -6,19 +6,58 @@ from typing import List, Optional, Any
 console = Console()
 
 
+def format_doi_status(doi_status: bool) -> str:
+    return "draft" if doi_status else "registered"
+
+
+# Assuming the boolean value is stored in a field named 'doi_status' in the resource objects
+# Update the _get_rich_resource_table function to include the new column and format the doi_status
 def _get_rich_resource_table(
     resource_objs: Optional[List[Any]], resource_table_cols: List[str], table_name: str
 ) -> Table:
     table = Table(title=table_name)
 
+    # Add all the existing columns
     for col in resource_table_cols:
         table.add_column(col)
+
+    # Add the new column for DOI status
+    table.add_column("DOI Status")
 
     if resource_objs:
         for resource_obj in resource_objs:
             row = []
             for field in resource_table_cols:
                 row.append(str(getattr(resource_obj, field)))
+            # Format the DOI status and add it to the row
+            doi_status_formatted = format_doi_status(
+                getattr(resource_obj, "doi_status", False)
+            )
+            row.append(doi_status_formatted)
+            table.add_row(*row)
+
+    return table
+
+
+def _get_rich_resource_table(
+    resource_objs: Optional[List[Any]], resource_table_cols: List[str], table_name: str
+) -> Table:
+    table = Table(title=table_name)
+
+    for col in resource_table_cols:
+        if col == "doi_is_draft":
+            table.add_column("doi status")
+        else:
+            table.add_column(col)
+
+    if resource_objs:
+        for resource_obj in resource_objs:
+            row = []
+            for field in resource_table_cols:
+                cell_value = getattr(resource_obj, field)
+                if field == "doi_is_draft":
+                    cell_value = "draft" if cell_value else "registered"
+                row.append(str(cell_value))
             table.add_row(*row)
 
     return table

--- a/garden_ai/app/console.py
+++ b/garden_ai/app/console.py
@@ -8,10 +8,6 @@ console = Console()
 DOI_STATUS_COLUMN = "doi_is_draft"
 
 
-def format_doi_status(doi_status: bool) -> str:
-    return "draft" if doi_status else "registered"
-
-
 def _get_rich_resource_table(
     resource_objs: Optional[List[Any]], resource_table_cols: List[str], table_name: str
 ) -> Table:

--- a/garden_ai/app/console.py
+++ b/garden_ai/app/console.py
@@ -5,47 +5,20 @@ from typing import List, Optional, Any
 
 console = Console()
 
+DOI_STATUS_COLUMN = "doi_is_draft"
+
 
 def format_doi_status(doi_status: bool) -> str:
     return "draft" if doi_status else "registered"
 
 
-# Assuming the boolean value is stored in a field named 'doi_status' in the resource objects
-# Update the _get_rich_resource_table function to include the new column and format the doi_status
-def _get_rich_resource_table(
-    resource_objs: Optional[List[Any]], resource_table_cols: List[str], table_name: str
-) -> Table:
-    table = Table(title=table_name)
-
-    # Add all the existing columns
-    for col in resource_table_cols:
-        table.add_column(col)
-
-    # Add the new column for DOI status
-    table.add_column("DOI Status")
-
-    if resource_objs:
-        for resource_obj in resource_objs:
-            row = []
-            for field in resource_table_cols:
-                row.append(str(getattr(resource_obj, field)))
-            # Format the DOI status and add it to the row
-            doi_status_formatted = format_doi_status(
-                getattr(resource_obj, "doi_status", False)
-            )
-            row.append(doi_status_formatted)
-            table.add_row(*row)
-
-    return table
-
-
 def _get_rich_resource_table(
     resource_objs: Optional[List[Any]], resource_table_cols: List[str], table_name: str
 ) -> Table:
     table = Table(title=table_name)
 
     for col in resource_table_cols:
-        if col == "doi_is_draft":
+        if col == DOI_STATUS_COLUMN:
             table.add_column("doi status")
         else:
             table.add_column(col)
@@ -55,7 +28,7 @@ def _get_rich_resource_table(
             row = []
             for field in resource_table_cols:
                 cell_value = getattr(resource_obj, field)
-                if field == "doi_is_draft":
+                if field == DOI_STATUS_COLUMN:
                     cell_value = "draft" if cell_value else "registered"
                 row.append(str(cell_value))
             table.add_row(*row)

--- a/garden_ai/app/entrypoint.py
+++ b/garden_ai/app/entrypoint.py
@@ -189,7 +189,7 @@ def register_doi(
     if not entrypoint:
         typer.error(f"Could not find entrypoint with doi {doi}")
         raise typer.Exit(code=1)
-    client.register_doi(entrypoint)
+    client.register_entrypoint_doi(entrypoint)
     rich.print(f"DOI {doi} has been moved out of draft status and can now be cited.")
 
 

--- a/garden_ai/app/entrypoint.py
+++ b/garden_ai/app/entrypoint.py
@@ -6,7 +6,11 @@ import rich
 from rich.prompt import Prompt
 
 from garden_ai import GardenClient
-from garden_ai.app.console import console, get_local_entrypoint_rich_table
+from garden_ai.app.console import (
+    console,
+    get_local_entrypoint_rich_table,
+    DOI_STATUS_COLUMN,
+)
 from garden_ai.app.completion import complete_entrypoint
 from garden_ai.entrypoints import Repository, Paper
 from garden_ai.local_data import (
@@ -197,7 +201,7 @@ def register_doi(
 def list():
     """Lists all local entrypoints."""
 
-    resource_table_cols = ["doi", "title", "description", "doi_is_draft"]
+    resource_table_cols = ["doi", "title", "description", DOI_STATUS_COLUMN]
     table_name = "Local Entrypoints"
 
     table = get_local_entrypoint_rich_table(

--- a/garden_ai/app/entrypoint.py
+++ b/garden_ai/app/entrypoint.py
@@ -191,7 +191,7 @@ def register_doi(
     client = GardenClient()
     entrypoint = get_local_entrypoint_by_doi(doi)
     if not entrypoint:
-        typer.error(f"Could not find entrypoint with doi {doi}")
+        rich.print(f"Could not find entrypoint with doi {doi}")
         raise typer.Exit(code=1)
     client.register_entrypoint_doi(entrypoint)
     rich.print(f"DOI {doi} has been moved out of draft status and can now be cited.")

--- a/garden_ai/app/entrypoint.py
+++ b/garden_ai/app/entrypoint.py
@@ -5,6 +5,7 @@ import typer
 import rich
 from rich.prompt import Prompt
 
+from garden_ai import GardenClient
 from garden_ai.app.console import console, get_local_entrypoint_rich_table
 from garden_ai.app.completion import complete_entrypoint
 from garden_ai.entrypoints import Repository, Paper
@@ -166,11 +167,37 @@ def add_paper(
         rich.print(f"The paper {title} is successfully added to entrypoint {doi}.")
 
 
+@entrypoint_app.command(no_args_is_help=True)
+def register_doi(
+    doi: str = typer.Argument(
+        ...,
+        autocompletion=complete_entrypoint,
+        help="The draft entrypoint DOI you want to register",
+        rich_help_panel="Required",
+    ),
+):
+    """
+    Moves an Entrypoint's DOI out of draft state.
+
+    Parameters
+    ----------
+    doi : str
+        The DOI of the entrypoint to be registered.
+    """
+    client = GardenClient()
+    entrypoint = get_local_entrypoint_by_doi(doi)
+    if not entrypoint:
+        typer.error(f"Could not find entrypoint with doi {doi}")
+        raise typer.Exit(code=1)
+    client.register_doi(entrypoint)
+    rich.print(f"DOI {doi} has been moved out of draft status and can now be cited.")
+
+
 @entrypoint_app.command(no_args_is_help=False)
 def list():
     """Lists all local entrypoints."""
 
-    resource_table_cols = ["doi", "title", "description"]
+    resource_table_cols = ["doi", "title", "description", "doi_is_draft"]
     table_name = "Local Entrypoints"
 
     table = get_local_entrypoint_rich_table(

--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -154,33 +154,6 @@ def create(
 
 
 @garden_app.command(no_args_is_help=True)
-def register_doi(
-    doi: str = typer.Argument(
-        ...,
-        autocompletion=complete_garden,
-        help="The draft garden DOI you want to register",
-        rich_help_panel="Required",
-    ),
-):
-    """
-    Moves a Garden's DOI out of draft state.
-
-    Parameters
-    ----------
-    doi : str
-        The DOI of the garden to be registered.
-    """
-    client = GardenClient()
-    garden = _get_garden(doi)
-    if not garden:
-        raise typer.Exit(code=1)
-    client.publish_garden_metadata(garden, register_doi=True)
-    garden.doi_is_draft = False
-    local_data.put_local_garden(garden)
-    rich.print(f"DOI {doi} has been moved out of draft status and can now be cited.")
-
-
-@garden_app.command(no_args_is_help=True)
 def search(
     title: Optional[str] = typer.Option(
         None, "-t", "--title", help="Title of a Garden"
@@ -331,6 +304,33 @@ def publish(
     console.print(
         f"Successfully published garden {garden.title} with DOI {garden.doi}!"
     )
+
+
+@garden_app.command(no_args_is_help=True)
+def register_doi(
+    doi: str = typer.Argument(
+        ...,
+        autocompletion=complete_garden,
+        help="The draft garden DOI you want to register",
+        rich_help_panel="Required",
+    ),
+):
+    """
+    Moves a Garden's DOI out of draft state.
+
+    Parameters
+    ----------
+    doi : str
+        The DOI of the garden to be registered.
+    """
+    client = GardenClient()
+    garden = _get_garden(doi)
+    if not garden:
+        raise typer.Exit(code=1)
+    client.publish_garden_metadata(garden, register_doi=True)
+    garden.doi_is_draft = False
+    local_data.put_local_garden(garden)
+    rich.print(f"DOI {doi} has been moved out of draft status and can now be cited.")
 
 
 @garden_app.command(no_args_is_help=False)

--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -16,7 +16,11 @@ from garden_ai.globus_search.garden_search import (
 from garden_ai.constants import GardenConstants
 from garden_ai.gardens import Garden
 from garden_ai.entrypoints import RegisteredEntrypoint
-from garden_ai.app.console import console, get_local_garden_rich_table
+from garden_ai.app.console import (
+    console,
+    get_local_garden_rich_table,
+    DOI_STATUS_COLUMN,
+)
 from garden_ai.app.completion import complete_garden, complete_entrypoint
 
 logger = logging.getLogger()
@@ -337,7 +341,7 @@ def register_doi(
 def list():
     """Lists all local Gardens."""
 
-    resource_table_cols = ["doi", "title", "description", "doi_is_draft"]
+    resource_table_cols = ["doi", "title", "description", DOI_STATUS_COLUMN]
     table_name = "Local Gardens"
 
     table = get_local_garden_rich_table(

--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -154,6 +154,33 @@ def create(
 
 
 @garden_app.command(no_args_is_help=True)
+def register_doi(
+    doi: str = typer.Argument(
+        ...,
+        autocompletion=complete_garden,
+        help="The draft garden DOI you want to register",
+        rich_help_panel="Required",
+    ),
+):
+    """
+    Moves a Garden's DOI out of draft state.
+
+    Parameters
+    ----------
+    doi : str
+        The DOI of the garden to be registered.
+    """
+    client = GardenClient()
+    garden = _get_garden(doi)
+    if not garden:
+        raise typer.Exit(code=1)
+    client.publish_garden_metadata(garden, register_doi=True)
+    garden.doi_is_draft = False
+    local_data.put_local_garden(garden)
+    rich.print(f"DOI {doi} has been moved out of draft status and can now be cited.")
+
+
+@garden_app.command(no_args_is_help=True)
 def search(
     title: Optional[str] = typer.Option(
         None, "-t", "--title", help="Title of a Garden"
@@ -310,7 +337,7 @@ def publish(
 def list():
     """Lists all local Gardens."""
 
-    resource_table_cols = ["doi", "title", "description"]
+    resource_table_cols = ["doi", "title", "description", "doi_is_draft"]
     table_name = "Local Gardens"
 
     table = get_local_garden_rich_table(

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -281,7 +281,6 @@ class GardenClient:
         """
         Makes an entrypoint's DOI registered and findable with DataCite via the Garden backend.
         """
-        foo = 0 / 0
         self._update_datacite(entrypoint, register_doi=True)
         entrypoint.doi_is_draft = False
         local_data.put_local_entrypoint(entrypoint)

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -281,6 +281,7 @@ class GardenClient:
         """
         Makes an entrypoint's DOI registered and findable with DataCite via the Garden backend.
         """
+        foo = 0 / 0
         self._update_datacite(entrypoint, register_doi=True)
         entrypoint.doi_is_draft = False
         local_data.put_local_entrypoint(entrypoint)

--- a/garden_ai/entrypoints.py
+++ b/garden_ai/entrypoints.py
@@ -136,6 +136,9 @@ class RegisteredEntrypoint(EntrypointMetadata):
 
     Attributes:
         func_uuid: The ID of the Globus Compute function registered for this entrypoint.
+        doi_is_draft: (bool): \
+            Used to track the status of this garden's DOI. All DOIs start out as drafts. \
+            You can promote a DOI to a registered state with `garden-ai entrypoint register-doi`.
         container_uuid: ID returned from Globus Compute's register_container.
         base_image_uri: location of the base image used by this entrypoint. eg docker://index.docker.io/maxtuecke/garden-ai:python-3.9-jupyter
         full_image_uri: The name and location of the complete image used by this entrypoint.
@@ -147,6 +150,7 @@ class RegisteredEntrypoint(EntrypointMetadata):
     doi: str = Field(
         ...
     )  # Repeating this field from base class because DOI is mandatory for RegisteredEntrypoint
+    doi_is_draft: bool = Field(True)
     func_uuid: UUID = Field(...)
     container_uuid: UUID = Field(...)
     base_image_uri: Optional[str] = Field(None)

--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -55,6 +55,10 @@ class Garden(BaseModel):
             A garden's DOI usable for citations, generated automatically via \
             DataCite using the required fields.
 
+        doi_is_draft: (bool):
+            Used to track the status of this garden's DOI. All DOIs start out as drafts. \
+            You can promote a DOI to a registered state with `garden-ai garden register-doi`.
+
         version (str):
             optional, defaults to "0.0.1".
 
@@ -93,6 +97,7 @@ class Garden(BaseModel):
     authors: List[str] = Field(default_factory=list, min_items=1, unique_items=True)
     contributors: List[str] = Field(default_factory=list, unique_items=True)
     doi: str = Field(...)
+    doi_is_draft: bool = Field(True)
     description: Optional[str] = Field(None)
     publisher: str = "Garden-AI"
     year: str = Field(default_factory=lambda: str(datetime.now().year))
@@ -102,7 +107,6 @@ class Garden(BaseModel):
     entrypoint_ids: List[str] = Field(default_factory=list)
     entrypoint_aliases: Dict[str, str] = Field(default_factory=dict)
     _entrypoint_cache: List[RegisteredEntrypoint] = PrivateAttr(default_factory=list)
-    _env_vars: Dict[str, str] = PrivateAttr(default_factory=dict)
 
     @root_validator(pre=True)
     def doi_omitted(cls, values):
@@ -350,7 +354,6 @@ class PublishedGarden(BaseModel):
     version: str = "0.0.1"
     entrypoints: List[RegisteredEntrypoint] = Field(...)
     entrypoint_aliases: Dict[str, str] = Field(default_factory=dict)
-    _env_vars: Dict[str, str] = PrivateAttr(default_factory=dict)
 
     @validator("year")
     def valid_year(cls, year):

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -4,56 +4,69 @@ from garden_ai import local_data
 from garden_ai.app.console import (
     get_local_garden_rich_table,
     get_local_entrypoint_rich_table,
+    DOI_STATUS_COLUMN,
 )
 
 
-def test_get_local_garden_table(mocker, garden_client, garden_all_fields, tmp_path):
+def test_get_local_garden_table(mocker, garden_all_fields, tmp_path):
     # mock to replace "~/.garden/db"
     mocker.patch("garden_ai.local_data.LOCAL_STORAGE", new=tmp_path)
     local_data.put_local_garden(garden_all_fields)
 
-    garden_cols = ["doi", "title", "description"]
+    # Construct a table manually
+    garden_col_literal_namess = ["doi", "title", "description", "doi status"]
     garden_table_name = "Local Gardens"
     garden_rows = [
-        (garden_all_fields.doi, garden_all_fields.title, garden_all_fields.description)
+        (
+            garden_all_fields.doi,
+            garden_all_fields.title,
+            garden_all_fields.description,
+            "draft",
+        )
     ]
     table = Table(title=garden_table_name)
 
-    for col in garden_cols:
+    for col in garden_col_literal_namess:
         table.add_column(col)
     for row in garden_rows:
         table.add_row(*(row))
 
+    # Construct it using the helper under test
+    garden_col_names = ["doi", "title", "description", DOI_STATUS_COLUMN]
     test_table = get_local_garden_rich_table(
-        resource_table_cols=garden_cols, table_name=garden_table_name
+        resource_table_cols=garden_col_names, table_name=garden_table_name
     )
     assert table.__dict__ == test_table.__dict__
 
 
 def test_get_local_entrypoint_table(
-    mocker, garden_client, registered_entrypoint_toy_example, tmp_path
+    mocker, registered_entrypoint_toy_example, tmp_path
 ):
     # mock to replace "~/.garden/db"
     mocker.patch("garden_ai.local_data.LOCAL_STORAGE", new=tmp_path)
     local_data.put_local_entrypoint(registered_entrypoint_toy_example)
 
-    entrypoint_cols = ["doi", "title", "description"]
+    # Construct a table manually
+    entrypoint_col_literal_names = ["doi", "title", "description", "doi status"]
     entrypoint_table_name = "Local Entrypoints"
     entrypoint_rows = [
         (
             registered_entrypoint_toy_example.doi,
             registered_entrypoint_toy_example.title,
             registered_entrypoint_toy_example.description,
+            "draft",
         )
     ]
     table = Table(title=entrypoint_table_name)
 
-    for col in entrypoint_cols:
+    for col in entrypoint_col_literal_names:
         table.add_column(col)
     for row in entrypoint_rows:
         table.add_row(*(row))
 
+    # Construct it using the helper under test
+    entrypoint_col_names = ["doi", "title", "description", DOI_STATUS_COLUMN]
     test_table = get_local_entrypoint_rich_table(
-        resource_table_cols=entrypoint_cols, table_name=entrypoint_table_name
+        resource_table_cols=entrypoint_col_names, table_name=entrypoint_table_name
     )
     assert table.__dict__ == test_table.__dict__


### PR DESCRIPTION
Closes #400 

## Overview

This PR adds new commands `garden-ai garden register-doi` and `garden-ai entrypoint register-doi`. These will promote the draft DOIs that Garden mints for all gardens and entrypoints to "registered" and "findable" status in Datacite.

This change is prompted by early feedback that Garden proactively creating and registering DOIs was surprising. This change makes it so that users have the option to review their work before pulling the trigger and making the DOI for an entrypoint or garden official.

The PR also adds to the `list` commands to let users easily see the draft statuses of their DOI.

_Screenshots_

<img width="1512" alt="Screenshot 2024-02-08 at 4 18 48 PM" src="https://github.com/Garden-AI/garden/assets/6283143/2a6d5a3f-41a1-46ec-9083-16512f833499">

<img width="1286" alt="Screenshot 2024-02-08 at 4 41 55 PM" src="https://github.com/Garden-AI/garden/assets/6283143/381cd122-991c-47f1-aa58-2e4abb793a05">

## Discussion

As I was reviewing how we deal with DOIs, it became clear that our support for users bringing their own DOI (not one generated with our account) is broken. This PR does not attempt to fix that. It also doesn't attempt to manage draft status of externally generated DOIs.

## Testing

I tested this manually and added tests for the new commands. I intend to do more end to end testing against the prod DataCite account with [this ticket](https://github.com/Garden-AI/garden/issues/284).

## Documentation

Just inline CLI help for now.

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--405.org.readthedocs.build/en/405/

<!-- readthedocs-preview garden-ai end -->