### PR TITLE
Update coverage config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      garden-ai:
+        target: auto # PRs should increase overall coverage
+        threshold: 5 # Allow a bit of wiggle room

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,19 +41,19 @@ jobs:
         run: |
           # stop the build if there are any-flake8 comments
           flake8
-      - name: Test with pytest
-        run: |
-          pytest -m "not integration" --cov=./ --cov-report=xml -r sx
       - name: Perform Type Checking With mypy
         run: |
           mypy .
-      - name: Upload coverage
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
-          fail_ci_if_error: true
-          files: ./coverage.xml
       - name: Check for vulnerable libraries with safety
         run: |
           safety check
+      - name: Test with pytest
+        run: |
+          pytest -m "not integration" --cov=./ --cov-report=xml -r sx
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4.2.0
+        env:
+            CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          verbose: true
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![PyPI](https://badge.fury.io/py/garden-ai.svg)](https://badge.fury.io/py/garden-ai)
 [![Tests](https://github.com/Garden-AI/garden/actions/workflows/pypi.yaml/badge.svg)](https://github.com/Garden-AI/garden/actions/workflows/pypi.yaml)
 [![tests](https://github.com/Garden-AI/garden/actions/workflows/ci.yaml/badge.svg)](https://github.com/Garden-AI/garden/actions/workflows/ci.yaml)
+[![codecov](https://codecov.io/github/Garden-AI/garden/graph/badge.svg?token=WYINAGF0S4)](https://codecov.io/github/Garden-AI/garden)
 
 ## At a Glance:
 


### PR DESCRIPTION
Resolves: #531 

## Overview

This PR sets up a basic codecov config in `.codecov.yml` and updates the ci pipeline to use a newer version of the codecov action.

# Documentation

This PR adds the codecov badge to `README.md`

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--535.org.readthedocs.build/en/535/

<!-- readthedocs-preview garden-ai end -->