### PR TITLE
hotfix: use new endpoint uuid in `constants.py`

### DIFF
--- a/garden_ai/constants.py
+++ b/garden_ai/constants.py
@@ -33,7 +33,7 @@ class GardenConstants:
         _DEV_ECR_REPO if os.environ.get("GARDEN_ENV") == "dev" else _PROD_ECR_REPO
     )
 
-    DEMO_ENDPOINT = "86a47061-f3d9-44f0-90dc-56ddc642c000"
+    DEMO_ENDPOINT = "6ed5d749-abc3-4c83-bcad-80837b3d126f"
 
     DLHUB_DOIS = set(
         [


### PR DESCRIPTION
Part of #428. Waiting to call #418 and #425 closed until I've got the helm chart cleaned up and documented etc in my other branch. 
## Overview
🪦  _Here lies DLHub Endpoint. May he `CrashLoopBackOff` in eternal peace._  🪦

## Discussion
Thursday is upon us, and sending anything to the dlhub endpoint just gets you: 
```
globus_sdk.exc.api.GlobusAPIError: 
('POST', 'https://compute.api.globus.org/v2/submit', 'Bearer', 403, 'ENDPOINT_ACCESS_FORBIDDEN', 'Unauthorized access to endpoint 86a47061-f3d9-44f0-90dc-56ddc642c000')
```

This PR just a) changes the default endpoint to the new one and b) pours one out 🫗 for the old. 

# What's not included 
Since only members of the associated globus group can actually use the new endpoint, the rest of #428 is going to be totally docs/error message focused to point users toward the link to join the group. 

In the meantime, I've sent Ryan Jacobs a group invite link directly and can send a followup once this change lands on pypi and he should update. 

## Testing

I've been frequently testing against both dlhub and the new endpoint for the past few days as I worked on getting it up and running, and as of today the new one is the less broken. 

The new one is _functional_ for both the one migrated dlhub model I've been using to test and the tutorial seedling. Still a couple of quirks, like the fact that a mysterious `encountered unknown data fields while reading a result message: {'details'}` warning now prints along with the results. 

But we do get results! 

To kick the tires, make sure you've joined [this](https://app.globus.org/groups/53952f8a-d592-11ee-9957-193531752178/about) group and try running any entrypoint.  
## Documentation

not yet! 

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--430.org.readthedocs.build/en/430/

<!-- readthedocs-preview garden-ai end -->