### PR TITLE
add missing `manage_projects` scope to auth code

### DIFF
--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -11,6 +11,7 @@ from uuid import UUID
 import typer
 from globus_compute_sdk import Client
 from globus_compute_sdk.sdk.login_manager.tokenstore import get_token_storage_adapter
+from globus_compute_sdk.sdk.login_manager import ComputeScopes
 from globus_compute_sdk.serialize.concretes import DillCodeTextInspect
 from globus_sdk import (
     AuthAPIError,
@@ -40,8 +41,6 @@ from garden_ai.entrypoints import (
 )
 from garden_ai.utils._meta import make_function_to_register
 from garden_ai.utils.misc import extract_email_from_globus_jwt
-
-COMPUTE_RESOURCE_SERVER_NAME = "funcx_service"
 
 logger = logging.getLogger()
 
@@ -109,7 +108,7 @@ class GardenClient:
                 SearchClient.scopes.resource_server
             )
             self.compute_authorizer = self._create_authorizer(
-                COMPUTE_RESOURCE_SERVER_NAME
+                ComputeScopes.resource_server
             )
             self.search_client = (
                 SearchClient(authorizer=self.search_authorizer)
@@ -168,10 +167,12 @@ class GardenClient:
             requested_scopes=[
                 AuthLoginClient.scopes.openid,
                 AuthLoginClient.scopes.email,
+                AuthLoginClient.scopes.manage_projects,
                 GroupsClient.scopes.view_my_groups_and_memberships,
                 SearchClient.scopes.all,
                 GardenClient.scopes.test_scope,
-                Client.FUNCX_SCOPE,
+                GardenClient.scopes.action_all,
+                ComputeScopes.all,
             ],
             refresh_tokens=True,
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -67,9 +67,11 @@ def test_client_no_previous_tokens(
         requested_scopes=[
             "openid",
             "email",
+            "urn:globus:auth:scope:auth.globus.org:manage_projects",
             "urn:globus:auth:scope:groups.api.globus.org:view_my_groups_and_memberships",
             "urn:globus:auth:scope:search.api.globus.org:all",
             "https://auth.globus.org/scopes/0948a6b0-a622-4078-b0a4-bfd6d77d65cf/test_scope",
+            "https://auth.globus.org/scopes/0948a6b0-a622-4078-b0a4-bfd6d77d65cf/action_all",
             "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all",
         ],
     )


### PR DESCRIPTION
fixes #448 

## Overview
The login bug came back because (as of bumping globus compute from 2.11->2.16) we were no longer requesting a superset of the scopes that the globus compute client does. They now also need the `AuthLoginClient.scopes.manage_projects` scope, so they would trigger another login flow without it. 

Adding the same scope to our list fixed it 🎉

## Discussion

I cleaned up the hardcoded `COMPUTE_RESOURCE_SERVER_NAME = "funcx_service"` to reference the sdk's `ComputeScopes` constant instead, because a comment I found in their sdk indicated they might rebrand that soon too. I also noticed that we're not even requesting our own `action_all` scope (we've just been using the `test_scope`) so I added that to the list, too. 
## Testing

Tested by removing my tokens and logging in again exactly once. Also need to update a unit test. 

## Documentation

no docs

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--449.org.readthedocs.build/en/449/

<!-- readthedocs-preview garden-ai end -->