### PR TITLE
local data toggle

### DIFF
--- a/garden_ai/backend_client.py
+++ b/garden_ai/backend_client.py
@@ -106,18 +106,19 @@ class BackendClient:
         return PublishedGarden(**result)
 
     def delete_garden(self, doi: str):
-        self._delete(f"/gardens/{doi}")
+        self._delete(f"/gardens/{doi}", {})
 
     def create_entrypoint(self, entrypoint: RegisteredEntrypoint):
         if not entrypoint.function_text:
             entrypoint.function_text = entrypoint.steps[0].function_text
-        self._post("/entrypoints", entrypoint.model_dump(mode="json", exclude="steps"))
+        payload = entrypoint.model_dump(mode="json", exclude={"steps"})
+        self._post("/entrypoints", payload)
 
     def update_entrypoint(self, entrypoint: RegisteredEntrypoint):
         doi = entrypoint.doi
         if not entrypoint.function_text:
             entrypoint.function_text = entrypoint.steps[0].function_text
-        payload = entrypoint.model_dump(mode="json", exclude="steps")
+        payload = entrypoint.model_dump(mode="json", exclude={"steps"})
         self._put(f"/entrypoints/{doi}", payload)
 
     def get_entrypoint(self, doi: str) -> RegisteredEntrypoint:
@@ -125,4 +126,4 @@ class BackendClient:
         return RegisteredEntrypoint(**result)
 
     def delete_entrypoint(self, doi: str):
-        self._delete(f"/entrypoints/{doi}")
+        self._delete(f"/entrypoints/{doi}", {})

--- a/garden_ai/entrypoints.py
+++ b/garden_ai/entrypoints.py
@@ -167,6 +167,8 @@ class RegisteredEntrypoint(EntrypointMetadata):
     test_functions: List[str] = Field(default_factory=list)
     requirements: Optional[List[str]] = Field(default_factory=list)
 
+    function_text: Optional[str] = Field(None)
+
     def __call__(
         self,
         *args: Any,

--- a/garden_ai/local_data.py
+++ b/garden_ai/local_data.py
@@ -1,14 +1,24 @@
-import json
-import logging
-from enum import Enum
+import os
 from pathlib import Path
-from typing import Dict, List, Optional, Union
 
-from pydantic_core import to_jsonable_python
+from dotenv import load_dotenv
 
-from garden_ai.constants import GardenConstants
-from garden_ai.gardens import Garden
-from garden_ai.entrypoints import RegisteredEntrypoint
+dotenv_path = Path(f"{__file__}/../..").resolve() / ".env"
+load_dotenv(dotenv_path=dotenv_path)
+if os.getenv("GARDEN_DISABLE_LOCAL_DATA", False):
+    raise NotImplementedError
+
+import json  # noqa: E402
+import logging  # noqa: E402
+from enum import Enum  # noqa: E402
+from pathlib import Path  # noqa: E402
+from typing import Dict, List, Optional, Union  # noqa: E402
+
+from pydantic_core import to_jsonable_python  # noqa: E402
+
+from garden_ai.constants import GardenConstants  # noqa: E402
+from garden_ai.entrypoints import RegisteredEntrypoint  # noqa: E402
+from garden_ai.gardens import Garden  # noqa: E402
 
 LOCAL_STORAGE = Path(GardenConstants.GARDEN_DIR)
 LOCAL_STORAGE.mkdir(parents=True, exist_ok=True)

--- a/garden_ai/local_data.py
+++ b/garden_ai/local_data.py
@@ -5,8 +5,8 @@ from dotenv import load_dotenv
 
 dotenv_path = Path(f"{__file__}/../..").resolve() / ".env"
 load_dotenv(dotenv_path=dotenv_path)
-if os.getenv("GARDEN_DISABLE_LOCAL_DATA", False):
-    raise NotImplementedError
+_IS_DISABLED = bool(os.getenv("GARDEN_DISABLE_LOCAL_DATA"))
+
 
 import json  # noqa: E402
 import logging  # noqa: E402


### PR DESCRIPTION
closes #494 
## Overview

Very small PR to sanity check approach before actually replacing all of the local_data calls. This turns `import local_data` into an error in the presence of a special environment variable, and adds the basic CRUD methods to the backend client. 

## Discussion

There should be exactly zero behavioral difference for anyone without the `GARDEN_DISABLE_LOCAL_DATA` variable set except for one new (currently optional) `function_text` field on `RegisteredEntrypoint` for compatibility with the backend response schema. 

This is always the same as the function text otherwise stored in `.steps[0].function_text`, it's only necessary because the backend doesn't have steps.

## Testing
Without the variable I can `import garden_ai` just like before, but with the environment variable set it fails with flying colors. 

## Documentation

n/a

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--495.org.readthedocs.build/en/495/

<!-- readthedocs-preview garden-ai end -->