### PR TITLE
Add small-scale tests of core modules

### DIFF
--- a/garden_ai/containers.py
+++ b/garden_ai/containers.py
@@ -15,6 +15,15 @@ import docker  # type: ignore
 from garden_ai.constants import GardenConstants
 from garden_ai.notebook_metadata import save_requirements_data, RequirementsData
 
+# This gets rid of a warning:
+#  DeprecationWarning: Jupyter is migrating its paths to use standard platformdirs
+#      given by the platformdirs library.  To remove this warning and
+#      see the appropriate new directories, set the environment variable
+#      `JUPYTER_PLATFORM_DIRS=1` and then run `jupyter --paths`.
+#      The use of platformdirs will be the default in `jupyter_core` v6
+#      from jupyter_core.paths import jupyter_data_dir, jupyter_runtime_dir, secure_write
+os.environ["JUPYTER_PLATFORM_DIRS"] = "1"
+
 
 class DockerStartFailure(Exception):
     """

--- a/garden_ai/notebook_metadata.py
+++ b/garden_ai/notebook_metadata.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, Callable
 from pydantic import BaseModel, ValidationError
 import typer
 import json
@@ -67,10 +67,10 @@ def add_notebook_metadata(
     # If metadata widget cell does not exist, add to top of notebook
     if not _has_metadata_cell_tag(ntbk):
         new_cell = nbformat.v4.new_code_cell(NOTEBOOK_DISPLAY_METADATA_CELL)
+        del new_cell["id"]
         new_cell["metadata"] = {
             "tags": [METADATA_CELL_TAG],
         }
-        del new_cell["id"]
         ntbk.cells.insert(0, new_cell)
 
     # Add empty garden_metadata dict to notebooks metadata if missing
@@ -180,50 +180,70 @@ def save_requirements_data(
         return None
 
 
-def display_metadata_widget():
+def make_html_popup_widget(message, alert_type="alert", background_color="#1cb4eb"):
+    # create html widget popup box that has info message with a close button on it
+    html_content = f"""
+    <div class="{alert_type}">
+        <span class="closebtn" onclick="this.parentElement.style.display='none';">&times;</span>
+        {message}
+    </div>
     """
-    Displays the metadata editor widget
-    When one of the widgets fields is changed, pickles and saves the updated NotebookMetadata.
-    When the notebook is saved, the post_save_hook in custom_jupyter_config will
-    go and look for the pickled NotebookMetadata and save it to the notebooks metadata.
-    When any requirements are changed, will display the button 'Install new requirements',
-    that installs the new requirements to the container and updates the users requirements
-    file if one was provided.
-    The widget does not support conda requirements since we are
-    planning on removing support for them.
+
+    css_content = f"""
+    <style>
+    .alert {{
+        padding: 20px;
+        background-color: {background_color};
+        color: white;
+        margin-bottom: 15px;
+        border-radius: 5px;
+        position: relative;
+        width: 95%;
+    }}
+    .closebtn {{
+        margin-left: 15px;
+        color: white;
+        font-weight: bold;
+        float: right;
+        font-size: 22px;
+        line-height: 20px;
+        cursor: pointer;
+        transition: 0.3s;
+    }}
+    .closebtn:hover {{
+        color: black;
+    }}
+    </style>
     """
-    from garden_ai.app.console import console
-    from rich.status import Status
 
-    # NOTEBOOK_PATH env var set in start_container_with_notebook
-    notebook_path = Path(os.environ["NOTEBOOK_PATH"])
-    nb_meta = get_notebook_metadata(notebook_path)
+    return widgets.HTML(f"{css_content}{html_content}")
 
-    output = widgets.Output()
 
-    # Global DOI widget
-    doi_widget = widgets.Textarea(
+def _build_doi_widget(nb_meta: NotebookMetadata) -> widgets.Textarea:
+    return widgets.Textarea(
         value=nb_meta.global_notebook_doi,
         placeholder="Global Garden DOI",
         continuous_update=False,
         disabled=False,
     )
 
-    # Base image name widget
-    base_image_widget = widgets.Dropdown(
+
+def _build_base_image_widget(nb_meta: NotebookMetadata) -> widgets.Dropdown:
+    return widgets.Dropdown(
         options=GardenConstants.PREMADE_IMAGES.keys(),
         value=nb_meta.notebook_image_name,
         disabled=False,
     )
 
-    # Requirements widget
-    if nb_meta.notebook_requirements.file_format == "pip":
-        reqs_string = "\n".join([req for req in nb_meta.notebook_requirements.contents])
+
+def _build_reqs_widget(nb_meta: NotebookMetadata) -> widgets.Textarea:
+    if nb_meta.notebook_requirements.file_format == "pip":  # type: ignore
+        reqs_string = "\n".join([req for req in nb_meta.notebook_requirements.contents])  # type: ignore
     else:
         # ignoring conda requirements, since we are planning to remove support for them anyways
         reqs_string = ""
 
-    reqs_widget = widgets.Textarea(
+    return widgets.Textarea(
         value=reqs_string,
         placeholder="Requirements",
         layout=widgets.Layout(width="100%", height="80px"),
@@ -231,62 +251,59 @@ def display_metadata_widget():
         disabled=False,
     )
 
-    update_reqs_widget = widgets.Button(
-        description="Install new requirements",
+
+def _build_update_reqs_widget(description: str) -> widgets.Button:
+    return widgets.Button(
+        description=description,
         style=widgets.ButtonStyle(button_color="lightgreen", font_weight="bold"),
         layout=widgets.Layout(width="100%", height="50px"),
     )
 
-    accordion_widget = widgets.Accordion(
+
+def _build_accordion_widget(
+    children: list[widgets.Widget], titles: list[str]
+) -> widgets.Accordion:
+    return widgets.Accordion(
+        children=children,
+        titles=titles,
+    )
+
+
+def _build_metadata_widget(children: list[widgets.Widget]) -> widgets.VBox:
+    return widgets.VBox(
+        children=children,
+    )
+
+
+def _build_metadata_widgets(nb_meta: NotebookMetadata) -> list[widgets.Widget]:
+    doi_widget = _build_doi_widget(nb_meta)
+    base_image_widget = _build_base_image_widget(nb_meta)
+    reqs_widget = _build_reqs_widget(nb_meta)
+    update_reqs_widget = _build_update_reqs_widget(
+        description="Install new requirements"
+    )
+    accordion_widget = _build_accordion_widget(
         children=[doi_widget, base_image_widget, reqs_widget],
-        titles=("Global DOI", "Base Image", "Requirements"),
+        titles=["Global DOI", "Base Image", "Requirements"],
     )
+    metadata_widget = _build_metadata_widget(children=[accordion_widget])
+    return [
+        doi_widget,
+        base_image_widget,
+        reqs_widget,
+        update_reqs_widget,
+        accordion_widget,
+        metadata_widget,
+    ]
 
-    metadata_widget = widgets.VBox(
-        children=[accordion_widget],
-    )
 
-    def make_html_popup_widget(message, alert_type="alert", background_color="#1cb4eb"):
-        # create html widget popup box that has info message with a close button on it
-        html_content = f"""
-        <div class="{alert_type}">
-            <span class="closebtn" onclick="this.parentElement.style.display='none';">&times;</span>
-            {message}
-        </div>
-        """
-
-        css_content = f"""
-        <style>
-        .alert {{
-            padding: 20px;
-            background-color: {background_color};
-            color: white;
-            margin-bottom: 15px;
-            border-radius: 5px;
-            position: relative;
-            width: 95%;
-        }}
-        .closebtn {{
-            margin-left: 15px;
-            color: white;
-            font-weight: bold;
-            float: right;
-            font-size: 22px;
-            line-height: 20px;
-            cursor: pointer;
-            transition: 0.3s;
-        }}
-        .closebtn:hover {{
-            color: black;
-        }}
-        </style>
-        """
-
-        return widgets.HTML(f"{css_content}{html_content}")
-
-    def doi_observer(change):
+def doi_observer(
+    nb_meta: NotebookMetadata,
+    metadata_widget: widgets.VBox,
+    output: widgets.Output,
+) -> Callable:
+    def _doi_observer(change):
         with output:
-            nonlocal nb_meta
             nb_meta.global_notebook_doi = change.new.strip()
             # save empty field as None
             if nb_meta.global_notebook_doi == "":
@@ -306,12 +323,16 @@ def display_metadata_widget():
                 if not isinstance(value, widgets.HTML)
             ]
 
-    doi_widget.observe(doi_observer, "value")
+    return _doi_observer
 
-    def base_image_observer(change):
+
+def base_image_observer(
+    nb_meta: NotebookMetadata,
+    metadata_widget: widgets.VBox,
+    output: widgets.Output,
+) -> Callable:
+    def _base_image_observer(change):
         with output:
-            nonlocal nb_meta
-
             nb_meta.notebook_image_name = change.new
             nb_meta.notebook_image_uri = GardenConstants.PREMADE_IMAGES[change.new]
             _save_metadata_as_json(nb_meta)
@@ -330,12 +351,17 @@ def display_metadata_widget():
                 if not isinstance(value, widgets.HTML)
             ]
 
-    base_image_widget.observe(base_image_observer, "value")
+    return _base_image_observer
 
-    def reqs_observer(change):
+
+def reqs_observer(
+    nb_meta: NotebookMetadata,
+    metadata_widget: widgets.VBox,
+    update_reqs_widget: widgets.Button,
+    output: widgets.Output,
+) -> Callable:
+    def _reqs_observer(change):
         with output:
-            nonlocal nb_meta
-
             nb_meta.notebook_requirements.contents = change.new.split("\n")
             if "" in nb_meta.notebook_requirements.contents:
                 nb_meta.notebook_requirements.contents.remove("")
@@ -363,14 +389,23 @@ def display_metadata_widget():
                 if not isinstance(value, widgets.HTML)
             ]
 
-    reqs_widget.observe(reqs_observer, "value")
+    return _reqs_observer
 
-    def update_reqs_observer(button):
+
+def update_reqs_observer(
+    nb_meta: NotebookMetadata,
+    metadata_widget: widgets.VBox,
+    update_reqs_widget: widgets.Button,
+    output: widgets.Output,
+) -> Callable:
+    from garden_ai.app.console import console
+    from rich.status import Status
+
+    def _update_reqs_observer(button):
         with output:
             # disable button so user cant start multiple installs
             button.disabled = True
 
-            nonlocal nb_meta
             # save changes to requirements file
             # REQUIREMENTS_PATH env var set to the containers requirements file path
             # in 'start_container_with_notebook' only if user provided requirements.
@@ -423,13 +458,59 @@ def display_metadata_widget():
                 if not isinstance(value, widgets.HTML)
             ]
 
-    update_reqs_widget.on_click(update_reqs_observer)
+    return _update_reqs_observer
 
+
+def display_metadata_widget():
+    """
+    Displays the metadata editor widget
+    When one of the widgets fields is changed, pickles and saves the updated NotebookMetadata.
+    When the notebook is saved, the post_save_hook in custom_jupyter_config will
+    go and look for the pickled NotebookMetadata and save it to the notebooks metadata.
+    When any requirements are changed, will display the button 'Install new requirements',
+    that installs the new requirements to the container and updates the users requirements
+    file if one was provided.
+    The widget does not support conda requirements since we are
+    planning on removing support for them.
+    """
+    # NOTEBOOK_PATH env var set in start_container_with_notebook
+    notebook_path = Path(os.environ["NOTEBOOK_PATH"])
+    nb_meta = get_notebook_metadata(notebook_path)
+
+    output = widgets.Output()
+
+    # Build the widgets
+    (
+        doi_widget,
+        base_image_widget,
+        reqs_widget,
+        update_reqs_widget,
+        accordion_widget,
+        metadata_widget,
+    ) = _build_metadata_widgets(nb_meta)
+
+    # Setup event handlers
+    doi_widget.observe(doi_observer(nb_meta, metadata_widget, output), "value")
+    base_image_widget.observe(
+        base_image_observer(nb_meta, metadata_widget, output),
+        "value",
+    )
+    reqs_widget.observe(
+        reqs_observer(nb_meta, metadata_widget, update_reqs_widget, output),
+        "value",
+    )
+    update_reqs_widget.on_click(
+        update_reqs_observer(nb_meta, metadata_widget, update_reqs_widget, output)
+    )
+
+    # Display the metadata_widget to kick things off
+    # other widgets will display based on user interaction
     display(metadata_widget, output)
 
 
 def _save_metadata_as_json(nb_meta: NotebookMetadata):
-    with open("./notebook_metadata.json", "w") as file:
+    working_dir = Path(os.environ.get("NOTEBOOK_PATH")).parent  # type: ignore
+    with open(working_dir / "notebook_metadata.json", "w") as file:
         json.dump(nb_meta.model_dump(), file)
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -187,13 +187,13 @@ Unidecode = ">=0.04.14,<0.05"
 
 [[package]]
 name = "babel"
-version = "2.15.0"
+version = "2.16.0"
 description = "Internationalization utilities"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Babel-2.15.0-py3-none-any.whl", hash = "sha256:08706bdad8d0a3413266ab61bd6c34d0c28d6e1e7badf40a2cebe67644e2e1fb"},
-    {file = "babel-2.15.0.tar.gz", hash = "sha256:8daf0e265d05768bc6c7a314cf1321e9a123afc328cc635c18622a2f30a04413"},
+    {file = "babel-2.16.0-py3-none-any.whl", hash = "sha256:368b5b98b37c06b7daf6696391c3240c938b37767d4584413e8438c5c435fa8b"},
+    {file = "babel-2.16.0.tar.gz", hash = "sha256:d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316"},
 ]
 
 [package.extras]
@@ -208,17 +208,6 @@ python-versions = "*"
 files = [
     {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
     {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
-]
-
-[[package]]
-name = "backports-strenum"
-version = "1.3.1"
-description = "Base class for creating enumerated constants that are also subclasses of str"
-optional = false
-python-versions = ">=3.8.6,<3.11"
-files = [
-    {file = "backports_strenum-1.3.1-py3-none-any.whl", hash = "sha256:cdcfe36dc897e2615dc793b7d3097f54d359918fc448754a517e6f23044ccf83"},
-    {file = "backports_strenum-1.3.1.tar.gz", hash = "sha256:77c52407342898497714f0596e86188bb7084f89063226f4ba66863482f42414"},
 ]
 
 [[package]]
@@ -308,17 +297,17 @@ css = ["tinycss2 (>=1.1.0,<1.3)"]
 
 [[package]]
 name = "boto3"
-version = "1.34.154"
+version = "1.34.162"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.34.154-py3-none-any.whl", hash = "sha256:7ca22adef4c77ee128e1e1dc7d48bc9512a87cc6fe3d771b3f913d5ecd41c057"},
-    {file = "boto3-1.34.154.tar.gz", hash = "sha256:864f06528c583dc7b02adf12db395ecfadbf9cb0da90e907e848ffb27128ce19"},
+    {file = "boto3-1.34.162-py3-none-any.whl", hash = "sha256:d6f6096bdab35a0c0deff469563b87d184a28df7689790f7fe7be98502b7c590"},
+    {file = "boto3-1.34.162.tar.gz", hash = "sha256:873f8f5d2f6f85f1018cbb0535b03cceddc7b655b61f66a0a56995238804f41f"},
 ]
 
 [package.dependencies]
-botocore = ">=1.34.154,<1.35.0"
+botocore = ">=1.34.162,<1.35.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -327,13 +316,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "boto3-stubs"
-version = "1.34.154"
-description = "Type annotations for boto3 1.34.154 generated with mypy-boto3-builder 7.25.0"
+version = "1.34.162"
+description = "Type annotations for boto3 1.34.162 generated with mypy-boto3-builder 7.26.0"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "boto3_stubs-1.34.154-py3-none-any.whl", hash = "sha256:74f113d508ec14452b4cdb4de0f4e1e561dc193d8cc9a8fec4b4c1beaaa3c6f0"},
-    {file = "boto3_stubs-1.34.154.tar.gz", hash = "sha256:71a0e4f5fa8baff6bae45c0fbb5a63df75de8baae983c5f75d61bdec9eb1c072"},
+    {file = "boto3_stubs-1.34.162-py3-none-any.whl", hash = "sha256:47c651272782a2e894082087eeaeb87a7e809e7e282748560cf39c155031abef"},
+    {file = "boto3_stubs-1.34.162.tar.gz", hash = "sha256:6d60b7b9652e1c99f3caba00779e1b94ba7062b0431147a00543af8b1f5252f4"},
 ]
 
 [package.dependencies]
@@ -384,7 +373,7 @@ bedrock-agent = ["mypy-boto3-bedrock-agent (>=1.34.0,<1.35.0)"]
 bedrock-agent-runtime = ["mypy-boto3-bedrock-agent-runtime (>=1.34.0,<1.35.0)"]
 bedrock-runtime = ["mypy-boto3-bedrock-runtime (>=1.34.0,<1.35.0)"]
 billingconductor = ["mypy-boto3-billingconductor (>=1.34.0,<1.35.0)"]
-boto3 = ["boto3 (==1.34.154)", "botocore (==1.34.154)"]
+boto3 = ["boto3 (==1.34.162)", "botocore (==1.34.162)"]
 braket = ["mypy-boto3-braket (>=1.34.0,<1.35.0)"]
 budgets = ["mypy-boto3-budgets (>=1.34.0,<1.35.0)"]
 ce = ["mypy-boto3-ce (>=1.34.0,<1.35.0)"]
@@ -734,13 +723,13 @@ xray = ["mypy-boto3-xray (>=1.34.0,<1.35.0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.154"
+version = "1.34.162"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.34.154-py3-none-any.whl", hash = "sha256:4eef4b1bb809b382ba9dc9c88f5fcc4a133f221a1acb693ee6bee4de9f325979"},
-    {file = "botocore-1.34.154.tar.gz", hash = "sha256:64d9b4c85a504d77cb56dabb2ad717cd8e1717424a88edb458b01d1e5797262a"},
+    {file = "botocore-1.34.162-py3-none-any.whl", hash = "sha256:2d918b02db88d27a75b48275e6fb2506e9adaaddbec1ffa6a8a0898b34e769be"},
+    {file = "botocore-1.34.162.tar.gz", hash = "sha256:adc23be4fb99ad31961236342b7cbf3c0bfc62532cd02852196032e8c0d682f3"},
 ]
 
 [package.dependencies]
@@ -749,17 +738,17 @@ python-dateutil = ">=2.1,<3.0.0"
 urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""}
 
 [package.extras]
-crt = ["awscrt (==0.20.11)"]
+crt = ["awscrt (==0.21.2)"]
 
 [[package]]
 name = "botocore-stubs"
-version = "1.34.154"
+version = "1.34.162"
 description = "Type annotations and code completion for botocore"
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "botocore_stubs-1.34.154-py3-none-any.whl", hash = "sha256:25d88f9618e45845ee41fa2fb3eff0b50830baf5041866ccaf7bc5ebe11ef4d1"},
-    {file = "botocore_stubs-1.34.154.tar.gz", hash = "sha256:9eef4e56b72bfc7c3728504a3b50ad80f08b12fe2ee92ca3d6e1e34d05c9ce5b"},
+    {file = "botocore_stubs-1.34.162-py3-none-any.whl", hash = "sha256:791581481790baf8e135343ab97249fffd4832338de2daa802575430fa4fc183"},
+    {file = "botocore_stubs-1.34.162.tar.gz", hash = "sha256:3e106ea43e2263f1f80726823586211541d0e436b6a608ef0b2240b62a53f22c"},
 ]
 
 [package.dependencies]
@@ -1313,13 +1302,13 @@ tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipyth
 
 [[package]]
 name = "faker"
-version = "26.2.0"
+version = "26.3.0"
 description = "Faker is a Python package that generates fake data for you."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Faker-26.2.0-py3-none-any.whl", hash = "sha256:7b123090774deff5f2cd3eb92a84dcbbf1e163f30a6d07321b7852c11bfe6a75"},
-    {file = "Faker-26.2.0.tar.gz", hash = "sha256:81768de19012147521140f0d8bf5353e501ac42c1065d25e0cac455d3615c0a7"},
+    {file = "Faker-26.3.0-py3-none-any.whl", hash = "sha256:97fe1e7e953dd640ca2cd4dfac4db7c4d2432dd1b7a244a3313517707f3b54e9"},
+    {file = "Faker-26.3.0.tar.gz", hash = "sha256:7c10ebdf74aaa0cc4fe6ec6db5a71e8598ec33503524bd4b5f4494785a5670dd"},
 ]
 
 [package.dependencies]
@@ -1492,13 +1481,13 @@ redis = ["redis (>=3.5.3,<6)"]
 
 [[package]]
 name = "globus-compute-sdk"
-version = "2.24.0"
+version = "2.26.0"
 description = "Globus Compute: High Performance Function Serving for Science"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "globus_compute_sdk-2.24.0-py3-none-any.whl", hash = "sha256:cd8591e86eb9d131b83018665965e2dea97c482d810ba48819c7f1c90ac9581c"},
-    {file = "globus_compute_sdk-2.24.0.tar.gz", hash = "sha256:f220e8fad73190857fadde6f36a9afbe8c631303a8f785a2ad99d3acb3fa4bca"},
+    {file = "globus_compute_sdk-2.26.0-py3-none-any.whl", hash = "sha256:b08f6c14ab74bb4bb30679e2d57b72d403bf8d789a9e617d420db84999310240"},
+    {file = "globus_compute_sdk-2.26.0.tar.gz", hash = "sha256:11826af48954537c8c917c87431c40d477f82bd97cd73974d219936c06066fbf"},
 ]
 
 [package.dependencies]
@@ -1538,17 +1527,16 @@ requests = ">=2.19.1,<3.0.0"
 
 [[package]]
 name = "griffe"
-version = "0.48.0"
+version = "1.0.0"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "griffe-0.48.0-py3-none-any.whl", hash = "sha256:f944c6ff7bd31cf76f264adcd6ab8f3d00a2f972ae5cc8db2d7b6dcffeff65a2"},
-    {file = "griffe-0.48.0.tar.gz", hash = "sha256:f099461c02f016b6be4af386d5aa92b01fb4efe6c1c2c360dda9a5d0a863bb7f"},
+    {file = "griffe-1.0.0-py3-none-any.whl", hash = "sha256:7e113220efc489c2e8189656b1f01c1184417ba5395573ff05cdc7d07a1b0a5e"},
+    {file = "griffe-1.0.0.tar.gz", hash = "sha256:a9df647e5602fc0f826fca1cda5d9a0e554cdea67eb7948f6629dca7336e6afd"},
 ]
 
 [package.dependencies]
-backports-strenum = {version = ">=1.3", markers = "python_version < \"3.11\""}
 colorama = ">=0.4"
 
 [[package]]
@@ -2383,13 +2371,13 @@ mkdocs = ">=1.1"
 
 [[package]]
 name = "mkdocs-callouts"
-version = "1.13.2"
+version = "1.14.0"
 description = "A simple plugin that converts Obsidian style callouts and converts them into mkdocs supported 'admonitions' (a.k.a. callouts)."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocs-callouts-1.13.2.tar.gz", hash = "sha256:ebb114fe005b1f968498eb677059f7a77236fed3a4feb18607b0fda09f0968ba"},
-    {file = "mkdocs_callouts-1.13.2-py3-none-any.whl", hash = "sha256:bc3d19f20159aaeffc2e8012a8c6b70cd3ba0cbacf38defe3abffa7510170100"},
+    {file = "mkdocs_callouts-1.14.0-py3-none-any.whl", hash = "sha256:38e36b09a4e8927473a659641ff256071072cea5bc271054cc3aa4cd550736a6"},
+    {file = "mkdocs_callouts-1.14.0.tar.gz", hash = "sha256:02635434ae4c8b69bcd4f8a8af9930ad9eb157a84efff17955a172f1e6622467"},
 ]
 
 [package.dependencies]
@@ -3435,62 +3423,64 @@ files = [
 
 [[package]]
 name = "pyyaml"
-version = "6.0.1"
+version = "6.0.2"
 description = "YAML parser and emitter for Python"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"},
-    {file = "PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
-    {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
-    {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
-    {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
-    {file = "PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
-    {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
-    {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-win32.whl", hash = "sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-win32.whl", hash = "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867"},
-    {file = "PyYAML-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
-    {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
-    {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
-    {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
-    {file = "PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
-    {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
-    {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563"},
+    {file = "PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083"},
+    {file = "PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
+    {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
 ]
 
 [[package]]
@@ -4084,18 +4074,18 @@ win32 = ["pywin32"]
 
 [[package]]
 name = "setuptools"
-version = "72.1.0"
+version = "72.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-72.1.0-py3-none-any.whl", hash = "sha256:5a03e1860cf56bb6ef48ce186b0e557fdba433237481a9a625176c2831be15d1"},
-    {file = "setuptools-72.1.0.tar.gz", hash = "sha256:8d243eff56d095e5817f796ede6ae32941278f542e0f941867cc05ae52b162ec"},
+    {file = "setuptools-72.2.0-py3-none-any.whl", hash = "sha256:f11dd94b7bae3a156a95ec151f24e4637fb4fa19c878e4d191bfb8b2d82728c4"},
+    {file = "setuptools-72.2.0.tar.gz", hash = "sha256:80aacbf633704e9c8bfa1d99fa5dd4dc59573efcf9e4042c13d3bcef91ac2ef9"},
 ]
 
 [package.extras]
 core = ["importlib-metadata (>=6)", "importlib-resources (>=5.10.2)", "jaraco.text (>=3.7)", "more-itertools (>=8.8)", "ordered-set (>=3.1.1)", "packaging (>=24)", "platformdirs (>=2.6.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
 test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "mypy (==1.11.*)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (<0.4)", "pytest-ruff (>=0.2.1)", "pytest-ruff (>=0.3.2)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
@@ -4144,13 +4134,13 @@ files = [
 
 [[package]]
 name = "soupsieve"
-version = "2.5"
+version = "2.6"
 description = "A modern CSS selector implementation for Beautiful Soup."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "soupsieve-2.5-py3-none-any.whl", hash = "sha256:eaa337ff55a1579b6549dc679565eac1e3d000563bcb1c8ab0d0fefbc0c2cdc7"},
-    {file = "soupsieve-2.5.tar.gz", hash = "sha256:5663d5a7b3bfaeee0bc4372e7fc48f9cff4940b3eec54a6451cc5299f1097690"},
+    {file = "soupsieve-2.6-py3-none-any.whl", hash = "sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9"},
+    {file = "soupsieve-2.6.tar.gz", hash = "sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb"},
 ]
 
 [[package]]
@@ -4354,13 +4344,13 @@ files = [
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.20240724"
+version = "6.0.12.20240808"
 description = "Typing stubs for PyYAML"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types-PyYAML-6.0.12.20240724.tar.gz", hash = "sha256:cf7b31ae67e0c5b2919c703d2affc415485099d3fe6666a6912f040fd05cb67f"},
-    {file = "types_PyYAML-6.0.12.20240724-py3-none-any.whl", hash = "sha256:e5becec598f3aa3a2ddf671de4a75fa1c6856fbf73b2840286c9d50fae2d5d48"},
+    {file = "types-PyYAML-6.0.12.20240808.tar.gz", hash = "sha256:b8f76ddbd7f65440a8bda5526a9607e4c7a322dc2f8e1a8c405644f9a6f4b9af"},
+    {file = "types_PyYAML-6.0.12.20240808-py3-none-any.whl", hash = "sha256:deda34c5c655265fc517b546c902aa6eed2ef8d3e921e4765fe606fe2afe8d35"},
 ]
 
 [[package]]
@@ -4485,43 +4475,46 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [[package]]
 name = "watchdog"
-version = "4.0.1"
+version = "4.0.2"
 description = "Filesystem events monitoring"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "watchdog-4.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:da2dfdaa8006eb6a71051795856bedd97e5b03e57da96f98e375682c48850645"},
-    {file = "watchdog-4.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e93f451f2dfa433d97765ca2634628b789b49ba8b504fdde5837cdcf25fdb53b"},
-    {file = "watchdog-4.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ef0107bbb6a55f5be727cfc2ef945d5676b97bffb8425650dadbb184be9f9a2b"},
-    {file = "watchdog-4.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:17e32f147d8bf9657e0922c0940bcde863b894cd871dbb694beb6704cfbd2fb5"},
-    {file = "watchdog-4.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:03e70d2df2258fb6cb0e95bbdbe06c16e608af94a3ffbd2b90c3f1e83eb10767"},
-    {file = "watchdog-4.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:123587af84260c991dc5f62a6e7ef3d1c57dfddc99faacee508c71d287248459"},
-    {file = "watchdog-4.0.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:093b23e6906a8b97051191a4a0c73a77ecc958121d42346274c6af6520dec175"},
-    {file = "watchdog-4.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:611be3904f9843f0529c35a3ff3fd617449463cb4b73b1633950b3d97fa4bfb7"},
-    {file = "watchdog-4.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:62c613ad689ddcb11707f030e722fa929f322ef7e4f18f5335d2b73c61a85c28"},
-    {file = "watchdog-4.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:d4925e4bf7b9bddd1c3de13c9b8a2cdb89a468f640e66fbfabaf735bd85b3e35"},
-    {file = "watchdog-4.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cad0bbd66cd59fc474b4a4376bc5ac3fc698723510cbb64091c2a793b18654db"},
-    {file = "watchdog-4.0.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a3c2c317a8fb53e5b3d25790553796105501a235343f5d2bf23bb8649c2c8709"},
-    {file = "watchdog-4.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c9904904b6564d4ee8a1ed820db76185a3c96e05560c776c79a6ce5ab71888ba"},
-    {file = "watchdog-4.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:667f3c579e813fcbad1b784db7a1aaa96524bed53437e119f6a2f5de4db04235"},
-    {file = "watchdog-4.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d10a681c9a1d5a77e75c48a3b8e1a9f2ae2928eda463e8d33660437705659682"},
-    {file = "watchdog-4.0.1-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:0144c0ea9997b92615af1d94afc0c217e07ce2c14912c7b1a5731776329fcfc7"},
-    {file = "watchdog-4.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:998d2be6976a0ee3a81fb8e2777900c28641fb5bfbd0c84717d89bca0addcdc5"},
-    {file = "watchdog-4.0.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:e7921319fe4430b11278d924ef66d4daa469fafb1da679a2e48c935fa27af193"},
-    {file = "watchdog-4.0.1-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:f0de0f284248ab40188f23380b03b59126d1479cd59940f2a34f8852db710625"},
-    {file = "watchdog-4.0.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:bca36be5707e81b9e6ce3208d92d95540d4ca244c006b61511753583c81c70dd"},
-    {file = "watchdog-4.0.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:ab998f567ebdf6b1da7dc1e5accfaa7c6992244629c0fdaef062f43249bd8dee"},
-    {file = "watchdog-4.0.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:dddba7ca1c807045323b6af4ff80f5ddc4d654c8bce8317dde1bd96b128ed253"},
-    {file = "watchdog-4.0.1-py3-none-manylinux2014_armv7l.whl", hash = "sha256:4513ec234c68b14d4161440e07f995f231be21a09329051e67a2118a7a612d2d"},
-    {file = "watchdog-4.0.1-py3-none-manylinux2014_i686.whl", hash = "sha256:4107ac5ab936a63952dea2a46a734a23230aa2f6f9db1291bf171dac3ebd53c6"},
-    {file = "watchdog-4.0.1-py3-none-manylinux2014_ppc64.whl", hash = "sha256:6e8c70d2cd745daec2a08734d9f63092b793ad97612470a0ee4cbb8f5f705c57"},
-    {file = "watchdog-4.0.1-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:f27279d060e2ab24c0aa98363ff906d2386aa6c4dc2f1a374655d4e02a6c5e5e"},
-    {file = "watchdog-4.0.1-py3-none-manylinux2014_s390x.whl", hash = "sha256:f8affdf3c0f0466e69f5b3917cdd042f89c8c63aebdb9f7c078996f607cdb0f5"},
-    {file = "watchdog-4.0.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:ac7041b385f04c047fcc2951dc001671dee1b7e0615cde772e84b01fbf68ee84"},
-    {file = "watchdog-4.0.1-py3-none-win32.whl", hash = "sha256:206afc3d964f9a233e6ad34618ec60b9837d0582b500b63687e34011e15bb429"},
-    {file = "watchdog-4.0.1-py3-none-win_amd64.whl", hash = "sha256:7577b3c43e5909623149f76b099ac49a1a01ca4e167d1785c76eb52fa585745a"},
-    {file = "watchdog-4.0.1-py3-none-win_ia64.whl", hash = "sha256:d7b9f5f3299e8dd230880b6c55504a1f69cf1e4316275d1b215ebdd8187ec88d"},
-    {file = "watchdog-4.0.1.tar.gz", hash = "sha256:eebaacf674fa25511e8867028d281e602ee6500045b57f43b08778082f7f8b44"},
+    {file = "watchdog-4.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ede7f010f2239b97cc79e6cb3c249e72962404ae3865860855d5cbe708b0fd22"},
+    {file = "watchdog-4.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a2cffa171445b0efa0726c561eca9a27d00a1f2b83846dbd5a4f639c4f8ca8e1"},
+    {file = "watchdog-4.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c50f148b31b03fbadd6d0b5980e38b558046b127dc483e5e4505fcef250f9503"},
+    {file = "watchdog-4.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7c7d4bf585ad501c5f6c980e7be9c4f15604c7cc150e942d82083b31a7548930"},
+    {file = "watchdog-4.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:914285126ad0b6eb2258bbbcb7b288d9dfd655ae88fa28945be05a7b475a800b"},
+    {file = "watchdog-4.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:984306dc4720da5498b16fc037b36ac443816125a3705dfde4fd90652d8028ef"},
+    {file = "watchdog-4.0.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:1cdcfd8142f604630deef34722d695fb455d04ab7cfe9963055df1fc69e6727a"},
+    {file = "watchdog-4.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d7ab624ff2f663f98cd03c8b7eedc09375a911794dfea6bf2a359fcc266bff29"},
+    {file = "watchdog-4.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:132937547a716027bd5714383dfc40dc66c26769f1ce8a72a859d6a48f371f3a"},
+    {file = "watchdog-4.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd67c7df93eb58f360c43802acc945fa8da70c675b6fa37a241e17ca698ca49b"},
+    {file = "watchdog-4.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:bcfd02377be80ef3b6bc4ce481ef3959640458d6feaae0bd43dd90a43da90a7d"},
+    {file = "watchdog-4.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:980b71510f59c884d684b3663d46e7a14b457c9611c481e5cef08f4dd022eed7"},
+    {file = "watchdog-4.0.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:aa160781cafff2719b663c8a506156e9289d111d80f3387cf3af49cedee1f040"},
+    {file = "watchdog-4.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f6ee8dedd255087bc7fe82adf046f0b75479b989185fb0bdf9a98b612170eac7"},
+    {file = "watchdog-4.0.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0b4359067d30d5b864e09c8597b112fe0a0a59321a0f331498b013fb097406b4"},
+    {file = "watchdog-4.0.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:770eef5372f146997638d737c9a3c597a3b41037cfbc5c41538fc27c09c3a3f9"},
+    {file = "watchdog-4.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:eeea812f38536a0aa859972d50c76e37f4456474b02bd93674d1947cf1e39578"},
+    {file = "watchdog-4.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b2c45f6e1e57ebb4687690c05bc3a2c1fb6ab260550c4290b8abb1335e0fd08b"},
+    {file = "watchdog-4.0.2-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:10b6683df70d340ac3279eff0b2766813f00f35a1d37515d2c99959ada8f05fa"},
+    {file = "watchdog-4.0.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:f7c739888c20f99824f7aa9d31ac8a97353e22d0c0e54703a547a218f6637eb3"},
+    {file = "watchdog-4.0.2-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:c100d09ac72a8a08ddbf0629ddfa0b8ee41740f9051429baa8e31bb903ad7508"},
+    {file = "watchdog-4.0.2-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:f5315a8c8dd6dd9425b974515081fc0aadca1d1d61e078d2246509fd756141ee"},
+    {file = "watchdog-4.0.2-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:2d468028a77b42cc685ed694a7a550a8d1771bb05193ba7b24006b8241a571a1"},
+    {file = "watchdog-4.0.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:f15edcae3830ff20e55d1f4e743e92970c847bcddc8b7509bcd172aa04de506e"},
+    {file = "watchdog-4.0.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:936acba76d636f70db8f3c66e76aa6cb5136a936fc2a5088b9ce1c7a3508fc83"},
+    {file = "watchdog-4.0.2-py3-none-manylinux2014_armv7l.whl", hash = "sha256:e252f8ca942a870f38cf785aef420285431311652d871409a64e2a0a52a2174c"},
+    {file = "watchdog-4.0.2-py3-none-manylinux2014_i686.whl", hash = "sha256:0e83619a2d5d436a7e58a1aea957a3c1ccbf9782c43c0b4fed80580e5e4acd1a"},
+    {file = "watchdog-4.0.2-py3-none-manylinux2014_ppc64.whl", hash = "sha256:88456d65f207b39f1981bf772e473799fcdc10801062c36fd5ad9f9d1d463a73"},
+    {file = "watchdog-4.0.2-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:32be97f3b75693a93c683787a87a0dc8db98bb84701539954eef991fb35f5fbc"},
+    {file = "watchdog-4.0.2-py3-none-manylinux2014_s390x.whl", hash = "sha256:c82253cfc9be68e3e49282831afad2c1f6593af80c0daf1287f6a92657986757"},
+    {file = "watchdog-4.0.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c0b14488bd336c5b1845cee83d3e631a1f8b4e9c5091ec539406e4a324f882d8"},
+    {file = "watchdog-4.0.2-py3-none-win32.whl", hash = "sha256:0d8a7e523ef03757a5aa29f591437d64d0d894635f8a50f370fe37f913ce4e19"},
+    {file = "watchdog-4.0.2-py3-none-win_amd64.whl", hash = "sha256:c344453ef3bf875a535b0488e3ad28e341adbd5a9ffb0f7d62cefacc8824ef2b"},
+    {file = "watchdog-4.0.2-py3-none-win_ia64.whl", hash = "sha256:baececaa8edff42cd16558a639a9b0ddf425f93d892e8392a56bf904f5eff22c"},
+    {file = "watchdog-4.0.2.tar.gz", hash = "sha256:b4dfbb6c49221be4535623ea4474a4d6ee0a9cef4a80b20c28db4d858b64e270"},
 ]
 
 [package.extras]
@@ -4540,13 +4533,13 @@ files = [
 
 [[package]]
 name = "webcolors"
-version = "24.6.0"
+version = "24.8.0"
 description = "A library for working with the color formats defined by HTML and CSS."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "webcolors-24.6.0-py3-none-any.whl", hash = "sha256:8cf5bc7e28defd1d48b9e83d5fc30741328305a8195c29a8e668fa45586568a1"},
-    {file = "webcolors-24.6.0.tar.gz", hash = "sha256:1d160d1de46b3e81e58d0a280d0c78b467dc80f47294b91b1ad8029d2cedb55b"},
+    {file = "webcolors-24.8.0-py3-none-any.whl", hash = "sha256:fc4c3b59358ada164552084a8ebee637c221e4059267d0f8325b3b560f6c7f0a"},
+    {file = "webcolors-24.8.0.tar.gz", hash = "sha256:08b07af286a01bcd30d583a7acadf629583d1f79bfef27dd2c2c5c263817277d"},
 ]
 
 [package.extras]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -335,7 +335,7 @@ def pip_requirements_raw() -> str:
 
 @pytest.fixture
 def pip_requirements() -> dict:
-    """Reeturn a dict with structure of a RequirementsData object"""
+    """Return a dict with structure of a RequirementsData object"""
     return {"file_format": "pip", "contents": ["scikit-learn==1.2.2", "pandas"]}
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from globus_compute_sdk.sdk.login_manager.manager import LoginManager  # type: ignore
 from globus_sdk import AuthLoginClient, OAuthTokenResponse, SearchClient
+import nbformat
 import pytest
 from typer.testing import CliRunner
 
@@ -295,3 +296,17 @@ def patch_infer_revision(mocker):
 def backend_client(garden_client):
     """Return a BackendClient instance"""
     return BackendClient(garden_client.garden_authorizer)
+
+
+@pytest.fixture
+def tmp_notebook_empty(
+    tmp_path,
+) -> pathlib.Path:
+    """Return a pathlib.Path pointing to an empty .ipynb notebook in a tmp directory.
+
+    Tests can modify the .ipynb file without affecting others
+    """
+    notebook_path = tmp_path / "temp_notebook.ipynb"
+    notebook_data = nbformat.v4.new_notebook()
+    nbformat.write(notebook_data, notebook_path)
+    yield notebook_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -322,4 +322,4 @@ def tmp_notebook_empty(
     notebook_path = tmp_path / "temp_notebook.ipynb"
     notebook_data = nbformat.v4.new_notebook()
     nbformat.write(notebook_data, notebook_path)
-    yield notebook_path
+    return notebook_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import json
 import pathlib  # noqa
 from unittest.mock import patch
@@ -45,7 +46,7 @@ def pytest_collection_modifyitems(session, config, items):
             item.add_marker(skip_integration)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def cli_runner() -> CliRunner:
     """Return a typer.testing.CliRunner for use in tests."""
     return CliRunner()
@@ -188,8 +189,8 @@ def logged_in_user(tmp_path):
         yield
 
 
-@pytest.fixture
-def garden_nested_metadata_json() -> dict:
+@pytest.fixture(scope="session")
+def garden_nested_metadata_raw() -> dict:
     """Return a dict with a valid GardenMetadata schema with nested entrypoints."""
     f = (
         pathlib.Path(__file__).parent
@@ -201,11 +202,23 @@ def garden_nested_metadata_json() -> dict:
 
 
 @pytest.fixture
-def entrypoint_metadata_json() -> dict:
+def garden_nested_metadata_json(garden_nested_metadata_raw) -> dict:
+    """Return a dict with a valid GardenMetadata schema with nested entrypoints."""
+    return deepcopy(garden_nested_metadata_raw)
+
+
+@pytest.fixture(scope="session")
+def entrypoint_metadata_raw() -> dict:
     """Return a dict with a valid EntrypointMetadata schema."""
     f = pathlib.Path(__file__).parent / "fixtures" / "entrypoint_metadata.json"
     with open(f, "r") as f_in:
         return json.load(f_in)
+
+
+@pytest.fixture
+def entrypoint_metadata_json(entrypoint_metadata_raw) -> dict:
+    """Return a dict with a valid EntrypointMetadata schema."""
+    return deepcopy(entrypoint_metadata_raw)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from globus_sdk import AuthLoginClient, OAuthTokenResponse, SearchClient
 import pytest
 from typer.testing import CliRunner
 
+from garden_ai.backend_client import BackendClient
 from garden_ai.client import GardenClient
 from garden_ai.constants import GardenConstants
 from garden_ai.garden_file_adapter import GardenFileAdapter
@@ -288,3 +289,9 @@ def patch_infer_revision(mocker):
     )
 
     yield
+
+
+@pytest.fixture
+def backend_client(garden_client):
+    """Return a BackendClient instance"""
+    return BackendClient(garden_client.garden_authorizer)

--- a/tests/test_backend_client.py
+++ b/tests/test_backend_client.py
@@ -1,0 +1,428 @@
+# flake8: noqa: F841
+import pytest
+
+import boto3
+
+from garden_ai import Garden, Entrypoint
+from garden_ai.gardens import GardenMetadata
+from garden_ai.entrypoints import RegisteredEntrypointMetadata
+
+
+def test_mint_doi_on_datacite_raises_on_bad_response(
+    mocker,
+    backend_client,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._post",
+        return_value={},
+    )
+
+    with pytest.raises(Exception):
+        backend_client.mint_doi_on_datacite({})
+
+
+def test_mint_doi_on_datacite_returns_doi_on_success(
+    mocker,
+    backend_client,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._post", return_value={"doi": "some/doi"}
+    )
+
+    doi = backend_client.mint_doi_on_datacite({})
+    assert doi == "some/doi"
+
+
+def test_update_doi_on_datacite_sends_request_to_backend(
+    mocker,
+    backend_client,
+):
+
+    mock_put = mocker.patch(
+        "garden_ai.backend_client.BackendClient._put",
+    )
+
+    backend_client.update_doi_on_datacite({})
+    mock_put.assert_called()
+
+
+def test_upload_notebook_raises_on_failure(
+    mocker,
+    backend_client,
+    faker,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._put",
+        side_effect=Exception("Intentional Error for Testing."),
+    )
+
+    with pytest.raises(Exception):
+        backend_client.upload_notebook(
+            {}, faker.user_name(), faker.first_name() + ".ipynb"
+        )
+
+
+def test_upload_notebook_returns_notebook_url_on_success(
+    mocker,
+    faker,
+    backend_client,
+):
+    fake_url = faker.url()
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._post",
+        return_value={"notebook_url": fake_url},
+    )
+
+    url = backend_client.upload_notebook(
+        {}, faker.user_name(), faker.first_name() + ".ipynb"
+    )
+
+    assert url == fake_url
+
+
+def test_get_docker_push_session_raises_on_bad_response(
+    mocker,
+    backend_client,
+):
+
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._get",
+        return_value={"bad": "data"},
+    )
+
+    with pytest.raises(Exception):
+        backend_client.get_docker_push_session()
+
+
+def test_get_docker_push_session_returns_boto3_session(
+    mocker,
+    backend_client,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._get",
+        return_value={
+            "AccessKeyId": "string",
+            "SecretAccessKey": "string",
+            "SessionToken": "string",
+            "ECRRepo": "string",
+            "RegionName": "us-east-1",
+        },
+    )
+
+    mock_boto3_session = mocker.MagicMock(spec=boto3.Session)
+
+    mocker.patch(
+        "garden_ai.backend_client.boto3.Session",
+        return_value=mock_boto3_session,
+    )
+
+    session = backend_client.get_docker_push_session()
+    assert session == mock_boto3_session
+
+
+def test_get_garden_returns_garden(
+    mocker,
+    backend_client,
+    garden_nested_metadata_json,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._get",
+        return_value=garden_nested_metadata_json,
+    )
+
+    garden = backend_client.get_garden("some/doi")
+    assert isinstance(garden, Garden)
+
+
+def test_get_garden_raises_on_backend_failure(
+    mocker,
+    backend_client,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._get",
+        side_effect=Exception("Intentional Error for Testing"),
+    )
+
+    with pytest.raises(Exception):
+        garden = backend_client.get_garden("some/doi")
+
+
+def test_put_garden_raises_on_backend_failure(
+    mocker,
+    backend_client,
+    mock_GardenMetadata,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._put",
+        side_effect=Exception("Intentional Error for Testing"),
+    )
+
+    with pytest.raises(Exception):
+        backend_client.put_garden(mock_GardenMetadata)
+
+
+def test_put_garden_returns_garden_on_success(
+    mocker,
+    backend_client,
+    mock_GardenMetadata,
+    garden_nested_metadata_json,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._put",
+        return_value=garden_nested_metadata_json,
+    )
+
+    updated_garden = backend_client.put_garden(mock_GardenMetadata)
+
+    assert isinstance(updated_garden, Garden)
+
+
+def test_get_garden_metadata_raises_on_backend_failure(
+    mocker,
+    backend_client,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._get",
+        side_effect=Exception("Intentional Error for Testing"),
+    )
+
+    with pytest.raises(Exception):
+        garden_meta = backend_client.get_garden_metadata("some/doi")
+
+
+def test_get_garden_metadata_returns_garden_on_success(
+    mocker,
+    backend_client,
+    garden_nested_metadata_json,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._get",
+        return_value=garden_nested_metadata_json,
+    )
+
+    garden_meta = backend_client.get_garden_metadata("some/doi")
+
+    assert isinstance(garden_meta, GardenMetadata)
+
+
+def test_delete_garden_raises_on_backend_failure(
+    mocker,
+    backend_client,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._delete",
+        side_effect=Exception("Intentional Error for Testing"),
+    )
+
+    with pytest.raises(Exception):
+        backend_client.delete_garden("some/doi")
+
+
+def test_get_entrypoint_meta_data_returns_metadata(
+    mocker,
+    backend_client,
+    entrypoint_metadata_json,
+):
+
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._get",
+        return_value=entrypoint_metadata_json,
+    )
+
+    entrypoint_meta = backend_client.get_entrypoint_metadata("some/doi")
+
+    assert isinstance(entrypoint_meta, RegisteredEntrypointMetadata)
+
+
+def test_get_entrypoint_metadata_raises_on_backend_failure(
+    mocker,
+    backend_client,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._get",
+        side_effect=Exception("Intentional Error for Testing"),
+    )
+
+    with pytest.raises(Exception):
+        entrypoint_meta = backend_client.get_entrypoint_metadata("some/doi")
+
+
+def test_get_entrypoint_returns_entrypoint(
+    mocker,
+    backend_client,
+    entrypoint_metadata_json,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._get",
+        return_value=entrypoint_metadata_json,
+    )
+
+    entrypoint = backend_client.get_entrypoint("some/doi")
+    assert isinstance(entrypoint, Entrypoint)
+
+
+def test_get_entrypoint_raises_on_backend_failure(
+    mocker,
+    backend_client,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._get",
+        side_effect=Exception("Intentional Error for Testing"),
+    )
+
+    with pytest.raises(Exception):
+        entrypoint = backend_client.get_entrypoint("some/doi")
+
+
+def test_delete_entrypoint_raises_on_backend_failure(
+    mocker,
+    backend_client,
+):
+
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._delete",
+        side_effect=Exception("Intentional Error for Testing"),
+    )
+
+    with pytest.raises(Exception):
+        backend_client.delete_entrypoint("some/doi")
+
+
+def test_get_entrypoints_raises_on_backend_failure(
+    mocker,
+    backend_client,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._get",
+        side_effect=Exception("Intentional Error for Testing"),
+    )
+
+    with pytest.raises(Exception):
+        backend_client.get_entrypoints(
+            dois=["some/doi"],
+            tags=["tag1", "tag2"],
+            authors=["author1", "author2"],
+            draft=True,
+            year="2023",
+            owner_uuid="someuuid",
+            limit=5,
+        )
+
+
+def test_get_entrypoints_returns_list_of_entrypoints(
+    mocker,
+    backend_client,
+    entrypoint_metadata_json,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._get",
+        return_value=[entrypoint_metadata_json for _ in range(5)],
+    )
+
+    entrypoints = backend_client.get_entrypoints(
+        # args don't matter for this test
+        dois=["some/doi"],
+    )
+
+    for ep in entrypoints:
+        assert isinstance(ep, Entrypoint)
+
+
+def test_get_gardens_raises_on_backend_failure(
+    mocker,
+    backend_client,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._get",
+        side_effect=Exception("Intentional Error for Testing"),
+    )
+
+    with pytest.raises(Exception):
+        backend_client.get_gardens(
+            dois=["some/doi"],
+            tags=["tag1", "tag2"],
+            authors=["author1", "author2"],
+            contributors=["contributor1", "contributor2"],
+            draft=True,
+            year="2023",
+            owner_uuid="someuuid",
+            limit=5,
+        )
+
+
+def test_get_gardens_returns_list_of_gardens(
+    mocker,
+    backend_client,
+    garden_nested_metadata_json,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._get",
+        return_value=[garden_nested_metadata_json for _ in range(5)],
+    )
+
+    gardens = backend_client.get_gardens(
+        # args don't matter for this test
+        dois=["some/doi"],
+    )
+
+    for garden in gardens:
+        assert isinstance(garden, Garden)
+
+
+def test_get_user_info_raises_on_backend_failure(
+    mocker,
+    backend_client,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._get",
+        side_effect=Exception("Intentional Error for Testing"),
+    )
+
+    with pytest.raises(Exception):
+        backend_client.get_user_info()
+
+
+def test_get_user_info_returns_user_info(
+    mocker,
+    backend_client,
+    mock_user_info_response,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._get",
+        return_value=mock_user_info_response,
+    )
+
+    user_info = backend_client.get_user_info()
+    assert user_info == mock_user_info_response
+
+
+def test_put_entrypoint_metadata_raises_on_backend_failure(
+    mocker,
+    backend_client,
+    mock_RegisteredEntrypointMetadata,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._put",
+        side_effect=Exception("Intentional Error for Testing"),
+    )
+
+    with pytest.raises(Exception):
+        backend_client.put_entrypoint_metadata(mock_RegisteredEntrypointMetadata)
+
+
+def test_put_entrypoint_metadata_returns_entrypoint_metadata_on_success(
+    mocker,
+    backend_client,
+    entrypoint_metadata_json,
+    mock_RegisteredEntrypointMetadata,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._put",
+        return_value=entrypoint_metadata_json,
+    )
+
+    entrypoint_meta = backend_client.put_entrypoint_metadata(
+        mock_RegisteredEntrypointMetadata
+    )
+
+    assert isinstance(entrypoint_meta, RegisteredEntrypointMetadata)

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,6 +1,6 @@
-import pathlib
 import datetime
 import json
+import pathlib
 import tarfile
 
 import docker
@@ -117,7 +117,10 @@ def mock_notebook_path(tmp_path):
 
 
 def test_build_notebook_session_image_success(
-    mock_docker_client, mock_notebook_path, mock_datetime, mocker
+    mock_docker_client,
+    mock_notebook_path,
+    mock_datetime,
+    mocker,
 ):
     base_image = "gardenai/fake-image:soonest"
 

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,0 +1,347 @@
+import pathlib
+import datetime
+import json
+import tarfile
+
+import docker
+import pytest
+import io
+
+import garden_ai.containers
+from garden_ai.constants import GardenConstants
+
+IMAGE_ID = "sha256:2d6e000f4f63e1234567a1234567890123456789a1234567890b1234567890c1"
+
+
+@pytest.fixture
+def mock_docker_client(mocker):
+    client = mocker.Mock(spec=docker.DockerClient)
+    client.images.pull.return_value = None
+    client.containers.run.return_value = mocker.Mock(
+        spec=docker.models.containers.Container
+    )
+
+    # Mock the APIClient and set it as the `api` attribute on the DockerClient mock
+    api_client = mocker.MagicMock()
+    api_client.build.return_value = [
+        {"stream": "Step 1/3 : FROM gardenai/base:python-3.10-base"},
+        {"stream": " ---> Using cache"},
+        {"stream": " ---> 2d6e000f4f63"},
+        {"aux": {"ID": IMAGE_ID}},
+        {"stream": "Successfully built 2d6e000f4f63"},
+    ]
+
+    image_mock = mocker.MagicMock()
+    image_mock.id = IMAGE_ID
+    client.images.get.return_value = image_mock
+
+    client.api = api_client
+    return client
+
+
+@pytest.fixture
+def mock_datetime(mocker):
+    """Fixture to mock datetime.datetime.now to return a fixed datetime object."""
+    fixed_timestamp = "20240101-120000000"
+    fixed_datetime = datetime.datetime.strptime(fixed_timestamp, "%Y%m%d-%H%M%S%f")
+    mock_datetime_class = mocker.patch("datetime.datetime")
+    mock_datetime_class.now.return_value = fixed_datetime
+    yield fixed_datetime
+
+
+def test_get_docker_client_raises_if_docker_fails_to_start(
+    mocker,
+):
+    mocker.patch(
+        "garden_ai.containers.docker.from_env",
+        side_effect=docker.errors.DockerException(
+            "Error while fetching server API version"
+        ),
+    )
+
+    with pytest.raises(garden_ai.containers.DockerStartFailure):
+        garden_ai.containers.get_docker_client()
+
+
+def test_start_container_with_notebook(mock_docker_client, mocker):
+    mock_socket = mocker.patch("garden_ai.containers.socket.socket")
+    # Make it so that the port check always shows that port is not in use.
+    mock_socket.return_value.connect_ex.return_value = 1
+
+    path = pathlib.Path("/path/to/notebook.ipynb")
+    base_image = "gardenai/fake-image:soonest"
+
+    container = garden_ai.containers.start_container_with_notebook(
+        mock_docker_client, path, base_image
+    )
+
+    mock_docker_client.images.pull.assert_called_once_with(
+        base_image, platform="linux/x86_64"
+    )
+
+    expected_volumes = {str(path): {"bind": f"/garden/{path.name}", "mode": "rw"}}
+
+    expected_entrypoint = [
+        "jupyter",
+        "notebook",
+        "--notebook-dir=/garden",
+        "--NotebookApp.token=''",
+        "--ip",
+        "0.0.0.0",
+        "--no-browser",
+        "--allow-root",
+        "--config=/garden/custom_jupyter_config.py",
+    ]
+
+    mock_docker_client.containers.run.assert_called_once_with(
+        base_image,
+        platform="linux/x86_64",
+        detach=True,
+        ports={"8888/tcp": GardenConstants.DEFAULT_JUPYTER_PORT},
+        volumes=expected_volumes,
+        entrypoint=expected_entrypoint,
+        environment={"NOTEBOOK_PATH": "/garden/notebook.ipynb"},
+        stdin_open=True,
+        tty=True,
+        remove=True,
+    )
+
+    assert isinstance(container, mocker.Mock)
+
+
+@pytest.fixture
+def mock_notebook_path(tmp_path):
+    path = tmp_path / "test_notebook.ipynb"
+    path.write_text('{"cells": []}')
+    return path
+
+
+def test_build_notebook_session_image_success(
+    mock_docker_client, mock_notebook_path, mock_datetime, mocker
+):
+    base_image = "gardenai/fake-image:soonest"
+
+    mocker.patch(
+        "nbconvert.PythonExporter.from_filename",
+        return_value=('print("Hello, world!")', None),
+    )
+    mocker.patch("pathlib.Path.read_text", return_value="# Test notebook")
+    mocker.patch("inspect.getsource", return_value="fake source code")
+    image = garden_ai.containers.build_notebook_session_image(
+        client=mock_docker_client,
+        notebook_path=mock_notebook_path,
+        base_image=base_image,
+    )
+
+    # Test that the build was called
+    mock_docker_client.api.build.assert_called()
+    build_kwargs = mock_docker_client.api.build.call_args.kwargs
+    # assert that build was instructed to cleanup intermediate containers
+    assert build_kwargs["rm"] and build_kwargs["forcerm"]
+
+    # assert tagging/timestamp behavior
+    assert "gardenai/custom:final-20240101-120000" == build_kwargs["tag"]
+
+    # Test that the function returned something successfully
+    assert image is not None
+
+
+def test_extract_metadata_from_image(mock_docker_client, mocker):
+    # Mock metadata returned from image
+    mock_metadata = {
+        "function_name_1": {"some": "metadata"},
+        "function_name_2": {"other": "metadata"},
+    }
+
+    file_contents = json.dumps(mock_metadata).encode("utf-8")
+    tar_stream = io.BytesIO()
+    with tarfile.open(fileobj=tar_stream, mode="w") as tar:
+        tarinfo = tarfile.TarInfo(name="metadata.json")
+        tarinfo.size = len(file_contents)
+        file_contents_stream = io.BytesIO(file_contents)
+        tar.addfile(tarinfo, file_contents_stream)
+    tar_stream.seek(0)
+
+    mock_container = mock_docker_client.containers.create.return_value
+    mock_container.get_archive.return_value = (iter([tar_stream.getvalue()]), None)
+
+    # Mock image object
+    mock_image = mocker.MagicMock(spec=docker.models.images.Image)
+    mock_image.id = "some_image_id"
+
+    # Invoke function
+    result = garden_ai.containers.extract_metadata_from_image(
+        client=mock_docker_client, image=mock_image
+    )
+
+    assert result == mock_metadata
+
+
+def test_push_image_to_public_repo(mock_docker_client, capsys, mocker):
+    repo_name = GardenConstants.GARDEN_ECR_REPO
+    image_id = "some_image_id"
+    mock_image = mocker.MagicMock(spec=docker.models.images.Image)
+    mock_image.id = image_id
+    mock_image.tag = mocker.MagicMock(return_value=True)
+    mock_credentials = {"username": "username", "password": "password"}
+    mock_push_logs = [
+        {"status": f"The push refers to repository [{repo_name}]"},
+        {"status": "Preparing", "progress": "Preparing..."},
+        {"status": "Pushing", "progress": "[===> ]"},
+        {
+            "status": "Pushed",
+            "progress": "[==================================================>]",
+        },
+        {"status": "latest: digest: sha256:somedigest size: 5278"},
+    ]
+    mock_docker_client.images.push.return_value = iter(mock_push_logs)
+
+    fixed_timestamp = "20240101-120000000000"
+    fixed_datetime = datetime.datetime.strptime(fixed_timestamp, "%Y%m%d-%H%M%S%f")
+
+    mock_datetime = mocker.patch("datetime.datetime")
+    mock_datetime.now.return_value = fixed_datetime
+    full_repo_tag = garden_ai.containers.push_image_to_public_repo(
+        client=mock_docker_client,
+        image=mock_image,
+        auth_config=mock_credentials,
+        # print_logs=False,
+    )
+
+    full_tag_expected = f"{repo_name}:pushed-{fixed_timestamp}"
+    mock_image.tag.assert_called_once_with(full_tag_expected)
+    mock_docker_client.images.push.assert_called_once_with(
+        full_tag_expected,
+        auth_config=mock_credentials,
+        stream=True,
+        decode=True,
+    )
+    assert full_repo_tag == full_tag_expected
+
+    captured = capsys.readouterr()
+    for log in mock_push_logs:
+        if "progress" in log:
+            expected_log = f"{log['status']} - {log['progress']}"
+        else:
+            expected_log = log["status"]
+        assert expected_log in captured.out
+
+
+@pytest.mark.parametrize("requirements_file", ["requirements.txt", None])
+def test_build_image_with_dependencies(
+    mock_docker_client, mocker, requirements_file, mock_datetime
+):
+    base_image = "gardenai/base:python-3.10-base"
+    requirements_path = pathlib.Path(requirements_file) if requirements_file else None
+
+    # Mock the file read for requirements.txt
+    file_content = (
+        "some-package==1.0.0"
+        if requirements_file == "requirements.txt"
+        else "dependencies:\n  - numpy"
+    )
+    mocker.patch("pathlib.Path.read_text", return_value=file_content)
+    mocker.patch(
+        "garden_ai.containers.save_requirements_data", return_value=requirements_path
+    )
+
+    # Prepare to capture the Dockerfile content
+    dockerfile_content_capture = io.StringIO()
+
+    # Mock the 'open' method on the specific Path object
+    mock_path_open = mocker.patch.object(pathlib.Path, "open")
+    mock_path_open.return_value.__enter__.return_value = dockerfile_content_capture
+
+    image_id = garden_ai.containers.build_image_with_dependencies(
+        client=mock_docker_client,
+        base_image=base_image,
+        requirements_data={"contents": "some requirements data"},
+    )
+
+    contents = dockerfile_content_capture.getvalue()
+    # Test that the Dockerfile was created correctly per requirements type
+    assert f"FROM {base_image}" in contents
+    assert "WORKDIR /garden" in contents
+    assert "RUN pip install --no-cache-dir --upgrade garden-ai" in contents
+    assert "COPY custom_jupyter_config.py /garden/custom_jupyter_config.py" in contents
+    if requirements_file == "requirements.txt":
+        assert f"COPY {requirements_file} /garden/{requirements_file}" in contents
+        assert "RUN pip install --upgrade -r /garden/requirements.txt" in contents
+        assert "conda" not in contents
+    else:  # None
+        assert "pip install -r" not in contents
+        assert "conda" not in contents
+
+    # Test that the build was called
+    mock_docker_client.api.build.assert_called()
+
+    build_kwargs = mock_docker_client.api.build.call_args.kwargs
+    # assert that build was instructed to cleanup intermediate containers
+    assert build_kwargs["rm"] and build_kwargs["forcerm"]
+
+    # assert tagging/timestamp behavior
+    assert "gardenai/custom:base-20240101-120000" == build_kwargs["tag"]
+
+    # Test that the function returned the correct image ID
+    # (this is set in the mock_docker_client fixture)
+    expected_image_id = IMAGE_ID
+    assert image_id == expected_image_id
+
+
+def test_handle_docker_errors():
+    def test_func():
+        return "Hello, World!"
+
+    wrapped_test_func = garden_ai.containers.handle_docker_errors(test_func)
+
+    # Test when no exception is raised
+    assert wrapped_test_func() == "Hello, World!"
+
+    # Test variations on DockerExceptions that are thrown when Garden can't access Docker
+    error_message_output_pairs = [
+        (
+            "Error while fetching server API version: ConnectionRefusedError",
+            "Could not connect to your local Docker daemon. Double check that Docker is running.",
+        ),
+        (
+            "Error while fetching server API version: PermissionError",
+            "It looks like your current user does not have permissions to use Docker.",
+        ),
+    ]
+
+    for error_message, expected_output in error_message_output_pairs:
+        with pytest.raises(garden_ai.containers.DockerStartFailure) as excinfo:
+
+            def test_func_error():
+                raise docker.errors.DockerException(error_message)
+
+            wrapped_test_func_error = garden_ai.containers.handle_docker_errors(
+                test_func_error
+            )
+            wrapped_test_func_error()
+        assert expected_output in str(excinfo.value.helpful_explanation)
+
+    # Test the case where it's a startup error, but not one of the common cases
+    with pytest.raises(garden_ai.containers.DockerStartFailure) as excinfo:
+
+        def test_func_error():
+            raise docker.errors.DockerException(
+                "Error while fetching server API version: SomeOtherError"
+            )
+
+        wrapped_test_func_error = garden_ai.containers.handle_docker_errors(
+            test_func_error
+        )
+        wrapped_test_func_error()
+    assert "SomeOtherError" in str(excinfo.value.original_exception)
+
+    # Test a Docker error unrelated to startup. The docker.errors.DockerException should be raised as-is.
+    with pytest.raises(docker.errors.DockerException):
+
+        def test_func_error():
+            raise docker.errors.DockerException("Some Docker error")
+
+        wrapped_test_func_error = garden_ai.containers.handle_docker_errors(
+            test_func_error
+        )
+        wrapped_test_func_error()

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -3,7 +3,7 @@ import json
 import pathlib
 import tarfile
 
-import docker
+import docker  # type: ignore
 import pytest
 import io
 

--- a/tests/test_gardens.py
+++ b/tests/test_gardens.py
@@ -1,0 +1,84 @@
+import pytest
+
+from garden_ai import Garden
+from garden_ai.gardens import GardenMetadata
+from garden_ai.entrypoints import Entrypoint, RegisteredEntrypointMetadata
+
+
+def test_garden_init_raises_if_metadata_entrypoints_dont_match(
+    garden_nested_metadata_json,
+):
+    entrypoints = []
+    garden_meta = GardenMetadata(**garden_nested_metadata_json)
+
+    with pytest.raises(ValueError):
+        # Giving an empty list of entrypoing should cause an error
+        # garden_meta has an entrypoint_id so there is a mismatch
+        garden = Garden(garden_meta, entrypoints)  # noqa: F841
+
+
+def test_garden_init(
+    garden_nested_metadata_json,
+    entrypoint_metadata_json,
+):
+    garden_meta = GardenMetadata(**garden_nested_metadata_json)
+    entrypoint_meta = RegisteredEntrypointMetadata(**entrypoint_metadata_json)
+    entrypoint = Entrypoint(entrypoint_meta)
+
+    garden = Garden(garden_meta, [entrypoint])
+    assert isinstance(garden, Garden)
+    assert garden.metadata == garden_meta
+    assert garden.entrypoints == [entrypoint]
+
+
+def test_can_call_entrypoints_like_methods(
+    garden_nested_metadata_json,
+    entrypoint_metadata_json,
+    mocker,
+):
+    garden_meta = GardenMetadata(**garden_nested_metadata_json)
+    entrypoint_meta = RegisteredEntrypointMetadata(**entrypoint_metadata_json)
+    entrypoint = Entrypoint(entrypoint_meta)
+
+    mock_call = mocker.patch.object(Entrypoint, "__call__")
+
+    garden = Garden(garden_meta, [entrypoint])
+    # Call the entrypoint like a method
+    garden.predict_defect_level_energies()
+    mock_call.assert_called()
+
+    with pytest.raises(AttributeError):
+        # but calling some other attribute should still fail
+        garden.some_entrypoint_that_does_not_exist()
+
+
+def test_repr_html_contains_garden_doi_and_entrypoint_dois(
+    garden_nested_metadata_json,
+    entrypoint_metadata_json,
+):
+    garden_meta = GardenMetadata(**garden_nested_metadata_json)
+    entrypoint_meta = RegisteredEntrypointMetadata(**entrypoint_metadata_json)
+    entrypoint = Entrypoint(entrypoint_meta)
+
+    garden = Garden(garden_meta, [entrypoint])
+    html = garden._repr_html_()
+
+    assert garden.metadata.doi in html
+    for ep in garden.entrypoints:
+        assert ep.metadata.doi in html
+
+
+def test_entrypoint_names_in_dir(
+    garden_nested_metadata_json,
+    entrypoint_metadata_json,
+):
+    garden_meta = GardenMetadata(**garden_nested_metadata_json)
+    entrypoint_meta = RegisteredEntrypointMetadata(**entrypoint_metadata_json)
+    entrypoint = Entrypoint(entrypoint_meta)
+
+    garden = Garden(garden_meta, [entrypoint])
+
+    attrs = dir(garden)
+
+    for ep in garden.entrypoints:
+        assert ep.metadata.short_name in attrs

--- a/tests/test_notebook_metadata.py
+++ b/tests/test_notebook_metadata.py
@@ -1,8 +1,12 @@
+import json
+import os
 from pathlib import Path
 
+import ipywidgets as widgets
 import nbformat
 import pytest
 
+from garden_ai.constants import GardenConstants
 from garden_ai.notebook_metadata import (
     add_notebook_metadata,
     set_notebook_metadata,
@@ -12,133 +16,46 @@ from garden_ai.notebook_metadata import (
     RequirementsData,
     NOTEBOOK_DISPLAY_METADATA_CELL,
     _has_metadata_cell_tag,
+    display_metadata_widget,
 )
 
 
-pip_requirements_raw = "scikit-learn==1.2.2\npandas\n"
-pip_requirements = {"file_format": "pip", "contents": ["scikit-learn==1.2.2", "pandas"]}
-
-notebook_empty = {"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 4}
-notebook_with_empty_metadata = {
-    "cells": [
-        {
-            "cell_type": "code",
-            "metadata": {
-                "tags": ["garden_display_metadata_cell"],
-            },
-            "execution_count": None,
-            "source": NOTEBOOK_DISPLAY_METADATA_CELL,
-            "outputs": [],
-        }
-    ],
-    "metadata": {
-        "garden_metadata": {
-            "notebook_image_uri": None,
-            "global_notebook_doi": None,
-            "notebook_image_name": None,
-            "notebook_requirements": None,
-        },
-    },
-    "nbformat": 4,
-    "nbformat_minor": 4,
-}
-notebook_with_metadata = {
-    "cells": [
-        {
-            "cell_type": "code",
-            "metadata": {
-                "tags": ["garden_display_metadata_cell"],
-            },
-            "execution_count": None,
-            "source": NOTEBOOK_DISPLAY_METADATA_CELL,
-            "outputs": [],
-        }
-    ],
-    "metadata": {
-        "garden_metadata": {
-            "notebook_image_uri": "A_BASE_IMAGE_URI",
-            "global_notebook_doi": "10.23677/testdoi",
-            "notebook_image_name": "3.9-base",
-            "notebook_requirements": pip_requirements,
-        },
-    },
-    "nbformat": 4,
-    "nbformat_minor": 4,
-}
-
-notebook_metadata_pip = {
-    "global_notebook_doi": "10.23677/testdoi",
-    "notebook_image_name": "3.9-base",
-    "notebook_requirements": pip_requirements,
-    "notebook_image_uri": "A_BASE_IMAGE_URI",
-}
-
-
-@pytest.mark.integration
-def test_add_notebook_metadata_writes_metadata_cell_to_notebook(
-    tmp_notebook_empty,
+def test_add_metadata(
+    mocker,
+    notebook_empty,
+    notebook_with_empty_metadata,
 ):
-    # A new notebook should not have the metadata cell
-    ntbk = nbformat.read(tmp_notebook_empty, nbformat.NO_CONVERT)
-    assert not _has_metadata_cell_tag(ntbk)
+    ntbk = nbformat.from_dict(notebook_empty)
 
-    # Add the metadata cell
-    add_notebook_metadata(tmp_notebook_empty)
+    mocker.patch("garden_ai.notebook_metadata._read_notebook", return_value=ntbk)
 
-    # The notebook should now have the metadata cell as its first cell
-    ntbk = nbformat.read(tmp_notebook_empty, nbformat.NO_CONVERT)
-    assert _has_metadata_cell_tag(ntbk)
-    assert ntbk.cells[0].source == NOTEBOOK_DISPLAY_METADATA_CELL
+    nbformat_write_mock = mocker.patch("garden_ai.notebook_metadata.nbformat.write")
+
+    add_notebook_metadata(None)
+
+    write_arg = nbformat_write_mock.call_args.args[0]
+    assert write_arg == notebook_with_empty_metadata
 
 
-@pytest.mark.integration
-def test_get_metadata_returns_empty_metadata_if_garden_metadata_not_foune(
-    tmp_notebook_empty,
+def test_get_metadata(
+    mocker,
+    notebook_metadata_pip,
+    notebook_with_metadata,
 ):
-    ntbk_meta = get_notebook_metadata(tmp_notebook_empty)
-    assert ntbk_meta.global_notebook_doi is None
-    assert ntbk_meta.notebook_image_name is None
-    assert ntbk_meta.notebook_image_uri is None
-    assert ntbk_meta.notebook_requirements is None
+    ntbk = nbformat.from_dict(notebook_with_metadata)
+
+    mocker.patch("garden_ai.notebook_metadata._read_notebook", return_value=ntbk)
+
+    notebook_metadata = get_notebook_metadata(None).model_dump()
+
+    assert notebook_metadata == notebook_metadata_pip
 
 
-@pytest.mark.integration
-def test_get_metadata_returns_empty_metadata_if_garden_metadata_is_bad(
-    tmp_notebook_empty,
+def test_set_metadata(
+    mocker,
+    notebook_with_metadata,
+    notebook_with_empty_metadata,
 ):
-    # Set up a bad garden_metadata cell
-    ntbk = nbformat.read(tmp_notebook_empty, nbformat.NO_CONVERT)
-    ntbk["metadata"]["garden_metadata"] = {"some": "bad_data"}
-    nbformat.write(ntbk, tmp_notebook_empty, version=nbformat.NO_CONVERT)
-
-    # Get the metadata
-    ntbk_meta = get_notebook_metadata(tmp_notebook_empty)
-    assert ntbk_meta.global_notebook_doi is None
-    assert ntbk_meta.notebook_image_name is None
-    assert ntbk_meta.notebook_image_uri is None
-    assert ntbk_meta.notebook_requirements is None
-
-
-@pytest.mark.integration
-def test_get_metadata_returns_metadata_if_already_present(
-    tmp_notebook_empty,
-):
-    # Set up a garden_metadata cell
-    ntbk = nbformat.read(tmp_notebook_empty, nbformat.NO_CONVERT)
-    ntbk["metadata"]["garden_metadata"] = notebook_metadata_pip
-    nbformat.write(ntbk, tmp_notebook_empty, version=nbformat.NO_CONVERT)
-
-    # Get the metadata
-    ntbk_meta = get_notebook_metadata(tmp_notebook_empty)
-    assert ntbk_meta.global_notebook_doi == notebook_metadata_pip["global_notebook_doi"]
-    assert ntbk_meta.notebook_image_name == notebook_metadata_pip["notebook_image_name"]
-    assert ntbk_meta.notebook_image_uri == notebook_metadata_pip["notebook_image_uri"]
-    assert ntbk_meta.notebook_requirements == RequirementsData(
-        **notebook_metadata_pip["notebook_requirements"]
-    )
-
-
-def test_set_metadata(mocker):
     ntbk = nbformat.from_dict(notebook_with_empty_metadata)
 
     mocker.patch("garden_ai.notebook_metadata._read_notebook", return_value=ntbk)
@@ -156,7 +73,97 @@ def test_set_metadata(mocker):
     assert write_arg == notebook_with_metadata
 
 
-@pytest.mark.integration
+def test_read_requirements_data_pip(
+    mocker,
+    pip_requirements_raw,
+    pip_requirements,
+):
+    # pip file
+    mocker.patch("builtins.open", mocker.mock_open(read_data=pip_requirements_raw))
+    requirements_data = read_requirements_data(Path("file.txt"))
+    assert requirements_data.model_dump() == pip_requirements
+
+
+def test_write_requirements(
+    mocker,
+    pip_requirements,
+    pip_requirements_raw,
+):
+    mock_file = mocker.patch("builtins.open", mocker.mock_open())
+    save_requirements_data(Path("file.txt"), RequirementsData(**pip_requirements))
+    mock_file().write.assert_called_with(pip_requirements_raw)
+
+
+def test_read_requirements_data_returns_none_if_invalid_format(
+    tmp_path,
+):
+    # An invalid file format
+    file = tmp_path / "some_file.json"
+    requirements_data = read_requirements_data(file)
+    assert requirements_data is None
+
+
+def test_add_notebook_metadata_writes_metadata_cell_to_notebook(
+    tmp_notebook_empty,
+):
+    # A new notebook should not have the metadata cell
+    ntbk = nbformat.read(tmp_notebook_empty, nbformat.NO_CONVERT)
+    assert not _has_metadata_cell_tag(ntbk)
+
+    # Add the metadata cell
+    add_notebook_metadata(tmp_notebook_empty)
+
+    # The notebook should now have the metadata cell as its first cell
+    ntbk = nbformat.read(tmp_notebook_empty, nbformat.NO_CONVERT)
+    assert _has_metadata_cell_tag(ntbk)
+    assert ntbk.cells[0].source == NOTEBOOK_DISPLAY_METADATA_CELL
+
+
+def test_get_metadata_returns_empty_metadata_if_garden_metadata_not_foune(
+    tmp_notebook_empty,
+):
+    ntbk_meta = get_notebook_metadata(tmp_notebook_empty)
+    assert ntbk_meta.global_notebook_doi is None
+    assert ntbk_meta.notebook_image_name is None
+    assert ntbk_meta.notebook_image_uri is None
+    assert ntbk_meta.notebook_requirements is None
+
+
+def test_get_metadata_returns_empty_metadata_if_garden_metadata_is_bad(
+    tmp_notebook_empty,
+):
+    # Set up a bad garden_metadata cell
+    ntbk = nbformat.read(tmp_notebook_empty, nbformat.NO_CONVERT)
+    ntbk["metadata"]["garden_metadata"] = {"some": "bad_data"}
+    nbformat.write(ntbk, tmp_notebook_empty, version=nbformat.NO_CONVERT)
+
+    # Get the metadata
+    ntbk_meta = get_notebook_metadata(tmp_notebook_empty)
+    assert ntbk_meta.global_notebook_doi is None
+    assert ntbk_meta.notebook_image_name is None
+    assert ntbk_meta.notebook_image_uri is None
+    assert ntbk_meta.notebook_requirements is None
+
+
+def test_get_metadata_returns_metadata_if_already_present(
+    notebook_metadata_pip,
+    tmp_notebook_empty,
+):
+    # Set up a garden_metadata cell
+    ntbk = nbformat.read(tmp_notebook_empty, nbformat.NO_CONVERT)
+    ntbk["metadata"]["garden_metadata"] = notebook_metadata_pip
+    nbformat.write(ntbk, tmp_notebook_empty, version=nbformat.NO_CONVERT)
+
+    # Get the metadata
+    ntbk_meta = get_notebook_metadata(tmp_notebook_empty)
+    assert ntbk_meta.global_notebook_doi == notebook_metadata_pip["global_notebook_doi"]
+    assert ntbk_meta.notebook_image_name == notebook_metadata_pip["notebook_image_name"]
+    assert ntbk_meta.notebook_image_uri == notebook_metadata_pip["notebook_image_uri"]
+    assert ntbk_meta.notebook_requirements == RequirementsData(
+        **notebook_metadata_pip["notebook_requirements"]
+    )
+
+
 def test_set_metadata_raises_if_unable_to_parse_notebook(
     tmp_path,
 ):
@@ -173,23 +180,116 @@ def test_set_metadata_raises_if_unable_to_parse_notebook(
         )
 
 
-def test_read_requirements_data_pip(mocker):
-    # pip file
-    mocker.patch("builtins.open", mocker.mock_open(read_data=pip_requirements_raw))
-    requirements_data = read_requirements_data(Path("file.txt"))
-    assert requirements_data.model_dump() == pip_requirements
-
-
-def test_read_requirements_data_returns_none_if_invalid_format(
-    tmp_path,
+def test_display_metadata_widget_displays(
+    mocker,
+    patch_notebook_env,
+    patch_get_notebook_metadata,
 ):
-    # An invalid file format
-    file = tmp_path / "some_file.json"
-    requirements_data = read_requirements_data(file)
-    assert requirements_data is None
+    mock_display = mocker.patch(
+        "garden_ai.notebook_metadata.display",
+    )
+
+    display_metadata_widget()
+
+    mock_display.assert_called_once()
 
 
-def test_write_requirements(mocker):
-    mock_file = mocker.patch("builtins.open", mocker.mock_open())
-    save_requirements_data(Path("file.txt"), RequirementsData(**pip_requirements))
-    mock_file().write.assert_called_with(pip_requirements_raw)
+def test_change_to_doi_updates_notebook_metadata_json(
+    mocker,
+    patch_notebook_env,
+    patch_get_notebook_metadata,
+):
+    # Create a stand-in for the doi_widget and patch it in
+    doi_widget = widgets.Textarea("Some DOI")
+    mocker.patch(
+        "garden_ai.notebook_metadata._build_doi_widget",
+        return_value=doi_widget,
+    )
+
+    # Display the metadata widget to kick everything off
+    display_metadata_widget()
+
+    # Update the doi widget simulating a user interaction
+    # This should cause a new notebook_metadata.json to be written
+    doi_widget.value = "New DOI"
+
+    # Grab the json file
+    ntbk_meta_path = (
+        Path(os.environ.get("NOTEBOOK_PATH")).parent / "notebook_metadata.json"
+    )
+    assert ntbk_meta_path.exists()
+    with open(ntbk_meta_path, "r") as f:
+        metadata = json.load(f)
+
+    # See if the updated doi is correct
+    assert metadata["global_notebook_doi"] == doi_widget.value
+
+
+def test_change_to_base_image_updates_notebook_metadata_json(
+    mocker,
+    patch_notebook_env,
+    patch_get_notebook_metadata,
+):
+    # Create a stand-in for the base_image_widget and patch it in
+    base_image_widget = widgets.Dropdown(
+        options=GardenConstants.PREMADE_IMAGES.keys(), value="3.10-base", disabled=False
+    )
+    mocker.patch(
+        "garden_ai.notebook_metadata._build_base_image_widget",
+        return_value=base_image_widget,
+    )
+
+    # Display the metadata widget to kick everything off
+    display_metadata_widget()
+
+    # Update the base image widget simulating a user interaction
+    # This should cause a new notebook_metadata.json to be written
+    base_image_widget.value = "3.11-base"
+
+    # Grab the json file
+    ntbk_meta_path = (
+        Path(os.environ.get("NOTEBOOK_PATH")).parent / "notebook_metadata.json"
+    )
+    assert ntbk_meta_path.exists()
+    with open(ntbk_meta_path, "r") as f:
+        metadata = json.load(f)
+
+    # See if the updated base image is correct
+    assert metadata["notebook_image_name"] == base_image_widget.value
+
+
+def test_change_to_requirements_updates_notebook_metadata_json(
+    mocker,
+    patch_notebook_env,
+    patch_get_notebook_metadata,
+):
+    # Create a stand-in for the reqs_widget and patch it in
+    reqs_widget = widgets.Textarea(
+        value="some-package",
+        placeholder="Requirements",
+        layout=widgets.Layout(width="100%", height="80px"),
+        continuous_update=False,
+        disabled=False,
+    )
+    mocker.patch(
+        "garden_ai.notebook_metadata._build_reqs_widget",
+        return_value=reqs_widget,
+    )
+
+    # Display the metadata widget to kick everything off
+    display_metadata_widget()
+
+    # Update the reqs widget simulating a user interaction
+    # This should cause a new notebook_metadata.json to be written
+    reqs_widget.value = "new-package"
+
+    # Grab the json file
+    ntbk_meta_path = (
+        Path(os.environ.get("NOTEBOOK_PATH")).parent / "notebook_metadata.json"
+    )
+    assert ntbk_meta_path.exists()
+    with open(ntbk_meta_path, "r") as f:
+        metadata = json.load(f)
+
+    # See if the updated reqs are correct
+    assert reqs_widget.value in metadata["notebook_requirements"]["contents"]

--- a/tests/test_notebook_metadata.py
+++ b/tests/test_notebook_metadata.py
@@ -2,7 +2,7 @@ import json
 import os
 from pathlib import Path
 
-import ipywidgets as widgets
+import ipywidgets as widgets  # type: ignore
 import nbformat
 import pytest
 


### PR DESCRIPTION
Related: #507 

## Overview

This PR add small-scale test coverage of the the core modules that make garden work.

## Discussion

This PR includes a sizeable refactor of the `notebook_metadata.py` module to make it easier to get better test coverage. I didn't change any of the underlying logic, mostly moved stuff around into helper functions.

The tests of the containers module are mostly from the old test suite. The containers module and notebook CLI commands are where the biggest gaps in coverage are after this PR. Integration tests that cover these modules will come in another PR.

## Testing

Lots of new tests, plus some old ones!


<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--530.org.readthedocs.build/en/530/

<!-- readthedocs-preview garden-ai end -->