### PR TITLE
Add idempotency check to @entrypoint_test

### DIFF
--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -1,6 +1,10 @@
+import unittest
 from unittest.mock import patch, MagicMock
+from garden_ai import EntrypointMetadata, garden_entrypoint, entrypoint_test
 from garden_ai.entrypoints import (
     RegisteredEntrypoint,
+    EntrypointIdempotencyError,
+    EntrypointTestError,
 )  # Adjust import paths as necessary
 
 # Mock UUIDs for testing
@@ -69,3 +73,60 @@ def test_normal_entrypoint(mock_executor):
         result == "mocked result"
     ), "Should return the direct result for an entrypoint with DOI not in list"
     mock_executor_instance.submit_to_registered_function.assert_called_once()
+
+
+def test_non_idempotent_garden_entrypoint_raises_error():
+    class NonIdempotentCounter:
+        def __init__(self):
+            self.times_called = 0
+
+        def increment(self):
+            self.times_called += 1
+            return self.times_called
+
+    counter = NonIdempotentCounter()
+
+    metadata = EntrypointMetadata(
+        title="Fake Entrypoint",
+        description="A sample description",
+        authors=["Farnsworth, Hubert J."],
+        tags=["test"],
+    )
+
+    # Setup a mock entrypoint that is non-idempotent
+    @garden_entrypoint(metadata=metadata)
+    def non_idempotent_entrypoint_func():
+        return counter.increment()
+
+    # Setup a simple entrypoint_test
+    @entrypoint_test(non_idempotent_entrypoint_func)
+    def test_the_entrypoint():
+        result = non_idempotent_entrypoint_func()
+        return result
+
+    # Assert the entrypoint test throws an error due to non-idempotency
+    with unittest.TestCase().assertRaises(EntrypointTestError):
+        test_the_entrypoint()
+
+
+def test_idempotent_garden_entrpoint_passes():
+    metadata = EntrypointMetadata(
+        title="Fake Entrypoint",
+        description="A sample description",
+        authors=["Farnsworth, Hubert J."],
+        tags=["test"],
+    )
+
+    # Setup a mock entrypoint that is idempotent
+    @garden_entrypoint(metadata=metadata)
+    def idempotent_entrypoint_func():
+        return True
+
+    # Setup a simple entrypoint_test
+    @entrypoint_test(idempotent_entrypoint_func)
+    def test_the_entrypoint():
+        result = idempotent_entrypoint_func()
+        return result
+
+    # Assert the test returns the value as it should pass the entrypoint_test
+    assert test_the_entrypoint() == True


### PR DESCRIPTION
Resolves #424

## Overview

`@entrypoint_test` will raise a `EntrypointIdempotencyError` if the function being tested is non-idempotent. If any other exceptions are raised during the test, they are raised as an `EntrypointTestError`. This should make it easier for users to catch issues with their entrypoints before publishing.

## Testing

Add unit tests in `test/test_entrypoints.py` to confirm behavior.

## Documentation

Updates the doc comments in `entrypoint_test`
