### PR TITLE
Extract metadata.json from built container as a file instead of `cat`ting its contents

### DIFF
--- a/garden_ai/containers.py
+++ b/garden_ai/containers.py
@@ -300,12 +300,15 @@ def extract_metadata_from_image(
 
         # There is only one file in the tarball
         member = tar.getmembers()[0]
-        file_contents = tar.extractfile(member).read().decode("utf-8")
+        file_obj = tar.extractfile(member)
+        if not file_obj:
+            raise FileNotFoundError(f"Could not find {file_path} in image {image.id}")
+        decoded_file_contents = file_obj.read().decode("utf-8")
     finally:
         container.stop()
         container.remove()
 
-    return json.loads(file_contents)
+    return json.loads(decoded_file_contents)
 
 
 @handle_docker_errors

--- a/garden_ai/containers.py
+++ b/garden_ai/containers.py
@@ -300,10 +300,10 @@ def extract_metadata_from_image(
 
         # There is only one file in the tarball
         member = tar.getmembers()[0]
-        file_obj = tar.extractfile(member)
-        if not file_obj:
+        member_file_obj = tar.extractfile(member)
+        if not member_file_obj:
             raise FileNotFoundError(f"Could not find {file_path} in image {image.id}")
-        decoded_file_contents = file_obj.read().decode("utf-8")
+        decoded_file_contents = member_file_obj.read().decode("utf-8")
     finally:
         container.stop()
         container.remove()


### PR DESCRIPTION
Might close #414 

## Overview

We _think_ that there is a bug on certain computers where stdout is not properly captured in the following line:

```
container_stdout = client.containers.run(
        image=image.id,
        entrypoint="/bin/sh",
        command=["-c", "cat /garden/metadata.json"],
        remove=True,
        detach=False,
    )
```

The Gardeners can't reproduce the bug, but we want to try circumventing stdout altogether to see if that fixes it. To do this we'll extract a file from the container instead of `cat`ting the file contents.

## Discussion

## Testing

I updated the unit test and I did manual runs to confirm it still works

## Documentation

No


<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--416.org.readthedocs.build/en/416/

<!-- readthedocs-preview garden-ai end -->