### PR TITLE
Pick another port if the default Jupyter port is in use

### DIFF
--- a/docs/user_guide/faqs.md
+++ b/docs/user_guide/faqs.md
@@ -20,4 +20,4 @@ If calling your entrypoint function in the `garden-ai notebook debug` session be
 
 Alas, you can't. Garden aways spins up Linux containers, so you can't install the `tensorflow-macos` variant. And the normal `tensorflow` doesn't run on Apple silicon.
 
-To work around this, we recommend using a VPS. Spin up a temporary EC2 instance (or equivalent on different cloud providers) running Linux where you can work on your notebook. When you ssh into your remote workstation, forward the port the notebook runs on so that you can still work on the notebook in your local browser. Like `ssh -L 8888:localhost:8888 my-remote-user@my-remote-workstation`.
+To work around this, we recommend using a VPS. Spin up a temporary EC2 instance (or equivalent on different cloud providers) running Linux where you can work on your notebook. When you ssh into your remote workstation, forward the port the notebook runs on so that you can still work on the notebook in your local browser. Like `ssh -L 9188:localhost:9188 my-remote-user@my-remote-workstation`.

--- a/docs/user_guide/tutorial.md
+++ b/docs/user_guide/tutorial.md
@@ -106,7 +106,7 @@ You should see output like this:
 
 ```bash
 Using base image: gardenai/base:python-3.10-jupyter-sklearn
-Notebook started! Opening http://127.0.0.1:8888/notebooks/tutorial_notebook.ipynb in your default browser (you may need to refresh the page)
+Notebook started! Opening http://127.0.0.1:9188/notebooks/tutorial_notebook.ipynb in your default browser (you may need to refresh the page)
 
 [stream of jupyter logs]
 ```

--- a/garden_ai/app/notebook.py
+++ b/garden_ai/app/notebook.py
@@ -268,14 +268,16 @@ def start(
         )
         _register_container_sigint_handler(container)
 
+    container.reload()
+    port = container.attrs["NetworkSettings"]["Ports"]["8888/tcp"][0]["HostPort"]
     typer.echo(
-        f"Notebook started! Opening http://127.0.0.1:8888/notebooks/{notebook_path.name} "
+        f"Notebook started! Opening http://127.0.0.1:{port}/notebooks/{notebook_path.name} "
         "in your default browser (you may need to refresh the page)"
     )
 
     # Give the notebook server a few seconds to start up so that the user doesn't have to refresh manually
     time.sleep(3)
-    webbrowser.open_new_tab(f"http://127.0.0.1:8888/notebooks/{notebook_path.name}")
+    webbrowser.open_new_tab(f"http://127.0.0.1:{port}/notebooks/{notebook_path.name}")
 
     # stream logs from the container
     for line in container.logs(stream=True):
@@ -377,11 +379,13 @@ def debug(
             )
             _register_container_sigint_handler(container)
 
+    container.reload()
+    port = container.attrs["NetworkSettings"]["Ports"]["8888/tcp"][0]["HostPort"]
     typer.echo(
-        f"Notebook started! Opening http://127.0.0.1:8888/notebooks/{debug_path.name} "
+        f"Notebook started! Opening http://127.0.0.1:{port}/notebooks/{debug_path.name} "
         "in your default browser (you may need to refresh the page)"
     )
-    webbrowser.open_new_tab(f"http://127.0.0.1:8888/notebooks/{debug_path.name}")
+    webbrowser.open_new_tab(f"http://127.0.0.1:{port}/notebooks/{debug_path.name}")
 
     # stream logs from the container
     for line in container.logs(stream=True):

--- a/garden_ai/constants.py
+++ b/garden_ai/constants.py
@@ -35,6 +35,11 @@ class GardenConstants:
 
     DEMO_ENDPOINT = "6ed5d749-abc3-4c83-bcad-80837b3d126f"
 
+    # Constants for picking a port to start a Jupyter notebook on
+    DEFAULT_JUPYTER_PORT = 9188
+    MAX_JUPYTER_PORTS_TO_ATTEMPT = 10
+
+    # The DOIs of entrypoints migrated from DLHub.
     DLHUB_DOIS = set(
         [
             "10.26311/3hz8-as26",

--- a/garden_ai/containers.py
+++ b/garden_ai/containers.py
@@ -3,6 +3,7 @@ import json
 import os
 import io
 import pathlib
+import socket
 import tarfile
 import functools
 import datetime
@@ -24,6 +25,22 @@ class DockerStartFailure(Exception):
         self.original_exception = original_exception
         self.helpful_explanation = explanation
         super().__init__(f"Docker failed to start: {original_exception}")
+
+
+class NoPortAvailable(Exception):
+    """
+    Raised when Garden can't find an available port to start a container.
+    """
+
+    def __init__(self):
+        max_port = (
+            GardenConstants.DEFAULT_JUPYTER_PORT
+            + GardenConstants.MAX_JUPYTER_PORTS_TO_ATTEMPT
+        )
+        super().__init__(
+            f"Failed to find an available port. "
+            f"All ports from {GardenConstants.DEFAULT_JUPYTER_PORT} to {max_port} are in use."
+        )
 
 
 class DockerPreBuildFailure(docker.errors.BuildError):
@@ -99,6 +116,27 @@ def get_docker_client() -> docker.DockerClient:
     return docker.from_env()
 
 
+def is_port_available(port):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    result = sock.connect_ex(("localhost", port))
+    sock.close()
+    return result != 0
+
+
+def find_available_port(start_port, max_attempts=10):
+    port = start_port
+    attempts = 0
+
+    while attempts < max_attempts:
+        if is_port_available(port):
+            return port
+        else:
+            port += 1
+            attempts += 1
+
+    raise NoPortAvailable()
+
+
 @handle_docker_errors
 def start_container_with_notebook(
     client: docker.DockerClient,
@@ -130,7 +168,7 @@ def start_container_with_notebook(
     - docker.models.containers.Container: The started container object.
 
     Note:
-    - The Jupyter Notebook server inside the container runs on port 8888
+    - The Jupyter Notebook server inside the container runs on a port between 9188 and 9198
       and is exposed to the host on the same port.
     """
     if pull:
@@ -141,11 +179,15 @@ def start_container_with_notebook(
     else:
         volumes = {}
 
+    port = find_available_port(
+        GardenConstants.DEFAULT_JUPYTER_PORT,
+        max_attempts=GardenConstants.MAX_JUPYTER_PORTS_TO_ATTEMPT,
+    )
     container = client.containers.run(
         base_image,
         platform="linux/x86_64",
         detach=True,
-        ports={"8888/tcp": 8888},
+        ports={f"8888/tcp": port},
         volumes=volumes,
         entrypoint=[
             "jupyter",

--- a/garden_ai/containers.py
+++ b/garden_ai/containers.py
@@ -38,7 +38,7 @@ class NoPortAvailable(Exception):
             + GardenConstants.MAX_JUPYTER_PORTS_TO_ATTEMPT
         )
         super().__init__(
-            f"Failed to find an available port. "
+            f"Failed to find an available port to start your Jupyter notebook. "
             f"All ports from {GardenConstants.DEFAULT_JUPYTER_PORT} to {max_port} are in use."
         )
 

--- a/garden_ai/containers.py
+++ b/garden_ai/containers.py
@@ -187,7 +187,7 @@ def start_container_with_notebook(
         base_image,
         platform="linux/x86_64",
         detach=True,
-        ports={f"8888/tcp": port},
+        ports={"8888/tcp": port},
         volumes=volumes,
         entrypoint=[
             "jupyter",

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -48,7 +48,11 @@ def mock_datetime():
         yield fixed_datetime
 
 
-def test_start_container_with_notebook(mock_docker_client):
+def test_start_container_with_notebook(mock_docker_client, mocker):
+    mock_socket = mocker.patch("garden_ai.containers.socket.socket")
+    # Make it so that the port check always shows that port is not in use.
+    mock_socket.return_value.connect_ex.return_value = 1
+
     path = pathlib.Path("/path/to/notebook.ipynb")
     base_image = "gardenai/fake-image:soonest"
 
@@ -77,7 +81,7 @@ def test_start_container_with_notebook(mock_docker_client):
         base_image,
         platform="linux/x86_64",
         detach=True,
-        ports={"8888/tcp": 8888},
+        ports={"8888/tcp": GardenConstants.DEFAULT_JUPYTER_PORT},
         volumes=expected_volumes,
         entrypoint=expected_entrypoint,
         stdin_open=True,


### PR DESCRIPTION
Closes #395 

## Overview

This PR makes it so the default port we open Jupyter on is less popular and less likely to have conflicts. (9188 instead of 8888.) And then if 9188 is in use we try 9189, 9190, and so on until we give up at 9198. This makes it so that users can have multiple Jupyter sessions open at a time. It also means that a user running Jupyter on a default port in a standalone application can use Garden without shutting down their other notebook

## Discussion


## Testing

I updated an affected unit test. I also tested manually on cases where I opened multiple instances of Jupyter in multiple terminal windows.

## Documentation

I updated some docs that referenced the old default port.


<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--444.org.readthedocs.build/en/444/

<!-- readthedocs-preview garden-ai end -->