### PR TITLE
Change requested groups scope to 'all'

### DIFF
--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -170,7 +170,7 @@ class GardenClient:
                 AuthLoginClient.scopes.openid,
                 AuthLoginClient.scopes.email,
                 AuthLoginClient.scopes.manage_projects,
-                GroupsClient.scopes.view_my_groups_and_memberships,
+                GroupsClient.scopes.all,
                 SearchClient.scopes.all,
                 GardenClient.scopes.test_scope,
                 GardenClient.scopes.action_all,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -69,7 +69,7 @@ def test_client_no_previous_tokens(
             "openid",
             "email",
             "urn:globus:auth:scope:auth.globus.org:manage_projects",
-            "urn:globus:auth:scope:groups.api.globus.org:view_my_groups_and_memberships",
+            "urn:globus:auth:scope:groups.api.globus.org:all",
             "urn:globus:auth:scope:search.api.globus.org:all",
             "https://auth.globus.org/scopes/0948a6b0-a622-4078-b0a4-bfd6d77d65cf/test_scope",
             "https://auth.globus.org/scopes/0948a6b0-a622-4078-b0a4-bfd6d77d65cf/action_all",


### PR DESCRIPTION
Fixes: #462 
Related: https://github.com/Garden-AI/garden-backend/pull/98

## Overview

To add users to the Garden Users Globus group we need to request the 'all' scope for the groups api in the auth flow.

## Testing

Logged out on cli, logged back in and everything works fine.

