### PR TITLE
make github connector idempotent

### DIFF
--- a/garden_ai/model_connectors/github_conn.py
+++ b/garden_ai/model_connectors/github_conn.py
@@ -50,9 +50,6 @@ class GitHubConnector:
                 repo.remotes.origin.pull(self.branch)
                 return self.local_dir
 
-        if not os.path.exists(self.local_dir):
-            os.mkdir(self.local_dir)
-
         Repo.clone_from(f"{self.repo_url}.git", self.local_dir, branch=self.branch)
 
         if self.enable_imports:

--- a/garden_ai/model_connectors/github_conn.py
+++ b/garden_ai/model_connectors/github_conn.py
@@ -3,7 +3,6 @@ from git.repo.fun import is_git_dir
 from garden_ai.mlmodel import ModelMetadata
 from garden_ai.utils.misc import trackcalls
 from requests.exceptions import HTTPError
-import os
 import sys
 import requests
 
@@ -38,16 +37,16 @@ class GitHubConnector:
     def stage(self) -> str:
 
         if is_git_dir(f"{self.local_dir}/.git"):
-            repo = Repo(self.local_dir)
-            # double check the repo in local_dir refers to the same repo as this connector
-            remote_url = repo.remotes.origin.url
-            if self.repo_url not in remote_url:
+            # double check the existing repo in local_dir refers to the same
+            # repo as this connector before pulling
+            found_repo = Repo(self.local_dir)
+            if self.repo_url not in found_repo.remotes.origin.url:
                 raise ValueError(
                     f"Failed to clone {self.repo_url} to {self.local_dir} "
-                    f"({remote_url} already cloned here)."
+                    f"({found_repo.remotes.origin.url} already cloned here)."
                 )
             else:
-                repo.remotes.origin.pull(self.branch)
+                found_repo.remotes.origin.pull(self.branch)
                 return self.local_dir
 
         Repo.clone_from(f"{self.repo_url}.git", self.local_dir, branch=self.branch)

--- a/garden_ai/model_connectors/github_conn.py
+++ b/garden_ai/model_connectors/github_conn.py
@@ -39,8 +39,16 @@ class GitHubConnector:
 
         if is_git_dir(f"{self.local_dir}/.git"):
             repo = Repo(self.local_dir)
-            repo.remotes.origin.pull(self.branch)
-            return self.local_dir
+            # double check the repo in local_dir refers to the same repo as this connector
+            remote_url = repo.remotes.origin.url
+            if self.repo_url not in remote_url:
+                raise ValueError(
+                    f"Failed to clone {self.repo_url} to {self.local_dir} "
+                    f"({remote_url} already cloned here)."
+                )
+            else:
+                repo.remotes.origin.pull(self.branch)
+                return self.local_dir
 
         if not os.path.exists(self.local_dir):
             os.mkdir(self.local_dir)

--- a/garden_ai/model_connectors/github_conn.py
+++ b/garden_ai/model_connectors/github_conn.py
@@ -35,6 +35,10 @@ class GitHubConnector:
 
     @trackcalls
     def stage(self) -> str:
+        if self.stage.has_been_called:
+            # skip because git-clone isn't idempotent otherwise
+            return self.local_dir
+
         if not os.path.exists(self.local_dir):
             os.mkdir(self.local_dir)
 

--- a/garden_ai/model_connectors/github_conn.py
+++ b/garden_ai/model_connectors/github_conn.py
@@ -1,4 +1,5 @@
 from git import Repo  # type: ignore
+from git.repo.fun import is_git_dir
 from garden_ai.mlmodel import ModelMetadata
 from garden_ai.utils.misc import trackcalls
 from requests.exceptions import HTTPError
@@ -35,8 +36,10 @@ class GitHubConnector:
 
     @trackcalls
     def stage(self) -> str:
-        if self.stage.has_been_called:
-            # skip because git-clone isn't idempotent otherwise
+
+        if is_git_dir(f"{self.local_dir}/.git"):
+            repo = Repo(self.local_dir)
+            repo.remotes.origin.pull(self.branch)
             return self.local_dir
 
         if not os.path.exists(self.local_dir):

--- a/garden_ai/utils/misc.py
+++ b/garden_ai/utils/misc.py
@@ -84,8 +84,12 @@ def clean_identifier(name: str) -> str:
 def trackcalls(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        wrapper.has_been_called = True
-        return func(*args, **kwargs)
+        # note: attribute set only after func completes execution
+        # so that func itself can determine if it's been called
+        try:
+            return func(*args, **kwargs)
+        finally:
+            wrapper.has_been_called = True
 
     wrapper.has_been_called = False
     return wrapper

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -121,6 +121,8 @@ def test_GHconnector_idempotent(mocker):
     mock_repo_instance = MagicMock()
     mock_repo_class.return_value = mock_repo_instance
     mock_repo_instance.remotes.origin.pull = MagicMock()
+    # Set up the mock to return a URL that matches the connector's repo_url
+    mock_repo_instance.remotes.origin.url = "https://github.com/fake/repo.git"
 
     # Mock Repo.clone_from method to track calls without actually cloning
     mock_clone_from = mocker.patch(


### PR DESCRIPTION
fixes #413 

## Discussion

~This tweaks the `trackcalls` decorator so that `stage` can use its own `has_been_called` attribute and guarantee that it only executes once.~

This makes the GH connector behave a little more like the huggingface one by pulling instead of cloning when the directory is already a git repo. 

## Testing

~Wrote a cute little unit test, since it was easy~ 
updated the unit test so it checks that pull is called instead of clone when appropriate
 
## Documentation

no docs 


<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--417.org.readthedocs.build/en/417/

<!-- readthedocs-preview garden-ai end -->