### PR TITLE
fix: staging error in GitHubConnector

### DIFF
--- a/garden_ai/model_connectors/model_connector.py
+++ b/garden_ai/model_connectors/model_connector.py
@@ -153,15 +153,16 @@ class ModelConnector(BaseModel, ABC):
             ConnectorStagingError: when something goes wrong during staging.
         """
         try:
-            self._checkout_revision()
-
             # pull from the repo if we have already downloaded it.
             if self._pull_if_downloaded():
-                return str(self.local_dir)
+                model_dir = str(self.local_dir)
             else:
                 # otherwise download the repo
-                return self._download()
+                model_dir = self._download()
 
+            # ensure the correct commit is checked out
+            self._checkout_revision()
+            return model_dir
         except Exception as e:
             raise ConnectorStagingError(str(self.repo_url), None) from e
 

--- a/tests/model_connectors/test_github_conn.py
+++ b/tests/model_connectors/test_github_conn.py
@@ -163,5 +163,12 @@ def test_stage_works_on_empty_local_dir(
     # This might still throw errors if the network is down or github is unreachable
     model_dir = c.stage()
 
+    # Make sure we have cloned the repo
     git_dir = Path(model_dir) / ".git"
     assert git_dir.exists()
+
+    # Ensure we have checked out the correct revision
+    head = git_dir / "HEAD"
+    with open(head, "r") as f:
+        head_rev = f.readline().strip()
+    assert head_rev == c.revision


### PR DESCRIPTION
Resolves: #521

# Overview
This PR fixes a bug @WillEngler found when calling `stage` on a `GitHubConnector`.

# Discussion
The error was due to calling `_checkout_revision` before cloning/downloading the repo. I moved the call to `_checkout_revision` to after the download step in `stage` to ensure the repo is present before attempting to checkout the tagged revision.

# Tests
Added a integration test covering the logic Will reported in #521
Run with:
`pytest -m "integration"`

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--529.org.readthedocs.build/en/529/

<!-- readthedocs-preview garden-ai end -->