### PR TITLE
Add logic to format DLHub model input and output correctly

### DIFF
--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -635,12 +635,3 @@ class GardenClient:
             if garden:
                 print(f"(Re-)publishing garden {garden.doi} ({garden.title}) ...")
                 self.publish_garden_metadata(garden)
-
-    def make_entrypoint_from_function_id(
-        self, fid: str, entrypoint_metadata: EntrypointMetadata
-    ) -> str:
-        kludge_entrypoint = RegisteredEntrypoint(
-            **entrypoint_metadata.dict(), func_uuid=fid, container_uuid=fid
-        )
-        local_data.put_local_entrypoint(kludge_entrypoint)
-        print("Added")

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -33,7 +33,12 @@ from garden_ai.garden_file_adapter import GardenFileAdapter
 from garden_ai.gardens import Garden, PublishedGarden
 from garden_ai.globus_search import garden_search
 from garden_ai.local_data import GardenNotFoundException, EntrypointNotFoundException
-from garden_ai.entrypoints import Paper, RegisteredEntrypoint, Repository
+from garden_ai.entrypoints import (
+    Paper,
+    RegisteredEntrypoint,
+    Repository,
+    EntrypointMetadata,
+)
 from garden_ai.utils._meta import make_function_to_register
 from garden_ai.utils.misc import extract_email_from_globus_jwt
 
@@ -630,3 +635,12 @@ class GardenClient:
             if garden:
                 print(f"(Re-)publishing garden {garden.doi} ({garden.title}) ...")
                 self.publish_garden_metadata(garden)
+
+    def make_entrypoint_from_function_id(
+        self, fid: str, entrypoint_metadata: EntrypointMetadata
+    ) -> str:
+        kludge_entrypoint = RegisteredEntrypoint(
+            **entrypoint_metadata.dict(), func_uuid=fid, container_uuid=fid
+        )
+        local_data.put_local_entrypoint(kludge_entrypoint)
+        print("Added")

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -37,7 +37,6 @@ from garden_ai.entrypoints import (
     Paper,
     RegisteredEntrypoint,
     Repository,
-    EntrypointMetadata,
 )
 from garden_ai.utils._meta import make_function_to_register
 from garden_ai.utils.misc import extract_email_from_globus_jwt

--- a/garden_ai/constants.py
+++ b/garden_ai/constants.py
@@ -33,7 +33,25 @@ class GardenConstants:
         _DEV_ECR_REPO if os.environ.get("GARDEN_ENV") == "dev" else _PROD_ECR_REPO
     )
 
-    DLHUB_ENDPOINT = "86a47061-f3d9-44f0-90dc-56ddc642c000"
+    DEMO_ENDPOINT = "86a47061-f3d9-44f0-90dc-56ddc642c000"
+
+    DLHUB_DOIS = set(
+        [
+            "10.26311/3hz8-as26",
+            "10.26311/8s9h-dz64",
+            "10.26311/bf7a-7071",
+            "10.26311/e2mw-qf63",
+            "10.26311/b6zb-ns88",
+            "10.26311/q6e2-2p11",
+            "10.26311/bkk2-gc19",
+            "10.26311/k2bk-hw50",
+            "10.26311/bgb7-k519",
+            "10.26311/x13g-7f17",
+            "10.26311/s8hf-3v65",
+            "10.26311/aefd-p769",
+            "10.26311/cd31-az33",
+        ]
+    )
 
     PREMADE_IMAGES = {
         "3.8-base": "gardenai/base:python-3.8-jupyter",

--- a/garden_ai/entrypoints.py
+++ b/garden_ai/entrypoints.py
@@ -183,7 +183,10 @@ class RegisteredEntrypoint(EntrypointMetadata):
         from garden_ai.app.console import console
 
         if not endpoint:
-            endpoint = GardenConstants.DLHUB_ENDPOINT
+            endpoint = GardenConstants.DEMO_ENDPOINT
+
+        if self._is_dlhub_entrypoint():
+            args = [{"inputs": args, "parameters": [], "debug": False}]
 
         with globus_compute_sdk.Executor(endpoint_id=str(endpoint)) as gce:
             with console.status(
@@ -192,7 +195,15 @@ class RegisteredEntrypoint(EntrypointMetadata):
                 future = gce.submit_to_registered_function(
                     function_id=str(self.func_uuid), args=args, kwargs=kwargs
                 )
-                return future.result()
+                result = future.result()
+                if self._is_dlhub_entrypoint():
+                    inner_result = result[0]
+                    if inner_result[1]["success"]:
+                        return inner_result[0]
+                    else:
+                        return result
+                else:
+                    return result
 
     def _repr_html_(self) -> str:
         # delayed import so dill doesn't try to serialize tabulate ref
@@ -235,6 +246,15 @@ class RegisteredEntrypoint(EntrypointMetadata):
                 else None
             ),
         ).json()
+
+    def _is_dlhub_entrypoint(self) -> bool:
+        """
+        There are 13 DLHub models that we converted to Garden entrypoints.
+        We know their DOIs. We can use this to check if a DOI is a DLHub entrypoint.
+        If so, we convert the user's input into the format that DLHub models expect.
+        We also just pass along the model output to the user and strip the rest.
+        """
+        return self.doi in GardenConstants.DLHUB_DOIS
 
 
 def garden_entrypoint(

--- a/garden_ai/entrypoints.py
+++ b/garden_ai/entrypoints.py
@@ -186,7 +186,7 @@ class RegisteredEntrypoint(EntrypointMetadata):
             endpoint = GardenConstants.DEMO_ENDPOINT
 
         if self._is_dlhub_entrypoint():
-            args = [{"inputs": args, "parameters": [], "debug": False}]
+            args = ({"inputs": args, "parameters": [], "debug": False},)
 
         with globus_compute_sdk.Executor(endpoint_id=str(endpoint)) as gce:
             with console.status(

--- a/tests/ete/constants.py
+++ b/tests/ete/constants.py
@@ -133,6 +133,6 @@ class ETEConstants:
             os.path.join(self.key_store_path, "tokens.json"),
         ]
 
-        self.default_endpoint = GardenConstants.DLHUB_ENDPOINT
+        self.default_endpoint = GardenConstants.DEMO_ENDPOINT
 
         self.custom_serialize = None

--- a/tests/integrations/test_pipeline_registration.py
+++ b/tests/integrations/test_pipeline_registration.py
@@ -6,11 +6,6 @@ from garden_ai.app.main import app
 runner = CliRunner()
 
 
-@pytest.fixture
-def dlhub_endpoint():
-    return "86a47061-f3d9-44f0-90dc-56ddc642c000"  # real endpoint
-
-
 @pytest.mark.integration
 def test_publish_garden():
     command = "garden publish -g e1a3b50b-4efc-42c8-8422-644f4f858b87"

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -34,13 +34,13 @@ def test_dlhub_entrypoint(mock_executor):
     ), "Should return the direct result for an entrypoint with DOI in list"
     mock_executor_instance.submit_to_registered_function.assert_called_once()
     mock_executor_instance.submit_to_registered_function.assert_called_with(
-        args=[
+        args=(
             {
                 "inputs": ("test arg",),
                 "parameters": [],
                 "debug": False,
-            }
-        ],
+            },
+        ),
         function_id=function_uuid,
         kwargs={},
     )

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -1,0 +1,72 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from garden_ai.entrypoints import (
+    RegisteredEntrypoint,
+)  # Adjust import paths as necessary
+
+# Mock UUIDs for testing
+function_uuid = "123e4567-e89b-12d3-a456-426614174000"
+container_uuid = "123e4567-e89b-12d3-a456-426614174001"
+
+
+@patch("garden_ai.entrypoints.globus_compute_sdk.Executor")
+def test_dlhub_entrypoint(mock_executor):
+    dlhub_entrypoint = RegisteredEntrypoint(
+        doi="10.26311/3hz8-as26",  # A DOI in the DLHub list
+        title="Migrated DLHub Model",
+        short_name="run_dlhub_model",
+        authors=["Joe Schmoe"],
+        func_uuid=function_uuid,
+        container_uuid=function_uuid,
+    )
+
+    dlhub_wrapped_result = (("answer", {"stdout": None, "success": True}), 3452354)
+
+    mock_executor_instance = MagicMock()
+    mock_executor.return_value.__enter__.return_value = mock_executor_instance
+    mock_executor_instance.submit_to_registered_function.return_value.result.return_value = (
+        dlhub_wrapped_result
+    )
+
+    result = dlhub_entrypoint("test arg", endpoint="specific-endpoint")
+
+    assert (
+        result == "answer"
+    ), "Should return the direct result for an entrypoint with DOI in list"
+    mock_executor_instance.submit_to_registered_function.assert_called_once()
+    mock_executor_instance.submit_to_registered_function.assert_called_with(
+        args=[
+            {
+                "inputs": ("test arg",),
+                "parameters": [],
+                "debug": False,
+            }
+        ],
+        function_id=function_uuid,
+        kwargs={},
+    )
+
+
+@patch("garden_ai.entrypoints.globus_compute_sdk.Executor")
+def test_normal_entrypoint(mock_executor):
+    normal_entrypoint = RegisteredEntrypoint(
+        doi="foo",  # A DOI not in the DLHub list
+        title="Some cool model",
+        short_name="run_model",
+        authors=["Jane Schmane"],
+        func_uuid=function_uuid,
+        container_uuid=function_uuid,
+    )
+
+    mock_executor_instance = MagicMock()
+    mock_executor.return_value.__enter__.return_value = mock_executor_instance
+    mock_executor_instance.submit_to_registered_function.return_value.result.return_value = (
+        "mocked result"
+    )
+
+    result = normal_entrypoint("test arg", endpoint="specific-endpoint")
+
+    assert (
+        result == "mocked result"
+    ), "Should return the direct result for an entrypoint with DOI not in list"
+    mock_executor_instance.submit_to_registered_function.assert_called_once()

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import patch, MagicMock
 from garden_ai.entrypoints import (
     RegisteredEntrypoint,


### PR DESCRIPTION
This came up in the course of #402

## Overview

DLHub wraps user input to models in a dictionary before sending it along to Globus Compute. Similarly, when receiving output from a successful run, DLHub unwraps the output from a nested tuple and returns the inner output to the user.

This PR makes it so that Garden will do the same for the legacy DLHub models we're migrating.

## Discussion

This is a little kludgey but good enough for now. We might be able to do something a little fancier where we add this code to the DLHub functions registered with Globus Compute if/when we want to get rid of this little hack.

## Testing

I tested this against sample input and output I got from a DLHub model that I migrated to Garden dev. I also added new unit tests. We will still need to test this end to end in the context of the full migration dry run on dev.

## Documentation

None

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--410.org.readthedocs.build/en/410/

<!-- readthedocs-preview garden-ai end -->