### PR TITLE
Edit entrypoint and garden metadata from the command line

### DIFF
--- a/garden_ai/app/entrypoint.py
+++ b/garden_ai/app/entrypoint.py
@@ -5,7 +5,6 @@ import typer
 import rich
 from rich.prompt import Prompt
 
-from garden_ai import local_data
 from garden_ai import GardenClient
 from garden_ai.app.console import (
     console,
@@ -246,6 +245,7 @@ def edit(
 
     entrypoint = get_local_entrypoint_by_doi(doi)
     if not entrypoint:
+        rich.print(f"Could not find entrypoint with doi {doi}")
         raise typer.Exit(code=1)
 
     string_fields = ["title", "description", "year", "short_name"]
@@ -253,7 +253,7 @@ def edit(
 
     edited_entrypoint = gui_edit_garden_entity(entrypoint, string_fields, list_fields)
 
-    local_data.put_local_entrypoint(edited_entrypoint)
+    put_local_entrypoint(edited_entrypoint)
     console.print(
         "Updated entrypoint {doi}. For the changes to be reflected on thegardens.ai, publish a garden that this entrypoint belongs to."
     )

--- a/garden_ai/app/entrypoint.py
+++ b/garden_ai/app/entrypoint.py
@@ -4,7 +4,10 @@ from typing import List
 import typer
 import rich
 from rich.prompt import Prompt
+from prompt_toolkit import prompt
+from prompt_toolkit.shortcuts import radiolist_dialog
 
+from garden_ai import local_data
 from garden_ai import GardenClient
 from garden_ai.app.console import (
     console,
@@ -229,3 +232,57 @@ def show(
             rich.print("\n")
         else:
             rich.print(f"Could not find entrypoint with id {entrypoint_id}")
+
+
+@entrypoint_app.command()
+def edit(
+    doi: str = typer.Argument(
+        ...,
+        autocompletion=complete_entrypoint,
+        help="The DOI of the entrypoint you want to edit",
+        rich_help_panel="Required",
+    )
+):
+    """Edit a Garden's metadata"""
+    entrypoint = get_local_entrypoint_by_doi(doi)
+    if not entrypoint:
+        raise typer.Exit(code=1)
+
+    string_fields = ["title", "description", "year", "short_name"]
+    list_fields = ["authors", "tags"]
+
+    choices = [
+        (field, f"{field}: {getattr(entrypoint, field)}")
+        for field in string_fields + list_fields
+    ]
+    selected_field = radiolist_dialog(
+        title="Select Field to Edit",
+        text="Use arrow keys to move, enter to select",
+        values=choices,
+    ).run()
+
+    if not selected_field:
+        return
+
+    if selected_field in string_fields:
+        old_value = getattr(entrypoint, selected_field)
+        new_value = prompt(f'Edit "{selected_field}"\n\n', default=old_value)
+
+    if selected_field in list_fields:
+        old_value = getattr(entrypoint, selected_field)
+        as_string = ", ".join(old_value)
+        new_value = prompt(
+            f'Edit list "{selected_field}". Values are comma-separated.\n\n',
+            default=as_string,
+        )
+        new_value = [x.strip() for x in new_value.split(",")]
+
+    typer.confirm(
+        f'You want to update "{selected_field}" to "{new_value}". Does this look right?',
+        abort=True,
+    )
+    setattr(entrypoint, selected_field, new_value)
+    local_data.put_local_entrypoint(entrypoint)
+    console.print(
+        "Updated entrypoint {doi}. For the changes to be reflected on thegardens.ai, publish a garden that this entrypoint belongs to."
+    )

--- a/garden_ai/app/entrypoint.py
+++ b/garden_ai/app/entrypoint.py
@@ -243,7 +243,8 @@ def edit(
         rich_help_panel="Required",
     )
 ):
-    """Edit a Garden's metadata"""
+    """Edit an Entrypoint's metadata"""
+
     entrypoint = get_local_entrypoint_by_doi(doi)
     if not entrypoint:
         raise typer.Exit(code=1)

--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -7,8 +7,6 @@ import rich
 import typer
 from globus_sdk import SearchAPIError
 from rich.prompt import Prompt
-from prompt_toolkit import prompt
-from prompt_toolkit.shortcuts import radiolist_dialog
 
 from garden_ai import local_data
 from garden_ai.client import GardenClient
@@ -16,6 +14,7 @@ from garden_ai.globus_search.garden_search import (
     RemoteGardenException,
 )
 from garden_ai.utils.dois import is_doi_registered
+from garden_ai.utils.interactive_cli import gui_edit_garden_entity
 from garden_ai.constants import GardenConstants
 from garden_ai.gardens import Garden
 from garden_ai.entrypoints import RegisteredEntrypoint
@@ -482,38 +481,9 @@ def edit(
     string_fields = ["title", "description", "year"]
     list_fields = ["authors", "contributors", "tags"]
 
-    choices = [
-        (field, f"{field}: {getattr(garden, field)}")
-        for field in string_fields + list_fields
-    ]
-    selected_field = radiolist_dialog(
-        title="Select Field to Edit",
-        text="Use arrow keys to move, enter to select",
-        values=choices,
-    ).run()
+    edited_garden = gui_edit_garden_entity(garden, string_fields, list_fields)
 
-    if not selected_field:
-        return
-
-    if selected_field in string_fields:
-        old_value = getattr(garden, selected_field)
-        new_value = prompt(f'Edit "{selected_field}"\n\n', default=old_value)
-
-    if selected_field in list_fields:
-        old_value = getattr(garden, selected_field)
-        as_string = ", ".join(old_value)
-        new_value = prompt(
-            f'Edit list "{selected_field}". Values are comma-separated.\n\n',
-            default=as_string,
-        )
-        new_value = [x.strip() for x in new_value.split(",")]
-
-    typer.confirm(
-        f'You want to update "{selected_field}" to "{new_value}". Does this look right?',
-        abort=True,
-    )
-    setattr(garden, selected_field, new_value)
-    local_data.put_local_garden(garden)
+    local_data.put_local_garden(edited_garden)
     console.print(
         f"Updated garden {doi}. Run `garden-ai garden publish -g {doi}` to push the change to thegardens.ai"
     )

--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -44,60 +44,6 @@ def garden():
     pass
 
 
-@garden_app.command()
-def edit(
-    doi: str = typer.Argument(
-        ...,
-        autocompletion=complete_garden,
-        help="The DOI of the garden you want to edit",
-        rich_help_panel="Required",
-    )
-):
-    """Edit a Garden's metadata"""
-    garden = _get_garden(doi)
-    if not garden:
-        raise typer.Exit(code=1)
-
-    string_fields = ["title", "description", "year"]
-    list_fields = ["authors", "contributors", "tags"]
-
-    choices = [
-        (field, f"{field}: {getattr(garden, field)}")
-        for field in string_fields + list_fields
-    ]
-    selected_field = radiolist_dialog(
-        title="Select Field to Edit",
-        text="Use arrow keys to move, enter to select",
-        values=choices,
-    ).run()
-
-    if not selected_field:
-        return
-
-    if selected_field in string_fields:
-        old_value = getattr(garden, selected_field)
-        new_value = prompt(f'Edit "{selected_field}"\n\n', default=old_value)
-
-    if selected_field in list_fields:
-        old_value = getattr(garden, selected_field)
-        as_string = ", ".join(old_value)
-        new_value = prompt(
-            f'Edit list "{selected_field}". Values are comma-separated.\n\n',
-            default=as_string,
-        )
-        new_value = [x.strip() for x in new_value.split(",")]
-
-    typer.confirm(
-        f'You want to update "{selected_field}" to "{new_value}". Does this look right?',
-        abort=True,
-    )
-    setattr(garden, selected_field, new_value)
-    local_data.put_local_garden(garden)
-    console.print(
-        f"Updated garden {doi}. Run `garden-ai garden publish -g {doi}` to push the change to thegardens.ai"
-    )
-
-
 @garden_app.command(no_args_is_help=True)
 def create(
     title: str = typer.Option(
@@ -516,6 +462,61 @@ def show(
             rich.print(f"Garden: {garden_id} local data:")
             rich.print_json(json=garden.json())
             rich.print("\n")
+
+
+@garden_app.command()
+def edit(
+    doi: str = typer.Argument(
+        ...,
+        autocompletion=complete_garden,
+        help="The DOI of the garden you want to edit",
+        rich_help_panel="Required",
+    )
+):
+    """Edit a Garden's metadata"""
+
+    garden = _get_garden(doi)
+    if not garden:
+        raise typer.Exit(code=1)
+
+    string_fields = ["title", "description", "year"]
+    list_fields = ["authors", "contributors", "tags"]
+
+    choices = [
+        (field, f"{field}: {getattr(garden, field)}")
+        for field in string_fields + list_fields
+    ]
+    selected_field = radiolist_dialog(
+        title="Select Field to Edit",
+        text="Use arrow keys to move, enter to select",
+        values=choices,
+    ).run()
+
+    if not selected_field:
+        return
+
+    if selected_field in string_fields:
+        old_value = getattr(garden, selected_field)
+        new_value = prompt(f'Edit "{selected_field}"\n\n', default=old_value)
+
+    if selected_field in list_fields:
+        old_value = getattr(garden, selected_field)
+        as_string = ", ".join(old_value)
+        new_value = prompt(
+            f'Edit list "{selected_field}". Values are comma-separated.\n\n',
+            default=as_string,
+        )
+        new_value = [x.strip() for x in new_value.split(",")]
+
+    typer.confirm(
+        f'You want to update "{selected_field}" to "{new_value}". Does this look right?',
+        abort=True,
+    )
+    setattr(garden, selected_field, new_value)
+    local_data.put_local_garden(garden)
+    console.print(
+        f"Updated garden {doi}. Run `garden-ai garden publish -g {doi}` to push the change to thegardens.ai"
+    )
 
 
 def _get_garden(garden_id: str) -> Optional[Garden]:

--- a/garden_ai/utils/interactive_cli.py
+++ b/garden_ai/utils/interactive_cli.py
@@ -23,13 +23,13 @@ def gui_edit_garden_entity(
     ).run()
 
     if not selected_field:
-        return
+        typer.echo("No field selected. Exiting.")
+        raise typer.Exit(code=1)
 
     if selected_field in string_fields:
         old_value = getattr(entity, selected_field)
         new_value = prompt(f'Edit "{selected_field}"\n\n', default=old_value)
-
-    if selected_field in list_fields:
+    elif selected_field in list_fields:
         old_value = getattr(entity, selected_field)
         as_string = ", ".join(old_value)
         new_value_as_string = prompt(
@@ -37,6 +37,9 @@ def gui_edit_garden_entity(
             default=as_string,
         )
         new_value = [x.strip() for x in new_value_as_string.split(",")]
+    else:
+        typer.echo(f'Did not recognize field "{selected_field}". Exiting.')
+        raise typer.Exit(code=1)
 
     typer.confirm(
         f'You want to update "{selected_field}" to "{new_value}". Does this look right?',

--- a/garden_ai/utils/interactive_cli.py
+++ b/garden_ai/utils/interactive_cli.py
@@ -18,7 +18,7 @@ def gui_edit_garden_entity(
     ]
     selected_field = radiolist_dialog(
         title="Select Field to Edit",
-        text="Use arrow keys to move, enter to select",
+        text="Use arrow keys to move, enter to select. Once you've selected a field, click Ok.",
         values=choices,
     ).run()
 
@@ -32,12 +32,12 @@ def gui_edit_garden_entity(
         new_value = prompt(f'Edit "{selected_field}"\n\n', default=old_value)
     elif selected_field in list_fields:
         old_value = getattr(entity, selected_field)
-        as_string = ", ".join(old_value)
+        as_string = "; ".join(old_value)
         new_value_as_string = prompt(
-            f'Edit list "{selected_field}". Values are comma-separated.\n\n',
+            f'Edit list "{selected_field}". Values are semicolon-separated.\n\n',
             default=as_string,
         )
-        new_value = [x.strip() for x in new_value_as_string.split(",")]
+        new_value = [x.strip() for x in new_value_as_string.split(";")]
     else:
         typer.echo(f'Did not recognize field "{selected_field}". Exiting.')
         raise typer.Exit(code=1)

--- a/garden_ai/utils/interactive_cli.py
+++ b/garden_ai/utils/interactive_cli.py
@@ -1,0 +1,45 @@
+from typing import Union, List, TypeVar
+
+import typer
+from prompt_toolkit.shortcuts import radiolist_dialog
+from prompt_toolkit import prompt
+
+from garden_ai import RegisteredEntrypoint, Garden
+
+T = TypeVar("T", RegisteredEntrypoint, Garden)
+
+
+def gui_edit_garden_entity(
+    entity: T, string_fields: List[str], list_fields: List[str]
+) -> T:
+    choices = [
+        (field, f"{field}: {getattr(entity, field)}")
+        for field in string_fields + list_fields
+    ]
+    selected_field = radiolist_dialog(
+        title="Select Field to Edit",
+        text="Use arrow keys to move, enter to select",
+        values=choices,
+    ).run()
+
+    if not selected_field:
+        return
+
+    if selected_field in string_fields:
+        old_value = getattr(entity, selected_field)
+        new_value = prompt(f'Edit "{selected_field}"\n\n', default=old_value)
+
+    if selected_field in list_fields:
+        old_value = getattr(entity, selected_field)
+        as_string = ", ".join(old_value)
+        new_value_as_string = prompt(
+            f'Edit list "{selected_field}". Values are comma-separated.\n\n',
+            default=as_string,
+        )
+        new_value = [x.strip() for x in new_value_as_string.split(",")]
+
+    typer.confirm(
+        f'You want to update "{selected_field}" to "{new_value}". Does this look right?',
+        abort=True,
+    )
+    setattr(entity, selected_field, new_value)

--- a/garden_ai/utils/interactive_cli.py
+++ b/garden_ai/utils/interactive_cli.py
@@ -43,3 +43,4 @@ def gui_edit_garden_entity(
         abort=True,
     )
     setattr(entity, selected_field, new_value)
+    return entity

--- a/garden_ai/utils/interactive_cli.py
+++ b/garden_ai/utils/interactive_cli.py
@@ -1,4 +1,4 @@
-from typing import List, TypeVar
+from typing import List, TypeVar, Union
 
 import typer
 from prompt_toolkit.shortcuts import radiolist_dialog
@@ -26,6 +26,7 @@ def gui_edit_garden_entity(
         typer.echo("No field selected. Exiting.")
         raise typer.Exit(code=1)
 
+    new_value: Union[str, List[str]]
     if selected_field in string_fields:
         old_value = getattr(entity, selected_field)
         new_value = prompt(f'Edit "{selected_field}"\n\n', default=old_value)

--- a/garden_ai/utils/interactive_cli.py
+++ b/garden_ai/utils/interactive_cli.py
@@ -1,4 +1,4 @@
-from typing import Union, List, TypeVar
+from typing import List, TypeVar
 
 import typer
 from prompt_toolkit.shortcuts import radiolist_dialog


### PR DESCRIPTION
Closes #386

## Overview

Adds new `entrypoint edit` and `garden edit` commands.

## Discussion

I'm deliberately making this pretty quick and dirty to avoid overbuilding this before we make an app and make this obsolete. For example, here's the view after you enter the command

![Screenshot 2024-03-04 at 11 40 17 AM](https://github.com/Garden-AI/garden/assets/6283143/6023aa1d-92dc-455d-8177-8f78186fb786)

You pick a field with an arrow key and enter, then click OK and you can edit the field. Having to click OK is janky, but (surprisingly) removing the need to click OK would be a step up in complexity to implement. This should solve the problem in the short term, even if it isn't beautiful.

## Testing

I tested both commands manually

## Documentation

Just in the CLI help

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--432.org.readthedocs.build/en/432/

<!-- readthedocs-preview garden-ai end -->