### PR TITLE
Get the dependency scan portion of CI to pass again

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -12,12 +12,9 @@ security: # configuration for the `safety check` command
             reason: the scipy developers identified its CVE classification as unwarranted # optional, for internal note purposes to communicate with your team. This reason will be reported in the Safety reports
             # this exception can be removed when Python 3.8 is not supported
             # expires: '2022-10-21' # datetime string - date this ignore will expire, best practice to use this variable
-        60789: # Vulnerability ID
-            reason: this is a vulnerability of a dependency of mlflow. We don't use the subset of mlflow that uses this
-        60841: # Vulnerability ID
-            reason: this is a vulnerability of a dependency of mlflow. We don't use the subset of mlflow that uses this
-        62044:
-            reason: This doesn't affect us and Owen has resolved this on another branch.
+        65212: # Vulnerability ID
+            reason: this is for a crypto error that is not relevant to us functionally, and only happens on PowerPCs.
+
     continue-on-vulnerability-error: False # Suppress non-zero exit codes when vulnerabilities are found. Enable this in pipelines and CI/CD processes if you want to pass builds that have vulnerabilities. We recommend you set this to False.
 alert: # configuration for the `safety alert` command
     security:


### PR DESCRIPTION
When merging in Owen's last PR, I saw that CI was red on merge even though it had been green at PR time. It was because of a new vuln that `safety` reported which is irrelevant to us.

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--435.org.readthedocs.build/en/435/

<!-- readthedocs-preview garden-ai end -->