### PR TITLE
conditionally call local_data

### DIFF
--- a/garden_ai/app/entrypoint.py
+++ b/garden_ai/app/entrypoint.py
@@ -38,7 +38,7 @@ def _get_entrypoint(doi):
 def _put_entrypoint(entrypoint):
     if local_data._IS_DISABLED:
         client = GardenClient()
-        client.backend_client.put_entrypoint(entrypoint)
+        client.backend_client.update_entrypoint(entrypoint)
     else:
         put_local_entrypoint(entrypoint)
     return
@@ -219,18 +219,22 @@ def register_doi(
     rich.print(f"DOI {doi} has been moved out of draft status and can now be cited.")
 
 
-@entrypoint_app.command(no_args_is_help=False)
-def list():
-    """Lists all local entrypoints."""
+if not local_data._IS_DISABLED:
+    # this subcommand is no longer meaningful when local_data is disabled.
+    # we can replace this with "list my gardens" behavior once
+    # https://github.com/Garden-AI/garden-backend/issues/111 is live.
+    @entrypoint_app.command(no_args_is_help=False)
+    def list():
+        """Lists all local entrypoints."""
 
-    resource_table_cols = ["doi", "title", "description", DOI_STATUS_COLUMN]
-    table_name = "Local Entrypoints"
+        resource_table_cols = ["doi", "title", "description", DOI_STATUS_COLUMN]
+        table_name = "Local Entrypoints"
 
-    table = get_local_entrypoint_rich_table(
-        resource_table_cols=resource_table_cols, table_name=table_name
-    )
-    console.print("\n")
-    console.print(table)
+        table = get_local_entrypoint_rich_table(
+            resource_table_cols=resource_table_cols, table_name=table_name
+        )
+        console.print("\n")
+        console.print(table)
 
 
 @entrypoint_app.command(no_args_is_help=True)

--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -461,7 +461,7 @@ def _get_entrypoint(entrypoint_id: str) -> Optional[RegisteredEntrypoint]:
         client = GardenClient()
         entrypoint = client.backend_client.get_entrypoint(entrypoint_id)
     else:
-        entrypoint = local_data.get_local_entrypoint_by_doi(entrypoint_id)
+        entrypoint = local_data.get_local_entrypoint_by_doi(entrypoint_id)  # type: ignore[assignment]
     if not entrypoint:
         logger.warning(f"Could not find entrypoint with id {entrypoint_id}")
         return None
@@ -526,7 +526,7 @@ def _get_garden(garden_id: str) -> Optional[Garden]:
             _entrypoints=published.entrypoints,
         )
     else:
-        garden = local_data.get_local_garden_by_doi(garden_id)
+        garden = local_data.get_local_garden_by_doi(garden_id)  # type: ignore[assignment]
     if not garden:
         logger.warning(f"Could not find local garden with id {garden_id}")
         return None

--- a/garden_ai/app/main.py
+++ b/garden_ai/app/main.py
@@ -35,6 +35,10 @@ def show_version(show: bool):
     if show:
         if env := os.environ.get("GARDEN_ENV"):
             version_str += f" ({env})"
+        import garden_ai.local_data
+
+        if garden_ai.local_data._IS_DISABLED:
+            version_str += " (local_data disabled)"
         rich.print(version_str)
         raise typer.Exit()
 

--- a/garden_ai/app/notebook.py
+++ b/garden_ai/app/notebook.py
@@ -156,7 +156,7 @@ def start(
         None,
         "--doi",
         help=(
-            "DOI of a Garden you want to add all entrypoints in this notebook too. "
+            "DOI of a Garden you want to add all entrypoints in this notebook to. "
             "To override the global notebook DOI for a specific entrypoint, "
             "provide the garden_entrypoint decorator with the optional garden_doi argument."
         ),

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -35,12 +35,8 @@ from garden_ai.backend_client import BackendClient
 from garden_ai.garden_file_adapter import GardenFileAdapter
 from garden_ai.gardens import Garden, PublishedGarden
 from garden_ai.globus_search import garden_search
-from garden_ai.local_data import GardenNotFoundException, EntrypointNotFoundException
-from garden_ai.entrypoints import (
-    Paper,
-    RegisteredEntrypoint,
-    Repository,
-)
+from garden_ai.local_data import EntrypointNotFoundException
+from garden_ai.entrypoints import RegisteredEntrypoint
 from garden_ai.utils._meta import make_function_to_register
 from garden_ai.utils.misc import extract_email_from_globus_jwt
 
@@ -290,7 +286,10 @@ class GardenClient:
         """
         self._update_datacite(entrypoint, register_doi=True)
         entrypoint.doi_is_draft = False
-        local_data.put_local_entrypoint(entrypoint)
+        if local_data._IS_DISABLED:
+            self.backend_client.update_entrypoint(entrypoint)
+        else:
+            local_data.put_local_entrypoint(entrypoint)
 
     def _mint_draft_doi(self) -> str:
         """Register a new draft DOI with DataCite via Garden backend."""
@@ -322,82 +321,6 @@ class GardenClient:
         self.backend_client.update_doi_on_datacite(payload)
         logger.info("Update request succeeded")
 
-    def add_paper(self, title: str, doi: str, **kwargs) -> None:
-        """Adds a ``Paper`` to a ``RegisteredEntrypoint`` corresponding to the given DOI.
-
-        Parameters
-        ----------
-        doi : str
-            The previously registered entrypoint's DOI. Raises an
-            exception if not found.
-
-        title : str
-            An official name or title for the paper.
-
-        **kwargs :
-            Metadata for the new Paper object. Keyword arguments matching
-            required or recommended fields will be (where necessary) coerced to the appropriate type.
-            May include: List[str] authors and Optional[str] citation.
-
-        Raises
-        ------
-        EntrypointNotFoundException
-            Raised when no known entrypoint exists with the given identifier.
-        """
-        entrypoint = local_data.get_local_entrypoint_by_doi(doi)
-        if not entrypoint:
-            raise EntrypointNotFoundException(
-                f"Could not find any entrypoints with DOI {doi}."
-            )
-        data = dict(kwargs)
-        if title:
-            data["title"] = title
-        paper = Paper(**data)
-        entrypoint.papers.append(paper)
-        local_data.put_local_entrypoint(entrypoint)
-
-    def add_repository(self, doi: str, url: str, repo_name: str, **kwargs) -> None:
-        """Adds a ``Repository`` to a ``RegisteredEntrypoint`` corresponding to the given DOI.
-
-        Parameters
-        ----------
-        doi : str
-            The previously registered entrypoint's DOI. Raises an
-            exception if not found.
-
-        title : str
-            An official name or title for the repository.
-
-        url: str
-            The url to access this repository.
-
-        **kwargs :
-            Metadata for the new Repository object. Keyword arguments matching
-            required or recommended fields will be (where necessary) coerced to the appropriate type.
-            May include: List[str] contributors.
-
-        Raises
-        ------
-        EntrypointNotFoundException
-            Raised when no known entrypoint exists with the given identifier.
-        """
-        data = dict(kwargs)
-        if doi:
-            data["doi"] = doi
-        if url:
-            data["url"] = url
-        if repo_name:
-            data["repo_name"] = repo_name
-        entrypoint = local_data.get_local_entrypoint_by_doi(doi)
-        if not entrypoint:
-            raise EntrypointNotFoundException(
-                f"Could not find any entrypoints with DOI {doi}."
-            )
-
-        repository = Repository(**data)
-        entrypoint.repositories.append(repository)
-        local_data.put_local_entrypoint(entrypoint)
-
     def get_registered_entrypoint(self, doi: str) -> RegisteredEntrypoint:
         """Return a callable ``RegisteredEntrypoint`` corresponding to the given DOI.
 
@@ -418,6 +341,8 @@ class GardenClient:
         EntrypointNotFoundException
             Raised when no known entrypoint exists with the given identifier.
         """
+        if local_data._IS_DISABLED:
+            return self.backend_client.get_entrypoint(doi)
         entrypoint = local_data.get_local_entrypoint_by_doi(doi)
 
         if entrypoint is None:
@@ -428,34 +353,6 @@ class GardenClient:
 
     def get_email(self) -> str:
         return local_data._get_user_email()
-
-    def get_local_garden(self, doi: str) -> Garden:
-        """Return a registered ``Garden`` corresponding to the given DOI.
-
-        Any ``RegisteredEntrypoints`` registered to the Garden will be callable
-        as attributes on the garden by their (registered) short_name, e.g.
-            ```python
-                my_garden = client.get_local_garden('garden-doi')
-                #  entrypoint would have been registered with short_name='my_entrypoint'
-                my_garden.my_entrypoint(*args, endpoint='where-to-execute')
-            ```
-        Tip: To access the entrypoint by a different name, use ``my_garden.rename_entrypoint(entrypoint_id, new_name)``.
-        To persist a new name for an entrypoint, re-register it to the garden and specify an alias.
-
-        Parameters
-        ----------
-        doi : str
-            The previously registered Garden's DOI. Raises an
-            exception if not found.
-
-        """
-        garden = local_data.get_local_garden_by_doi(doi)
-
-        if garden is None:
-            raise GardenNotFoundException(
-                f"Could not find any Gardens with identifier {doi}."
-            )
-        return garden
 
     def publish_garden_metadata(self, garden: Garden, register_doi=False) -> None:
         """
@@ -492,39 +389,6 @@ class GardenClient:
         Given a Globus Search advanced query, returns JSON Globus Search result string with gardens as entries.
         """
         return garden_search.search_gardens(query, self.search_client)
-
-    def clone_published_garden(self, doi: str, *, silent: bool = False) -> Garden:
-        """
-        Queries Globus Search for the garden with the given DOI
-        and creates a local clone of it that can be modified.
-
-        NOTE: the clone will have a different DOI than the original
-
-        Parameters
-        ----------
-        doi: The DOI of the garden you want to clone.
-        silent: Whether or not to print any messages.
-
-        Returns
-        -------
-        Garden populated with metadata from the remote metadata record.
-        """
-        published = self.get_published_garden(doi)
-
-        for entrypoint in published.entrypoints:
-            local_data.put_local_entrypoint(entrypoint)
-
-        data = published.model_dump()
-        del data["doi"]  # the clone should not retain the DOI
-
-        garden = self.create_garden(**data)
-
-        if not silent:
-            log_msg = f"Garden {doi} successfully cloned locally and given replacement DOI {garden.doi}."
-            logger.info(log_msg)
-            print(log_msg)
-
-        return garden
 
     def get_published_garden(self, doi: str) -> PublishedGarden:
         """

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -517,8 +517,7 @@ class GardenClient:
                         **published.model_dump(), _entrypoints=published.entrypoints
                     )
                 else:
-                    garden = local_data.get_local_garden_by_doi(garden_doi)
-
+                    garden = local_data.get_local_garden_by_doi(garden_doi)  # type: ignore[assignment]
                 if garden is None:
                     msg = (
                         f"Could not add entrypoint {key} to garden "
@@ -537,12 +536,12 @@ class GardenClient:
 
         for doi in dirty_gardens:
             if local_data._IS_DISABLED:
-                published = self.backend_client.get_garden(garden_doi)
+                published = self.backend_client.get_garden(doi)
                 garden = Garden(
                     **published.model_dump(), _entrypoints=published.entrypoints
                 )
             else:
-                garden = local_data.get_local_garden_by_doi(garden_doi)
+                garden = local_data.get_local_garden_by_doi(doi)  # type: ignore[assignment]
             if garden:
                 print(f"(Re-)publishing garden {garden.doi} ({garden.title}) ...")
                 self.publish_garden_metadata(garden)

--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -359,6 +359,7 @@ class PublishedGarden(BaseModel):
         List[str], Field(default_factory=list), require_unique_items
     ]
     doi: str = Field(...)
+    doi_is_draft: bool = Field(True)
     description: Optional[str] = Field(None)
     publisher: str = "Garden-AI"
     year: str = Field(default_factory=lambda: str(datetime.now().year))

--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -141,7 +141,9 @@ class Garden(BaseModel):
             raise ValueError("year must be formatted `YYYY`")
         return str(year)
 
-    def __init__(self, _entrypoints: List[RegisteredEntrypoint] = None, **kwargs):
+    def __init__(
+        self, _entrypoints: Optional[List[RegisteredEntrypoint]] = None, **kwargs
+    ):
         super().__init__(**kwargs)
 
         if _entrypoints is not None:
@@ -186,7 +188,7 @@ class Garden(BaseModel):
 
         entrypoints = []
         for doi in self.entrypoint_ids:
-            entrypoint = get_local_entrypoint_by_doi(doi)
+            entrypoint = get_local_entrypoint_by_doi(doi)  # type: ignore[assignment]
             if entrypoint is None:
                 raise EntrypointNotFoundException(
                     f"Could not find registered entrypoint with id {doi}."
@@ -231,7 +233,7 @@ class Garden(BaseModel):
         else:
             from .local_data import get_local_entrypoint_by_doi
 
-            entrypoint = get_local_entrypoint_by_doi(entrypoint_id)
+            entrypoint = get_local_entrypoint_by_doi(entrypoint_id)  # type: ignore[assignment]
             if entrypoint is None:
                 raise ValueError(
                     f"Error: no entrypoint was found in the local database with the given DOI {entrypoint_id}."

--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -145,7 +145,9 @@ class Garden(BaseModel):
         super().__init__(**kwargs)
 
         if _entrypoints is not None:
-            # HACK: see usage in app.garden._get_garden
+            # HACK: for compatibility with usage in app.garden._get_garden
+            # skips expensive _collect_entrypoints() call when we already have
+            # them from the GET /gardens response
             self._entrypoint_cache = _entrypoints
             return
 

--- a/tests/test_local_db.py
+++ b/tests/test_local_db.py
@@ -1,4 +1,4 @@
-from garden_ai import PublishedGarden, local_data
+from garden_ai import local_data
 
 
 def test_local_storage_garden(mocker, garden_client, garden_all_fields, tmp_path):
@@ -41,24 +41,3 @@ def test_local_storage_keyerror(
     # can find the entrypoint
     from_record = local_data.get_local_entrypoint_by_doi(entrypoint.doi)
     assert from_record == entrypoint
-
-
-def test_local_db_clone(mocker, garden_client, garden_all_fields, tmp_path):
-    # mock to replace "~/.garden/db"
-    mocker.patch("garden_ai.local_data.LOCAL_STORAGE", new=tmp_path)
-
-    # mock fetch and new garden creation operations
-    mocker.patch(
-        "garden_ai.client.GardenClient.get_published_garden",
-        return_value=PublishedGarden.from_garden(garden_all_fields),
-    )
-    mocker.patch(
-        "garden_ai.client.GardenClient._mint_draft_doi",
-        return_value="10.26311/fake-doi",
-    )
-
-    # this test asserts that the clone operation is correctly populating
-    # the local db with the entrypoints referenced by the remote garden
-    garden_client.clone_published_garden(garden_all_fields.doi, silent=True)
-
-    assert local_data.get_local_entrypoint_by_doi("10.26311/fake-doi") is not None


### PR DESCRIPTION
completes #496 

## Overview

This PR uses the environment variable introduced in #495 to use the new backend as a drop-in replacement anywhere that currently uses `local_data`. 

## Discussion

This has some ugly hacks to keep everything consistent with current behavior, especially when it comes to the `Garden` vs `PublishedGarden` distinction. Some of those `Garden` helper methods are pretty crufty and I can't wait to get rid of them completely. 

We only even have the distinction there because of constraints due to local data in the first place -- one for normalized local_data entries, the other is for the denormalized search index entries. When the migration is through and the SDK no longer needs to worry about building the entries for the search index, we can simplify down to a single normalized `GardenMetadata` class. 

Until then, I suppose lazy-importing a client to talk to the backend is no more hacky than lazy-importing local_data to build the nested metadata for the search index. 

The only functionality we don't _quite_ have the backend ready to replace is the `list` subcommands, which just print/format all the gardens/entrypoints in local data. Once we have https://github.com/Garden-AI/garden-backend/issues/111 complete we can replace these with "list gardens that belong to me" functionality, but in the meantime those commands just aren't especially meaningful in a world without local_data, so now we just don't define them unless local_data is enabled. 

## Testing

Sanity checked all of the `garden-ai {garden, entrypoint, notebook}` subcommands exhaustively from the CLI with/without having the `GARDEN_DISABLE_LOCAL_DATA` variable set. If unset, everything works the same as before. If set, all the commands still work as expected but by calling the backend API instead of touching local_data. The only thing that still goes in local data is the user's email for the whoami command. 


## Documentation
no docs 

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--498.org.readthedocs.build/en/498/

<!-- readthedocs-preview garden-ai end -->