### PR TITLE
toggle for deprecating search index routes

### DIFF
--- a/garden_ai/backend_client.py
+++ b/garden_ai/backend_client.py
@@ -96,10 +96,10 @@ class BackendClient:
         self._post("/gardens", garden.model_dump(mode="json"))
         return
 
-    def update_garden(self, garden: Garden):
+    def update_garden(self, garden: Garden) -> PublishedGarden:
         doi = garden.doi
-        self._put(f"/gardens/{doi}", garden.model_dump(mode="json"))
-        return
+        result = self._put(f"/gardens/{doi}", garden.model_dump(mode="json"))
+        return PublishedGarden(**result)
 
     def get_garden(self, doi: str) -> PublishedGarden:
         result = self._get(f"/gardens/{doi}")

--- a/garden_ai/globus_search/__init__.py
+++ b/garden_ai/globus_search/__init__.py
@@ -1,0 +1,7 @@
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+dotenv_path = Path(f"{__file__}/../..").resolve() / ".env"
+load_dotenv(dotenv_path=dotenv_path)
+_IS_DISABLED = bool(os.getenv("GARDEN_DISABLE_SEARCH_INDEX"))


### PR DESCRIPTION
closes #497 

## Overview

This PR includes logic to toggle the sdk's use of `/garden-search-record` routes on the backend, similar to the local_data toggle (but was _much_ simpler in practice).

## Discussion

The dev backend has already deprecated the `/garden-search-record` routes, which was handy for testing this. When it's time to "flip the switch" on the migration, my plan is for the SDK side to just cut a new release with the `local_data` and `globus_search._IS_DISABLED` constants hardcoded to `True`. The subsequent cleanup PR can worry about the unreachable code left over as well as tidying up the schemas we no longer need in a local-data-free world.

## Testing

Manually, with `garden create`; `garden publish` and `garden delete`. Since these were the only operations that touched the search index this was enough to convince me. Because the dev backend already syncs with the dev search index, I was able to see the changes propagate through on the staging frontend despite not calling the `/garden-search-record` routes anywhere. 

## Documentation

n/a 

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--501.org.readthedocs.build/en/501/

<!-- readthedocs-preview garden-ai end -->