### PR TITLE
Quick fix: get correct traceback line in build errors

### DIFF
--- a/garden_ai/app/notebook.py
+++ b/garden_ai/app/notebook.py
@@ -74,7 +74,7 @@ class DockerClientSession:
                 "If you supplied a requirements file, check that it's formatted correctly.\n"
             )
         elif isinstance(e, DockerBuildFailure):
-            last_line = e.build_log[-1] if len(e.build_log) > 0 else ""
+            last_line = e.build_log[-2] if len(e.build_log) > 1 else ""
             if "Traceback" in last_line:
                 print_err(
                     "Garden could not build a Docker image from your notebook. "


### PR DESCRIPTION
## Overview

Owen's container handling improvements in the `docker prune` PR means there's now an extra line in build log output in the case of a build failure. The last line is something like "Removing intermediate container 33cb4f87eb1e". This PR updates some error handling code to reflect this.

## Discussion

Yeah, I know this is fragile ... If it breaks again let's reconsider.

## Testing

Tested manually

## Documentation

No


<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--406.org.readthedocs.build/en/406/

<!-- readthedocs-preview garden-ai end -->