### PR TITLE
@backend_toggle feature flags decorator

### DIFF
--- a/.env.shared
+++ b/.env.shared
@@ -1,3 +1,4 @@
 # note: does not override existing vars
 # so if you've explicitly set GARDEN_ENV=prod, that choice will be respected
 GARDEN_ENV=dev
+GARDEN_BACKEND_TOGGLES=mint_doi_on_datacite,update_doi_on_datacite

--- a/garden_ai/backend_client.py
+++ b/garden_ai/backend_client.py
@@ -1,7 +1,9 @@
 import json
+import os
 import logging
 from typing import Callable, Optional
 import boto3
+from functools import wraps
 
 import requests
 
@@ -9,6 +11,55 @@ from garden_ai.constants import GardenConstants
 from garden_ai.gardens import PublishedGarden
 
 logger = logging.getLogger()
+
+
+def backend_toggle(func):
+    """feature flag decorator for BackendClient methods.
+
+    Behavior is controlled by the env vars GARDEN_ENV and GARDEN_BACKEND_TOGGLES
+    (see .env.shared). To disable for all methods, set
+    GARDEN_BACKEND_TOGGLES="".
+
+    If a decorated method's name (e.g. mint_doi_on_datacite) is found in the
+    GARDEN_BACKEND_TOGGLES var, it will target an instance of the new backend
+    according to the value of GARDEN_ENV.
+
+    If GARDEN_ENV=dev or prod, this targets one of the lightsail deployments. If
+    GARDEN_ENV=local, this targets localhost:5500 (i.e. an instance started with
+    the backend's run-dev-server.sh script)
+    """
+    # dev, prod or local
+    garden_env = os.getenv("GARDEN_ENV", "")
+    # e.g. "mint_doi_on_datacite,update_doi_on_datacite"
+    toggles = os.getenv("GARDEN_BACKEND_TOGGLES", "")
+    env_url_mapping = {
+        "dev": "https://garden-service-dev.0dh7fu9qsbhfi.us-east-1.cs.amazonlightsail.com",
+        "prod": "https://garden-service-prod.0dh7fu9qsbhfi.us-east-1.cs.amazonlightsail.com",
+        "local": "http://localhost:5500",
+    }
+    if garden_env not in env_url_mapping or func.__name__ not in toggles:
+        return func
+
+    old_url = GardenConstants.GARDEN_ENDPOINT
+    new_url = env_url_mapping[garden_env]
+
+    old_call_method = BackendClient._call
+
+    def _call_with_trailing_slash(self: BackendClient, http_verb, resource, payload):
+        resource = resource + "/"
+        return old_call_method(self, http_verb, resource, payload)
+
+    @wraps(func)
+    def monkey_patch_url(*args, **kwargs):
+        try:
+            GardenConstants.GARDEN_ENDPOINT = new_url
+            BackendClient._call = _call_with_trailing_slash
+            return func(*args, **kwargs)
+        finally:
+            GardenConstants.GARDEN_ENDPOINT = old_url
+            BackendClient._call = old_call_method
+
+    return monkey_patch_url
 
 
 # Client for the Garden backend API. The name "GardenClient" was taken :)
@@ -46,6 +97,7 @@ class BackendClient:
     def _get(self, resource: str) -> dict:
         return self._call(requests.get, resource, None)
 
+    @backend_toggle
     def mint_doi_on_datacite(self, payload: dict) -> str:
         response_dict = self._post("/doi", payload)
         doi = response_dict.get("doi", None)
@@ -53,16 +105,20 @@ class BackendClient:
             raise ValueError("Failed to mint DOI. Response was missing doi field.")
         return doi
 
+    @backend_toggle
     def update_doi_on_datacite(self, payload: dict):
         self._put("/doi", payload)
 
+    @backend_toggle
     def publish_garden_metadata(self, garden: PublishedGarden):
         payload = json.loads(garden.json())
         self._post("/garden-search-record", payload)
 
+    @backend_toggle
     def delete_garden_metadata(self, doi: str):
         self._delete("/garden-search-record", {"doi": doi})
 
+    @backend_toggle
     def upload_notebook(
         self, notebook_contents: dict, username: str, notebook_name: str
     ):
@@ -74,6 +130,7 @@ class BackendClient:
         resp = self._post("/notebook", payload)
         return resp["notebook_url"]
 
+    @backend_toggle
     def get_docker_push_session(self) -> boto3.Session:
         resp = self._get("/docker-push-token")
 

--- a/garden_ai/backend_client.py
+++ b/garden_ai/backend_client.py
@@ -28,7 +28,7 @@ def backend_toggle(func):
     GARDEN_ENV=local, this targets localhost:5500 (i.e. an instance started with
     the backend's run-dev-server.sh script)
     """
-    # dev, prod or local
+    # "dev", "prod" or "local"
     garden_env = os.getenv("GARDEN_ENV", "")
     # e.g. "mint_doi_on_datacite,update_doi_on_datacite"
     toggles = os.getenv("GARDEN_BACKEND_TOGGLES", "")
@@ -46,6 +46,10 @@ def backend_toggle(func):
     old_call_method = BackendClient._call
 
     def _call_with_trailing_slash(self: BackendClient, http_verb, resource, payload):
+        """Drop in replacement for monkey-patching `BackendClient._call`"""
+        # for context: calls to the new backend on lightsail break without a
+        # trailing slash, but a trailing slash everywhere would break calls to
+        # the old backend.
         resource = resource + "/"
         return old_call_method(self, http_verb, resource, payload)
 

--- a/garden_ai/constants.py
+++ b/garden_ai/constants.py
@@ -22,15 +22,19 @@ class GardenConstants:
     GARDEN_KEY_STORE = os.path.join(GARDEN_DIR, "tokens.json")
     URL_ENV_VAR_NAME = "GARDEN_MODELS"
     GARDEN_ENDPOINT = (
-        _DEV_ENDPOINT if os.environ.get("GARDEN_ENV") == "dev" else _PROD_ENDPOINT
+        _DEV_ENDPOINT
+        if os.environ.get("GARDEN_ENV") in ("dev", "local")
+        else _PROD_ENDPOINT
     )
     GARDEN_INDEX_UUID = (
         _DEV_SEARCH_INDEX
-        if os.environ.get("GARDEN_ENV") == "dev"
+        if os.environ.get("GARDEN_ENV") in ("dev", "local")
         else _PROD_SEARCH_INDEX
     )
     GARDEN_ECR_REPO = (
-        _DEV_ECR_REPO if os.environ.get("GARDEN_ENV") == "dev" else _PROD_ECR_REPO
+        _DEV_ECR_REPO
+        if os.environ.get("GARDEN_ENV") in ("dev", "local")
+        else _PROD_ECR_REPO
     )
 
     DEMO_ENDPOINT = "6ed5d749-abc3-4c83-bcad-80837b3d126f"


### PR DESCRIPTION
closes #457 

## Overview

This gives us a nice way to point certain backend client methods at instances of the revamp-in-progress backend for the sake of testing. This is controlled by the values of a new `GARDEN_BACKEND_TOGGLES` environment variable and the old `GARDEN_ENV` variable. 

Note that these are left unset by default if you've e.g. installed garden from PyPI. Default behavior for anyone outside of a `poetry shell` is still always to target the current prod backend. Default behavior for anyone inside a `poetry shell` (or someone who manually sets these variables) has changed.

The new `GARDEN_BACKEND_TOGGLES` variable should be a list of methods to point at revamp resources instead of the usual ones. For example, because I've added a default value of `GARDEN_BACKEND_TOGGLES=mint_doi_on_datacite,update_doi_on_datacite` to the `.env.shared`, if you're running garden from `poetry shell` it will default to the dev lambda (as usual) for every method except the two doi methods, which will now target the dev lightsail deployment.

The existing `GARDEN_ENV` variable can now be `"local"` in addition to "dev" and "prod". If set to dev or prod, the toggled methods will target the respective lightsail deployments instead of the respective dev/prod lambdas. Note that only explicitly setting GARDEN_ENV=prod has this behavior; if GARDEN_ENV is unset then everything is still the old prod resources. 

If set to "local", toggled methods will target `localhost:5500` to play nicely with the revamp's `run-dev-server.sh` script. un-toggled methods will target the dev lambda when GARDEN_ENV=local.

## Discussion

The decorator was probably more fun to write than to read. But it works pretty well and will be nice and easy to delete when we're done with the revamp.

## Testing

Manually, both by exercising backend methods directly from a repl and by using the CLI in a poetry shell.

## Documentation

No docs

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--458.org.readthedocs.build/en/458/

<!-- readthedocs-preview garden-ai end -->