### PR TITLE
428 reference new endpoint

### DIFF
--- a/docs/user_guide/introduction.md
+++ b/docs/user_guide/introduction.md
@@ -1,7 +1,7 @@
 # 🌱 Welcome to Garden 🌱
 
 Docs are WIP, but in the meantime here are good places to start:
-- [Installation](installation.md) - getting your local machine set up for gardening
+- [Installation](installation.md) - getting yourself set up for gardening
 - [Overview](../architecture_overview.md) - High-level explanation of key concepts
 - [Tutorial](../user_guide/tutorial.md) - A short end-to-end example using the CLI. See also: ["seedlings" repository](https://github.com/Garden-AI/seedlings)
 - [contributing](../developer_guide/contributing.md) - Getting started as a contributor

--- a/docs/user_guide/tutorial.md
+++ b/docs/user_guide/tutorial.md
@@ -17,6 +17,9 @@ For this walkthrough, we will deploy a simple Scikit-Learn model that classifies
 - You need a free Globus account.
     - [Globus](https://www.globus.org/what-we-do) is a research computing platform that Garden builds on top of. Garden uses Globus to link you to academic computing clusters that you have access to.
     - [Go here to create a free Globus account.](https://app.globus.org/) If you are a researcher at a university, we recommend logging in with your institution's SSO. You can also log in with a Google or GitHub account.
+- You need to join the "Garden Users" Globus Group.
+	- This is necessary in order to run code on our demo Globus Compute endpoint.
+	- Join the group [here](https://app.globus.org/groups/53952f8a-d592-11ee-9957-193531752178/about).
 
 Confirm you have Garden and Docker installed.
 
@@ -152,6 +155,12 @@ Notice how Garden published your entrypoint to your tutorial garden. Now anyone 
 ### Step 5: Test Your Published Model
 
 Now that you've published your first garden and first entrypoint function, you should invoke it remotely like a user would.
+
+> [!NOTE] IMPORTANT
+> You will need to be part of the "Garden Users" Globus Group in order to run your code remotely on our demo endpoint.
+>
+> Join the group [here](https://app.globus.org/groups/53952f8a-d592-11ee-9957-193531752178/about).
+
 
 **The tutorial will continue in a separate notebook.** [Click here to continue in a Google Colab notebook that walks you through running your model like an end user would](https://colab.research.google.com/drive/1VM_SjYFnY1pxxac9ILQuqBT0fl3JADu0?usp=sharing). If you don't want to use Colab, you can also start a new notebook locally with `garden-ai notebook start` and follow the steps from the Colab notebook.
 

--- a/helm/garden_values.yaml
+++ b/helm/garden_values.yaml
@@ -10,16 +10,15 @@ image:
 
 workerDebug: false
 workerImage: python:3.10
+
 # workerInit paraphrased for compatibility with legacy dlhub models from
 # https://github.com/funcx-faas/funcX/blob/dlhub_deployment_version_0.3/helm/dlhub_values.yaml.
-# - omits `pip install home_run`, as it's since been installed in the bespoke dlhub images
-# - installs post-rebrand globus-compute-endpoint libraries
-#   - note: the latest version of globus-compute-endpoint compatible with 3.7 (v2.2.3) is
-#       broken. the long `import sys` command is just to conditionally install
-#       from my fork of the repo which "fixes" it enough for dlhub models to work.
-#   - otherwise, we want the globus-compute-endpoint bound as relaxed as
-#       possible so that different python versions can resolve their deps appropriately
-# - leaves mystery mkdir and PYTHONPATH commands as-is (no impact on garden images)
+# does the following:
+#   - modifies PYTHONPATH for backwards compatibility with dlhub
+#   - installs globus-compute-endpoint>=2.0 when running python 3.8 or above
+#   - otherwise install a patched version of globus compute v2.2.3 (the last
+#       3.7-compatible version) from github, since the one on pypi is broken.
+#       (This only applies to dlhub models; garden never supported 3.7)
 workerInit: export PYTHONPATH="$PYTHONPATH:/app:/home/ubuntu"; mkdir -p /home/ubuntu/; python -c "import sys; sys.exit(0 if sys.version_info < (3, 8) else 1)" && pip install "git+https://github.com/OwenPriceSkelly/funcX.git@3.7-compatibility-hack#subdirectory=compute_endpoint" || pip install "globus-compute-endpoint>=2.0"
 
 # we're restricted to the dlhub namespace on river
@@ -36,6 +35,9 @@ minBlocks: 1
 maxBlocks: 100
 maxWorkersPerPod: 1
 maxIdleTime: 3600
+
+# 20min should be generous for a demo endpoint
+taskTTLSeconds: 1200
 
 # any additional desired globus-compute-endpoint CLI args
 endpointCLIargs: --log-to-console

--- a/helm/garden_values.yaml
+++ b/helm/garden_values.yaml
@@ -14,11 +14,13 @@ workerImage: python:3.10
 # https://github.com/funcx-faas/funcX/blob/dlhub_deployment_version_0.3/helm/dlhub_values.yaml.
 # - omits `pip install home_run`, as it's since been installed in the bespoke dlhub images
 # - installs post-rebrand globus-compute-endpoint libraries
+#   - note: the latest version of globus-compute-endpoint compatible with 3.7 (v2.2.3) is
+#       broken. the long `import sys` command is just to conditionally install
+#       from my fork of the repo which "fixes" it enough for dlhub models to work.
+#   - otherwise, we want the globus-compute-endpoint bound as relaxed as
+#       possible so that different python versions can resolve their deps appropriately
 # - leaves mystery mkdir and PYTHONPATH commands as-is (no impact on garden images)
-workerInit: pip install "globus-compute-endpoint>=2.0.0"; export PYTHONPATH="$PYTHONPATH:/app:/home/ubuntu"; mkdir -p /home/ubuntu/
-# note: we want to leave this globus-compute-endpoint bound as relaxed as possible so that
-# containers running python 3.7 (i.e. legacy dlhub models) can still resolve dependencies
-# without impacting garden images unnecessarily
+workerInit: export PYTHONPATH="$PYTHONPATH:/app:/home/ubuntu"; mkdir -p /home/ubuntu/; python -c "import sys; sys.exit(0 if sys.version_info < (3, 8) else 1)" && pip install "git+https://github.com/OwenPriceSkelly/funcX.git@3.7-compatibility-hack#subdirectory=compute_endpoint" || pip install "globus-compute-endpoint>=2.0"
 
 # we're restricted to the dlhub namespace on river
 workerNamespace: dlhub


### PR DESCRIPTION
closes #428 

## Overview

This wraps up the demo-endpoint-related changes to the SDK and has the final (for the foreseeable future) tweaks to the helm chart. 

## Discussion

Changes to the workerInit for the demo endpoint have been live since last week -- this is the kludge for running models with python <= 3.7 which I hope to never touch again. 
I also added a 20 minute task timeout, which should be generous enough for good faith demos but not like, mining bitcoin or whatever. 

The docs now point tutorial-followers to join the Garden Users group as both a prerequisite and again at the point where users are going to try running on the demo endpoint.

The special error handling is there so users who bravely don't read docs still have an easy way to join.

still TODO: configure the globus group to auto-accept members instead of (only occasionally?) requiring me to manually approve them, but nothing in this PR is blocked on that. 

## Testing

I tested this with DLHub models (to make sure they remained unbroken) and by logging in with my personal email so I could confirm that the error handling looked correct for group non-members.

## Documentation

Yes, just in the tutorial


<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--434.org.readthedocs.build/en/434/

<!-- readthedocs-preview garden-ai end -->