### PR TITLE
Bugfix: Send correct URL to Datacite on `garden register-doi`

### DIFF
--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -311,7 +311,11 @@ class GardenClient:
         # "publish" in the event field moves the DOI from draft state to findable state
         # https://support.datacite.org/docs/how-do-i-make-a-findable-doi-with-the-rest-api
         if register_doi:
-            metadata.update(event="publish", url=f"https://thegardens.ai/{obj.doi}")
+            doi_split = obj.doi.split("/")
+            metadata.update(
+                event="publish",
+                url=f"https://thegardens.ai/#/garden/{doi_split[0]}%2f{doi_split[1]}",
+            )
 
         payload = {"data": {"type": "dois", "attributes": metadata}}
         self.backend_client.update_doi_on_datacite(payload)

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -7,6 +7,7 @@ import base64
 from pathlib import Path
 from typing import List, Union
 from uuid import UUID
+import urllib
 
 import typer
 from globus_compute_sdk import Client
@@ -311,10 +312,10 @@ class GardenClient:
         # "publish" in the event field moves the DOI from draft state to findable state
         # https://support.datacite.org/docs/how-do-i-make-a-findable-doi-with-the-rest-api
         if register_doi:
-            doi_split = obj.doi.split("/")
+            doi = urllib.parse.quote(obj.doi, safe="")
             metadata.update(
                 event="publish",
-                url=f"https://thegardens.ai/#/garden/{doi_split[0]}%2f{doi_split[1]}",
+                url=f"https://thegardens.ai/#/garden/{doi}",
             )
 
         payload = {"data": {"type": "dois", "attributes": metadata}}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -203,48 +203,10 @@ def test_client_credentials_grant(cc_grant_tuple):
 
 def test_client_datacite_url_correct(
     mocker,
-    mock_authorizer_tuple,
-    token,
-    mock_keystore,
-    identity_jwt,
+    garden_client,
 ):
-    mock_authorizer_constructor, mock_authorizer = mock_authorizer_tuple
-    # Mocks for KeyStore
-    mock_keystore.file_exists.return_value = False
 
-    # Mocks for Login Flow
-    mock_auth_client = mocker.MagicMock(AuthLoginClient)
-    mock_auth_client.oauth2_get_authorize_url = mocker.Mock(
-        return_value="https://globus.auth.garden"
-    )
-    mock_auth_client.oauth2_start_flow = mocker.Mock()
-    mocker.patch("garden_ai.client.Prompt.ask").return_value = "my token"
-    mocker.patch("garden_ai.client.typer.launch")
-
-    mock_search_client = mocker.MagicMock(SearchClient)
-
-    mock_token_response = mocker.MagicMock(OAuthTokenResponse)
-    mock_token_response.by_resource_server = {
-        "groups.api.globus.org": token,
-        "search.api.globus.org": token,
-        "0948a6b0-a622-4078-b0a4-bfd6d77d65cf": token,
-        "funcx_service": token,
-        "auth.globus.org": token,
-    }
-    mock_token_response.data = {"id_token": identity_jwt}
-    mock_auth_client.oauth2_exchange_code_for_tokens = mocker.Mock(
-        return_value=mock_token_response
-    )
-
-    # Mocks compute client login
-    mock_login_manager = mocker.MagicMock(LoginManager)
-    mock_login_manager.ensure_logged_in = mocker.Mock(return_value=True)
-    mocker.patch("globus_compute_sdk.sdk.client.LoginManager").return_value = (
-        mock_login_manager
-    )
-
-    # Call the Garden constructor
-    gc = GardenClient(auth_client=mock_auth_client, search_client=mock_search_client)
+    gc = garden_client
 
     # Create a mock object for PublishedGarden or RegisteredEntrypoint
     mock_obj = MagicMock()
@@ -261,7 +223,7 @@ def test_client_datacite_url_correct(
     # Call _update_datacite with the mock and tell it to register the doi
     gc._update_datacite(mock_obj, register_doi=True)
 
-    expected_url = f"https://thegardens.ai/#/garden/{mock_obj.doi.replace('/', '%2f')}"
+    expected_url = f"https://thegardens.ai/#/garden/{mock_obj.doi.replace('/', '%2F')}"
 
     # Assert that the URL in the payload is correct
     payload = mock_update_doi_on_datacite.call_args[0][0]


### PR DESCRIPTION
Fixes #474

## Overview

Send datacite the correctly formatted URL when registering a doi.

## Testing

Added a new unit test in `test/test_client.py` to verify the URL is correct.

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--477.org.readthedocs.build/en/477/

<!-- readthedocs-preview garden-ai end -->