### PR TITLE
459 point at custom domains

### DIFF
--- a/.env.shared
+++ b/.env.shared
@@ -1,4 +1,3 @@
 # note: does not override existing vars
 # so if you've explicitly set GARDEN_ENV=prod, that choice will be respected
 GARDEN_ENV=dev
-GARDEN_BACKEND_TOGGLES=mint_doi_on_datacite,update_doi_on_datacite

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     -   id: check-added-large-files
     -   id: no-commit-to-branch # don't commit to main
 -   repo: https://github.com/psf/black
-    rev: 24.1.0
+    rev: 24.4.2
     hooks:
     - id: black
       language_version: python3.11

--- a/garden_ai/backend_client.py
+++ b/garden_ai/backend_client.py
@@ -1,9 +1,7 @@
 import json
-import os
 import logging
 from typing import Callable, Optional
 import boto3
-from functools import wraps
 
 import requests
 
@@ -11,59 +9,6 @@ from garden_ai.constants import GardenConstants
 from garden_ai.gardens import PublishedGarden
 
 logger = logging.getLogger()
-
-
-def backend_toggle(func):
-    """feature flag decorator for BackendClient methods.
-
-    Behavior is controlled by the env vars GARDEN_ENV and GARDEN_BACKEND_TOGGLES
-    (see .env.shared). To disable for all methods, set
-    GARDEN_BACKEND_TOGGLES="".
-
-    If a decorated method's name (e.g. mint_doi_on_datacite) is found in the
-    GARDEN_BACKEND_TOGGLES var, it will target an instance of the new backend
-    according to the value of GARDEN_ENV.
-
-    If GARDEN_ENV=dev or prod, this targets one of the lightsail deployments. If
-    GARDEN_ENV=local, this targets localhost:5500 (i.e. an instance started with
-    the backend's run-dev-server.sh script)
-    """
-    # "dev", "prod" or "local"
-    garden_env = os.getenv("GARDEN_ENV", "")
-    # e.g. "mint_doi_on_datacite,update_doi_on_datacite"
-    toggles = os.getenv("GARDEN_BACKEND_TOGGLES", "")
-    env_url_mapping = {
-        "dev": "https://garden-service-dev.0dh7fu9qsbhfi.us-east-1.cs.amazonlightsail.com",
-        "prod": "https://garden-service-prod.0dh7fu9qsbhfi.us-east-1.cs.amazonlightsail.com",
-        "local": "http://localhost:5500",
-    }
-    if garden_env not in env_url_mapping or func.__name__ not in toggles:
-        return func
-
-    @wraps(func)
-    def monkey_patch_url(*args, **kwargs):
-        old_url = GardenConstants.GARDEN_ENDPOINT
-        new_url = env_url_mapping[garden_env]
-
-        old_call_method = BackendClient._call
-
-        def new_call_method(self: BackendClient, http_verb, resource, payload):
-            """Drop in replacement for monkey-patching `BackendClient._call`"""
-            # for context: calls to the new backend on lightsail break without a
-            # trailing slash, but a trailing slash everywhere would break calls to
-            # the old backend.
-            resource = resource + "/"
-            return old_call_method(self, http_verb, resource, payload)
-
-        try:
-            GardenConstants.GARDEN_ENDPOINT = new_url
-            BackendClient._call = new_call_method
-            return func(*args, **kwargs)
-        finally:
-            GardenConstants.GARDEN_ENDPOINT = old_url
-            BackendClient._call = old_call_method
-
-    return monkey_patch_url
 
 
 # Client for the Garden backend API. The name "GardenClient" was taken :)
@@ -101,7 +46,6 @@ class BackendClient:
     def _get(self, resource: str) -> dict:
         return self._call(requests.get, resource, None)
 
-    @backend_toggle
     def mint_doi_on_datacite(self, payload: dict) -> str:
         response_dict = self._post("/doi", payload)
         doi = response_dict.get("doi", None)
@@ -109,20 +53,16 @@ class BackendClient:
             raise ValueError("Failed to mint DOI. Response was missing doi field.")
         return doi
 
-    @backend_toggle
     def update_doi_on_datacite(self, payload: dict):
         self._put("/doi", payload)
 
-    @backend_toggle
     def publish_garden_metadata(self, garden: PublishedGarden):
         payload = json.loads(garden.json())
         self._post("/garden-search-record", payload)
 
-    @backend_toggle
     def delete_garden_metadata(self, doi: str):
         self._delete("/garden-search-record", {"doi": doi})
 
-    @backend_toggle
     def upload_notebook(
         self, notebook_contents: dict, username: str, notebook_name: str
     ):
@@ -134,7 +74,6 @@ class BackendClient:
         resp = self._post("/notebook", payload)
         return resp["notebook_url"]
 
-    @backend_toggle
     def get_docker_push_session(self) -> boto3.Session:
         resp = self._get("/docker-push-token")
 

--- a/garden_ai/constants.py
+++ b/garden_ai/constants.py
@@ -6,8 +6,9 @@ import pathlib
 dotenv_path = pathlib.Path(f"{__file__}/../..").resolve() / ".env.shared"
 load_dotenv(str(dotenv_path), override=False)
 
-_PROD_ENDPOINT = "https://nu3cetwc84.execute-api.us-east-1.amazonaws.com/garden_prod"
-_DEV_ENDPOINT = "https://y0ipq1bueb.execute-api.us-east-1.amazonaws.com/garden_dev"
+_PROD_ENDPOINT = "https://api.thegardens.ai"
+_DEV_ENDPOINT = "https://api-dev.thegardens.ai"
+_LOCAL_ENDPOINT = "http://localhost:5500"
 
 _DEV_SEARCH_INDEX = "58e4df29-4492-4e7d-9317-b27eba62a911"
 _PROD_SEARCH_INDEX = "813d4556-cbd4-4ba9-97f2-a7155f70682f"
@@ -22,9 +23,9 @@ class GardenConstants:
     GARDEN_KEY_STORE = os.path.join(GARDEN_DIR, "tokens.json")
     URL_ENV_VAR_NAME = "GARDEN_MODELS"
     GARDEN_ENDPOINT = (
-        _DEV_ENDPOINT
-        if os.environ.get("GARDEN_ENV") in ("dev", "local")
-        else _PROD_ENDPOINT
+        _LOCAL_ENDPOINT
+        if os.environ.get("GARDEN_ENV") == "local"
+        else _DEV_ENDPOINT if os.environ.get("GARDEN_ENV") == "dev" else _PROD_ENDPOINT
     )
     GARDEN_INDEX_UUID = (
         _DEV_SEARCH_INDEX


### PR DESCRIPTION
completes #459 

## Overview
what it says on the tin: this points the sdk at the appropriate `api[-dev].thegardens.ai` urls instead of the old ones. 

## Discussion
Two other small changes:

  - kills the `@backend_toggle` decorator (RIP 🪦)
  - bumps the pre-commit formatter. it was disagreeing slightly with the version of `black` that my emacs was pointed at, causing me near-fatal Minor Annoyance 

## Testing

tested a few routes by using the CLI in a poetry shell against both local and dev instances, i.e. the CLI was hitting api-dev.thegardens.ai just fine. this is what prompted the backend PR to remove the trailing slashes from routes 

## Documentation

no docs 

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--460.org.readthedocs.build/en/460/

<!-- readthedocs-preview garden-ai end -->