### PR TITLE
target prod by default

### DIFF
--- a/.env.shared
+++ b/.env.shared
@@ -1,2 +1,3 @@
 # note: does not override existing vars
+# so if you've explicitly set GARDEN_ENV=prod, that choice will be respected
 GARDEN_ENV=dev

--- a/.env.shared
+++ b/.env.shared
@@ -1,0 +1,2 @@
+# note: does not override existing vars
+GARDEN_ENV=dev

--- a/garden_ai/app/main.py
+++ b/garden_ai/app/main.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -28,8 +29,11 @@ app.add_typer(docker_app)
 
 def show_version(show: bool):
     """Display the installed version and quit."""
+    version_str = f"garden-ai {__version__}"
     if show:
-        rich.print(f"garden-ai {__version__}")
+        if env := os.environ.get("GARDEN_ENV"):
+            version_str += f" ({env})"
+        rich.print(version_str)
         raise typer.Exit()
 
 

--- a/garden_ai/constants.py
+++ b/garden_ai/constants.py
@@ -1,4 +1,10 @@
 import os
+from dotenv import load_dotenv
+import pathlib
+
+# get env file from project root
+dotenv_path = pathlib.Path(f"{__file__}/../..").resolve() / ".env.shared"
+load_dotenv(str(dotenv_path), override=False)
 
 _PROD_ENDPOINT = "https://nu3cetwc84.execute-api.us-east-1.amazonaws.com/garden_prod"
 _DEV_ENDPOINT = "https://y0ipq1bueb.execute-api.us-east-1.amazonaws.com/garden_dev"
@@ -16,15 +22,15 @@ class GardenConstants:
     GARDEN_KEY_STORE = os.path.join(GARDEN_DIR, "tokens.json")
     URL_ENV_VAR_NAME = "GARDEN_MODELS"
     GARDEN_ENDPOINT = (
-        _PROD_ENDPOINT if os.environ.get("GARDEN_ENV") == "prod" else _DEV_ENDPOINT
+        _DEV_ENDPOINT if os.environ.get("GARDEN_ENV") == "dev" else _PROD_ENDPOINT
     )
     GARDEN_INDEX_UUID = (
-        _PROD_SEARCH_INDEX
-        if os.environ.get("GARDEN_ENV") == "prod"
-        else _DEV_SEARCH_INDEX
+        _DEV_SEARCH_INDEX
+        if os.environ.get("GARDEN_ENV") == "dev"
+        else _PROD_SEARCH_INDEX
     )
     GARDEN_ECR_REPO = (
-        _PROD_ECR_REPO if os.environ.get("GARDEN_ENV") == "prod" else _DEV_ECR_REPO
+        _DEV_ECR_REPO if os.environ.get("GARDEN_ENV") == "dev" else _PROD_ECR_REPO
     )
 
     DLHUB_ENDPOINT = "86a47061-f3d9-44f0-90dc-56ddc642c000"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2625,6 +2625,21 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "python-dotenv"
+version = "1.0.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
+    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pytz"
 version = "2023.3.post1"
 description = "World timezone definitions, modern and historical"
@@ -3787,4 +3802,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "7c8b1bb523007ed4c48bf47cdc96b9f75d01d31db4acfcea38683e03c68a461c"
+content-hash = "9b9ca8115aac714d7de394b8236557c2ea41f77caf1200e95c5e5e47b22d86fe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ ipython = "<8.13"
 dill = "0.3.5.1"
 boto3 = "^1.29"
 boto3-stubs = "^1.29"
+python-dotenv = "^1.0.1"
 
 [tool.poetry.scripts]
 garden-ai = "garden_ai.app.main:app"


### PR DESCRIPTION
fixes #284 

## Overview

The default values in `garden_ai.constants` now point at prod instead of dev. This can be controlled with the environment variable `GARDEN_ENV=dev` or `GARDEN_ENV=prod`. 

So that we don't need to worry about accidentally hitting prod ourselves if that env var is left unset, I also added a `.env.shared` file at the project root which sets `GARDEN_ENV=dev`. Because this file isn't distributed to pypi, this only applies if the `garden-ai` executable was installed from source (which is always the case in e.g. a `poetry shell`). 

The `.env.shared` won't override existing values, so this works like you'd expect:  

```sh
$ (plain install) garden-ai do something                # hits prod default 

$ (poetry shell) garden-ai do something                 # hits dev default 
$ (poetry shell) GARDEN_ENV=prod garden-ai do something # hits prod explicitly 
```

For quick sanity checking I also added a bit to `garden-ai --version` so that it'll print `GARDEN_ENV` if it's been set: 

```sh
$ (poetry shell) garden-ai --version
garden-ai 0.0.0 (dev)
```

## Testing

sanity checked DOI minting but haven't done the full end-to-end prod sanity check 


## Documentation

No docs changes, but I could be persuaded to add something to the contributor guide 

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--409.org.readthedocs.build/en/409/

<!-- readthedocs-preview garden-ai end -->