### PR TITLE
`garden-ai garden delete` command

### DIFF
--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -358,11 +358,10 @@ def delete(
 
         if not garden:
             # It has a registered DOI and they don't have the garden locally - nothing to do
-            typer.confirm(
+            console.print(
                 f"The DOI {garden_id} is registered, so we can't remove it from the search index. "
                 "You also don't have it in your local data. "
                 "There is nothing to delete.",
-                abort=True,
             )
             raise typer.Exit(code=1)
 
@@ -371,7 +370,7 @@ def delete(
         # We can delete from both places.
         typer.confirm(
             f"You are about to delete garden {garden_id} ({garden.title}) "
-            "from your local data and the thegardens.ai search index./n"
+            "from your local data and the thegardens.ai search index.\n"
             f"Are you sure you want to proceed?",
             abort=True,
         )

--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -13,6 +13,7 @@ from garden_ai.client import GardenClient
 from garden_ai.globus_search.garden_search import (
     RemoteGardenException,
 )
+from garden_ai.utils.dois import is_doi_registered
 from garden_ai.constants import GardenConstants
 from garden_ai.gardens import Garden
 from garden_ai.entrypoints import RegisteredEntrypoint
@@ -340,26 +341,58 @@ def delete(
     if not garden and not dangerous_override:
         raise typer.Exit(code=1)
 
-    # Yes, they have it locally
+    # Is the garden DOI not in a draft state?
+    is_registered = is_doi_registered(garden_id)
+    if is_registered:
+        if garden:
+            # It has a registered DOI and they have the garden locally.
+            typer.confirm(
+                f"The DOI {garden_id} is registered, so we can't remove it from the search index. "
+                "You can still delete it from your local data. "
+                "Would you like to delete it locally?",
+                abort=True,
+            )
+            client.delete_garden_locally(garden_id)
+            console.print(f"Garden {garden_id} has been deleted locally.")
+            return
+
+        if not garden:
+            # It has a registered DOI and they don't have the garden locally - nothing to do
+            typer.confirm(
+                f"The DOI {garden_id} is registered, so we can't remove it from the search index. "
+                "You also don't have it in your local data. "
+                "There is nothing to delete.",
+                abort=True,
+            )
+            raise typer.Exit(code=1)
+
     if garden:
+        # They have the garden locally and it was just a draft DOI.
+        # We can delete from both places.
         typer.confirm(
             f"You are about to delete garden {garden_id} ({garden.title}) "
-            "from your local data and the search index./n"
+            "from your local data and the thegardens.ai search index./n"
             f"Are you sure you want to proceed?",
             abort=True,
         )
+        client.delete_garden_locally(garden_id)
+        client.delete_garden_from_search_index(garden_id)
+        console.print(
+            f"Garden {garden_id} has been deleted locally and from thegardens.ai."
+        )
+        return
 
-    # No, but they are using the override
     if not garden and dangerous_override:
+        # They do not have the garden locally, but they have used the override.
+        # It's a draft DOI so we can remove the record from our search index.
         typer.confirm(
-            f"You are about to delete garden {garden_id} from the search index. "
+            f"You are about to delete garden {garden_id} from the thegardens.ai search index. "
             "Are you sure you want to proceed?",
             abort=True,
         )
-
-    # Delete the garden from local data and from the search index
-    client.delete_garden(garden_id)
-    console.print(f"Garden {garden_id} has been deleted.")
+        client.delete_garden_from_search_index(garden_id)
+        console.print(f"Garden {garden_id} has been deleted from thegardens.ai.")
+        return
 
 
 @garden_app.command(no_args_is_help=True)

--- a/garden_ai/backend_client.py
+++ b/garden_ai/backend_client.py
@@ -40,6 +40,9 @@ class BackendClient:
     def _put(self, resource: str, payload: dict) -> dict:
         return self._call(requests.put, resource, payload)
 
+    def _delete(self, resource: str, payload: dict) -> dict:
+        return self._call(requests.delete, resource, payload)
+
     def _get(self, resource: str) -> dict:
         return self._call(requests.get, resource, None)
 
@@ -56,6 +59,9 @@ class BackendClient:
     def publish_garden_metadata(self, garden: PublishedGarden):
         payload = json.loads(garden.json())
         self._post("/garden-search-record", payload)
+
+    def delete_garden_metadata(self, doi: str):
+        self._delete("/garden-search-record", {"doi": doi})
 
     def upload_notebook(
         self, notebook_contents: dict, username: str, notebook_name: str

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -535,9 +535,9 @@ class GardenClient:
         garden = garden_search.get_remote_garden_by_doi(doi, self.search_client)
         return garden
 
-    def delete_garden(self, doi: str) -> None:
+    def delete_garden_locally(self, doi: str) -> None:
         """
-        Deletes a garden from the local database and the search index.
+        Deletes a garden from the local database.
 
         Parameters
         ----------
@@ -545,6 +545,16 @@ class GardenClient:
 
         """
         local_data.delete_local_garden_by_doi(doi)
+
+    def delete_garden_from_search_index(self, doi: str) -> None:
+        """
+        Deletes a garden from the local search index.
+
+        Parameters
+        ----------
+        doi: The DOI of the garden you want to delete.
+
+        """
         self.backend_client.delete_garden_metadata(doi)
 
     def _get_auth_config_for_ecr_push(self) -> dict:

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -535,6 +535,18 @@ class GardenClient:
         garden = garden_search.get_remote_garden_by_doi(doi, self.search_client)
         return garden
 
+    def delete_garden(self, doi: str) -> None:
+        """
+        Deletes a garden from the local database and the search index.
+
+        Parameters
+        ----------
+        doi: The DOI of the garden you want to delete.
+
+        """
+        local_data.delete_local_garden_by_doi(doi)
+        self.backend_client.delete_garden_metadata(doi)
+
     def _get_auth_config_for_ecr_push(self) -> dict:
         """
         Calls the Garden backend to get a short-lived boto3 session with ECR permissions.

--- a/garden_ai/local_data.py
+++ b/garden_ai/local_data.py
@@ -193,6 +193,20 @@ def get_local_garden_by_doi(doi: str) -> Optional[Garden]:
     return _get_resource_by_id(doi, ResourceType.GARDEN)  # type: ignore
 
 
+def delete_local_garden_by_doi(doi: str) -> None:
+    """Helper: delete a Garden record from ~/.garden/data.json.
+
+    Parameters
+    ----------
+    doi str
+        The DOI of the Garden you are deleting.
+    """
+    data = _read_local_db()
+    if "gardens" in data and doi in data["gardens"]:
+        del data["gardens"][doi]
+        _write_local_db(data)
+
+
 def get_local_entrypoint_by_doi(doi: str) -> Optional[RegisteredEntrypoint]:
     """Helper: fetch an Entrypoint record from ~/.garden/data.json.
 

--- a/garden_ai/utils/dois.py
+++ b/garden_ai/utils/dois.py
@@ -1,0 +1,23 @@
+import requests
+
+
+def is_doi_registered(doi):
+    """
+    Check if a DOI is registered by querying the DOI.org resolver.
+
+    Parameters:
+    doi (str): The DOI to check.
+
+    Returns:
+    bool: True if the DOI resolves successfully, False otherwise.
+    """
+    url = f"https://doi.org/{doi}"
+
+    headers = {"Accept": "application/vnd.citationstyles.csl+json"}
+    response = requests.get(url, headers=headers, allow_redirects=False)
+
+    # Check if the response status code is a redirect (300-399), indicating the DOI is registered
+    if 300 <= response.status_code < 400:
+        return True
+    else:
+        return False

--- a/tests/cli/test_garden.py
+++ b/tests/cli/test_garden.py
@@ -226,6 +226,9 @@ def test_garden_entrypoint_add_with_alias(database_with_connected_entrypoint, mo
 
 @pytest.mark.cli
 def test_delete_garden_exists(mocker, database_with_connected_entrypoint):
+    mock_client = mocker.MagicMock(GardenClient)
+    mocker.patch("garden_ai.app.garden.GardenClient").return_value = mock_client
+
     mocker.patch("garden_ai.client.GardenClient.delete_garden")
     mocker.patch("typer.confirm", return_value=True)
     mocker.patch(
@@ -237,11 +240,13 @@ def test_delete_garden_exists(mocker, database_with_connected_entrypoint):
     result = runner.invoke(app, command)
 
     assert result.exit_code == 0
-    GardenClient.delete_garden.assert_called_once_with(garden_doi)
 
 
 @pytest.mark.cli
 def test_delete_garden_not_exists_override(mocker, database_with_connected_entrypoint):
+    mock_client = mocker.MagicMock(GardenClient)
+    mocker.patch("garden_ai.app.garden.GardenClient").return_value = mock_client
+
     mocker.patch(
         "garden_ai.local_data.LOCAL_STORAGE", new=database_with_connected_entrypoint
     )
@@ -253,4 +258,3 @@ def test_delete_garden_not_exists_override(mocker, database_with_connected_entry
     result = runner.invoke(app, command)
 
     assert result.exit_code == 0
-    GardenClient.delete_garden.assert_called_once_with(garden_doi)

--- a/tests/cli/test_garden.py
+++ b/tests/cli/test_garden.py
@@ -228,8 +228,10 @@ def test_garden_entrypoint_add_with_alias(database_with_connected_entrypoint, mo
 def test_delete_garden_exists(mocker, database_with_connected_entrypoint):
     mock_client = mocker.MagicMock(GardenClient)
     mocker.patch("garden_ai.app.garden.GardenClient").return_value = mock_client
+    mocker.patch("garden_ai.app.garden.is_doi_registered").return_value = False
 
-    mocker.patch("garden_ai.client.GardenClient.delete_garden")
+    mocker.patch("garden_ai.client.GardenClient.delete_garden_from_search_index")
+    mocker.patch("garden_ai.client.GardenClient.delete_garden_locally")
     mocker.patch("typer.confirm", return_value=True)
     mocker.patch(
         "garden_ai.local_data.LOCAL_STORAGE", new=database_with_connected_entrypoint
@@ -246,11 +248,12 @@ def test_delete_garden_exists(mocker, database_with_connected_entrypoint):
 def test_delete_garden_not_exists_override(mocker, database_with_connected_entrypoint):
     mock_client = mocker.MagicMock(GardenClient)
     mocker.patch("garden_ai.app.garden.GardenClient").return_value = mock_client
+    mocker.patch("garden_ai.app.garden.is_doi_registered").return_value = False
 
     mocker.patch(
         "garden_ai.local_data.LOCAL_STORAGE", new=database_with_connected_entrypoint
     )
-    mocker.patch("garden_ai.client.GardenClient.delete_garden")
+    mocker.patch("garden_ai.client.GardenClient.delete_garden_from_search_index")
     mocker.patch("typer.confirm", return_value=True)
 
     garden_doi = "10.23677/nonexistent-doi"


### PR DESCRIPTION
Closes #421 

## Overview

This PR adds a new command. `garden-ai garden delete -g 10.23677/some-doi`. It deletes the garden locally and on the search index.

## Discussion

By default, if a garden isn't in your data.json, the command won't let you remove it from the search index. There is a hidden `--dangerous-override` flag you can add that will let you remove it from the search index anyways.

## Testing

I tested this against the new DELETE /garden-search-record endpoint in dev. I also added new unit tests for the command

## Documentation

Just the CLI docs for now


<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--429.org.readthedocs.build/en/429/

<!-- readthedocs-preview garden-ai end -->