### PR TITLE
Add requirements to RegisteredEntrypoint metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ dmypy.json
 
 # VSCode config
 .vscode/*
+
+# Emacs
+TAGS

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,7 @@ repos:
     - id: black
       language_version: python3
       args: [--exclude, 'fixtures']
+-   repo: https://github.com/PyCQA/flake8
+    rev: 7.0.0
+    hooks:
+    - id: flake8

--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -130,6 +130,8 @@ def create(
                     authors += [name]
                 else:
                     break
+        else:
+            contributors = []
 
     if not description:
         description = Prompt.ask(

--- a/garden_ai/entrypoints.py
+++ b/garden_ai/entrypoints.py
@@ -148,6 +148,7 @@ class RegisteredEntrypoint(EntrypointMetadata):
         notebook_url: Link to the notebook used to build this entrypoint.
         steps: Ordered list of Python functions that the entrypoint author wants to highlight.
         test_functions: List of test functions that exercise the entrypoint.
+        requirements: List of Python packages required by the entrypoint.
     """
 
     doi: str = Field(
@@ -161,6 +162,7 @@ class RegisteredEntrypoint(EntrypointMetadata):
     notebook_url: Optional[str] = Field(None)
     steps: List[Step] = Field(default_factory=list)
     test_functions: List[str] = Field(default_factory=list)
+    requirements: Optional[List[str]] = Field(default_factory=list)
 
     def __call__(
         self,


### PR DESCRIPTION
Resolves #375
 
## Overview

- Pin requirements in the `RegisteredEntrypoint` metadata if a requirements file is present when a notebook is published.

- Write the requirements into `metadata.json` inside the published container image. This ensures when a garden is published to the search index the metadata for each entrypoint includes the requirements.

- Fix a small bug where creating a garden with no contributors threw an exception.

- add flake8 to pre-commit

- add emacs TAGS to `.gitignore`

## Testing

Tested manually by creating a notebook with a requirements file and a single entrypoint, publishing it, and confirming that the `metadata.json` in the published image contains the requirements data. Tested another notebook with no added requirements to ensure other functionality is not impacted.

I am struggling to come up with efficient unit tests for this. I want to confirm the `metadata.json` is correct, but to do that I need to build a container image which will significantly slow down the test suite.

## Documentation

Updates the doc comments for `RegisteredEntrypoint`
