### PR TITLE
gardens have ModalFunction attributes 

### DIFF
--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -83,7 +83,7 @@ class Garden:
 
         for modal_function in self.modal_functions:
             if name == modal_function.metadata.function_name:
-                return name
+                return modal_function
 
         raise AttributeError(
             f"'{self.__class__.__name__}' object has no attribute '{name}'."

--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -160,10 +160,13 @@ class Garden:
             entrypoints += [Entrypoint(RegisteredEntrypointMetadata(**entrypoint_data))]
             metadata.entrypoint_ids += [entrypoint_data["doi"]]
 
-        modal_functions = []
-        for modal_fn_data in data["modal_functions"]:
-            modal_functions += [ModalFunction(ModalFunctionMetadata(**modal_fn_data))]
-            # TODO: use DOIs once modal functions have them
-            metadata.modal_function_ids += [modal_fn_data["function_name"]]
+        if "modal_functions" in data:
+            modal_functions = []
+            for modal_fn_data in data["modal_functions"]:
+                modal_functions += [
+                    ModalFunction(ModalFunctionMetadata(**modal_fn_data))
+                ]
+                # TODO: use DOIs once modal functions have them
+                metadata.modal_function_ids += [modal_fn_data["function_name"]]
 
         return cls(metadata, entrypoints)

--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -6,6 +6,8 @@ from tabulate import tabulate
 
 from garden_ai.schemas.entrypoint import RegisteredEntrypointMetadata
 from garden_ai.schemas.garden import GardenMetadata
+from garden_ai.schemas.modal import ModalFunctionMetadata
+from garden_ai.modal.functions import ModalFunction
 
 from .entrypoints import Entrypoint
 
@@ -36,14 +38,31 @@ class Garden:
         ```
     """  # noqa: E501
 
-    def __init__(self, metadata: GardenMetadata, entrypoints: list[Entrypoint]):
-        if set(metadata.entrypoint_ids) != set([ep.metadata.doi for ep in entrypoints]):
+    def __init__(
+        self,
+        metadata: GardenMetadata,
+        entrypoints: list[Entrypoint] | None = None,
+        modal_functions: list[ModalFunction] | None = None,
+    ):
+        entrypoints = entrypoints or []
+        modal_functions = modal_functions or []
+
+        if set(metadata.entrypoint_ids) ^ set([ep.metadata.doi for ep in entrypoints]):
             raise ValueError(
                 "Expected `entrypoints` DOIs to match `metadata.entrypoint_ids`. "
                 f"Got: {[ep.metadata.doi for ep in entrypoints]} != {metadata.entrypoint_ids}"
             )
+        # TODO: update to use DOIs when modal functions have them
+        if set(metadata.modal_function_ids) ^ set(
+            [mf.metadata.function_name for mf in modal_functions]
+        ):
+            raise ValueError(
+                "Expected `modal_functions` to match `metadata.modal_function_ids`. "
+                f"Got: {[mf.metadata.function_name for mf in modal_functions]} != {metadata.modal_function_ids}"
+            )
         self.metadata = metadata
         self.entrypoints = entrypoints
+        self.modal_functions = modal_functions
         return
 
     def __getattr__(self, name):
@@ -62,6 +81,10 @@ class Garden:
             elif name == short_name:
                 message_extra = f" Did you mean {alias}?"
 
+        for modal_function in self.modal_functions:
+            if name == modal_function.metadata.function_name:
+                return name
+
         raise AttributeError(
             f"'{self.__class__.__name__}' object has no attribute '{name}'."
             + message_extra
@@ -76,13 +99,20 @@ class Garden:
                 name = entrypoint.metadata.short_name
             entrypoint_names += [name]
 
-        return list(super().__dir__()) + entrypoint_names
+        modal_function_names = [
+            mf.metadata.function_name for mf in self.modal_functions
+        ]
+
+        return list(super().__dir__()) + entrypoint_names + modal_function_names
 
     def _repr_html_(self) -> str:
         data = self.metadata.model_dump(
             exclude={"owner_identity_id", "id", "language", "publisher"}
         )
         data["entrypoints"] = [ep.metadata.model_dump() for ep in self.entrypoints]
+        data["modal_functions"] = [
+            mf.metadata.model_dump() for mf in self.modal_functions
+        ]
 
         style = "<style>th {text-align: left;}</style>"
         title = f"<h2>{data['title']}</h2>"
@@ -98,6 +128,17 @@ class Garden:
             headers="keys",
             tablefmt="html",
         )
+        modal_functions = "<h3>Modal Functions</h3>" + tabulate(
+            [
+                {
+                    key.title(): str(entrypoint[key])
+                    for key in ("short_name", "title", "authors", "doi")
+                }
+                for entrypoint in data["modal_functions"]
+            ],
+            headers="keys",
+            tablefmt="html",
+        )
         optional = "<h3>Additional data</h3>" + tabulate(
             [
                 (field, str(val))
@@ -108,7 +149,7 @@ class Garden:
             ],
             tablefmt="html",
         )
-        return style + title + details + entrypoints + optional
+        return style + title + details + entrypoints + modal_functions + optional
 
     @classmethod
     def _from_nested_metadata(cls, data: dict):
@@ -118,5 +159,11 @@ class Garden:
         for entrypoint_data in data["entrypoints"]:
             entrypoints += [Entrypoint(RegisteredEntrypointMetadata(**entrypoint_data))]
             metadata.entrypoint_ids += [entrypoint_data["doi"]]
+
+        modal_functions = []
+        for modal_fn_data in data["modal_functions"]:
+            modal_functions += [ModalFunction(ModalFunctionMetadata(**modal_fn_data))]
+            # TODO: use DOIs once modal functions have them
+            metadata.modal_function_ids += [modal_fn_data["function_name"]]
 
         return cls(metadata, entrypoints)

--- a/garden_ai/modal/functions.py
+++ b/garden_ai/modal/functions.py
@@ -62,6 +62,9 @@ class ModalFunction:
                 modal_result_struct, response.data_format, modal_client.stub
             )
 
+    def __eq__(self, other):
+        return isinstance(other, type(self)) and self.metadata == other.metadata
+
 
 def _modal_process_result_sync(
     modal_result_struct: api_pb2.GenericResult,

--- a/garden_ai/schemas/__init__.py
+++ b/garden_ai/schemas/__init__.py
@@ -1,0 +1,5 @@
+from .modal import (  # noqa
+    ModalFunctionMetadata,
+    ModalInvocationRequest,
+    ModalInvocationResponse,
+)

--- a/garden_ai/schemas/garden.py
+++ b/garden_ai/schemas/garden.py
@@ -55,6 +55,10 @@ class GardenMetadata(BaseModel):
     entrypoint_aliases: dict[str, str] = Field(default_factory=dict)
     entrypoint_ids: UniqueList[str] = Field(default_factory=list)
 
+    # TODO: for now a modal function ID is just the function's name, but once modal
+    # functions have DOIs this should be updated for consistency with entrypoints.
+    modal_function_ids: UniqueList[str] = Field(default_factory=list)
+
     owner_identity_id: UUID | None = None
     id: int | None = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,6 +220,20 @@ def garden_nested_metadata_json(garden_nested_metadata_raw) -> dict:
 
 
 @pytest.fixture(scope="session")
+def modal_function_metadata_raw() -> dict:
+    """Return a dict with a valid ModalFunctionMetadata schema."""
+    f = pathlib.Path(__file__).parent / "fixtures" / "modal_function_metadata.json"
+    with open(f, "r") as f_in:
+        return json.load(f_in)
+
+
+@pytest.fixture
+def modal_function_metadata_json(modal_function_metadata_raw) -> dict:
+    """Return a dict with a valid ModalFunctionMetadata schema."""
+    return deepcopy(modal_function_metadata_raw)
+
+
+@pytest.fixture(scope="session")
 def entrypoint_metadata_raw() -> dict:
     """Return a dict with a valid EntrypointMetadata schema."""
     f = pathlib.Path(__file__).parent / "fixtures" / "entrypoint_metadata.json"

--- a/tests/fixtures/garden_nested_metadata_response.json
+++ b/tests/fixtures/garden_nested_metadata_response.json
@@ -1,14 +1,12 @@
-  {
+{
     "title": "Semiconductor property prediction models",
-    "authors": [
-      "Will Engler"
-    ],
+    "authors": ["Will Engler"],
     "contributors": [
-      "Ryan Jacobs",
-      "Dane Morgan",
-      "Arun Mannodi-Kanakkithodi",
-      "Maria Chan",
-      "Maciej Polak"
+        "Ryan Jacobs",
+        "Dane Morgan",
+        "Arun Mannodi-Kanakkithodi",
+        "Maria Chan",
+        "Maciej Polak"
     ],
     "doi": "10.26311/bg7s-v305",
     "doi_is_draft": true,
@@ -23,43 +21,46 @@
     "owner_identity_id": "76024960-c68b-4fec-8cb8-b65b096f18da",
     "id": 1,
     "entrypoints": [
-      {
-        "doi": "10.26311/3hz8-as26",
-        "doi_is_draft": true,
-        "title": "Semiconductor defect impurity levels",
-        "description": "Input: (Type: ndarray Shape: ['None', '15']) List of 15 elemental and one-hot encoded features to evaluate model. The list includes: M_3site, M_i_3site, M_i_neut_site, M_i_5site, M_5site, charge_from, charge_to, epsilon, CovalentRadius_max_value, ElectronAffinity_composition_average, NUnfilled_difference, phi_arithmetic_average, Site1_AtomicRadii_arithmetic_average, Site1_BCCvolume_padiff_differenc, Site1_HHIr_composition_average. Output: (Type: ndarray, Shape: 'None') Predictions of semiconductor defect level energies (in eV)",
-        "year": "2020",
-        "func_uuid": "b04ac190-f692-4138-94ca-e6717a77f1e1",
-        "container_uuid": "580c7757-9449-4f46-ac3e-03fb3a86b82f",
-        "base_image_uri": "n/a - dlhub",
-        "full_image_uri": "n/a - dlhub",
-        "notebook_url": "https://www.dlhub.org/",
-        "is_archived": false,
-        "short_name": "predict_defect_level_energies",
-        "function_text": "N/A",
-        "authors": [
-          "Maciej Polak",
-          "Ryan Jacobs",
-          "Arun Mannodi-Kanakkithodi",
-          "Maria Chan",
-          "Dane Morgan"
-        ],
-        "tags": [
-          "Materials Science"
-        ],
-        "test_functions": [
-          "def test_model():\n    import numpy as np\n    # The input shape is n rows of 15 attributes - replace with real data\n    input = np.zeros((1, 15))\n    return predict_defect_level_energies(input)\n"
-        ],
-        "requirements": [],
-        "models": [],
-        "repositories": [],
-        "papers": [],
-        "datasets": [],
-        "owner_identity_id": "76024960-c68b-4fec-8cb8-b65b096f18da",
-        "id": 1
-      }
+        {
+            "doi": "10.26311/3hz8-as26",
+            "doi_is_draft": true,
+            "title": "Semiconductor defect impurity levels",
+            "description": "Input: (Type: ndarray Shape: ['None', '15']) List of 15 elemental and one-hot encoded features to evaluate model. The list includes: M_3site, M_i_3site, M_i_neut_site, M_i_5site, M_5site, charge_from, charge_to, epsilon, CovalentRadius_max_value, ElectronAffinity_composition_average, NUnfilled_difference, phi_arithmetic_average, Site1_AtomicRadii_arithmetic_average, Site1_BCCvolume_padiff_differenc, Site1_HHIr_composition_average. Output: (Type: ndarray, Shape: 'None') Predictions of semiconductor defect level energies (in eV)",
+            "year": "2020",
+            "func_uuid": "b04ac190-f692-4138-94ca-e6717a77f1e1",
+            "container_uuid": "580c7757-9449-4f46-ac3e-03fb3a86b82f",
+            "base_image_uri": "n/a - dlhub",
+            "full_image_uri": "n/a - dlhub",
+            "notebook_url": "https://www.dlhub.org/",
+            "is_archived": false,
+            "short_name": "predict_defect_level_energies",
+            "function_text": "N/A",
+            "authors": [
+                "Maciej Polak",
+                "Ryan Jacobs",
+                "Arun Mannodi-Kanakkithodi",
+                "Maria Chan",
+                "Dane Morgan"
+            ],
+            "tags": ["Materials Science"],
+            "test_functions": [
+                "def test_model():\n    import numpy as np\n    # The input shape is n rows of 15 attributes - replace with real data\n    input = np.zeros((1, 15))\n    return predict_defect_level_energies(input)\n"
+            ],
+            "requirements": [],
+            "models": [],
+            "repositories": [],
+            "papers": [],
+            "datasets": [],
+            "owner_identity_id": "76024960-c68b-4fec-8cb8-b65b096f18da",
+            "id": 1
+        }
     ],
-    "entrypoint_ids": [
-      "10.26311/3hz8-as26"
-    ]
-  }
+    "entrypoint_ids": ["10.26311/3hz8-as26"],
+    "modal_functions": [
+        {
+            "app_name": "00000000-0000-0000-0000-000000000000-test-modal-app",
+            "function_name": "test_function_name"
+        }
+    ],
+    "modal_function_ids": ["test_function_name"]
+}

--- a/tests/fixtures/modal_function_metadata.json
+++ b/tests/fixtures/modal_function_metadata.json
@@ -1,0 +1,4 @@
+{
+    "app_name": "00000000-0000-0000-0000-000000000000-test-modal-app",
+    "function_name": "test_function_name"
+}

--- a/tests/test_gardens.py
+++ b/tests/test_gardens.py
@@ -3,32 +3,49 @@ import pytest
 from garden_ai import Garden
 from garden_ai.gardens import GardenMetadata
 from garden_ai.entrypoints import Entrypoint, RegisteredEntrypointMetadata
+from garden_ai.modal.functions import ModalFunctionMetadata, ModalFunction
+from copy import deepcopy
 
 
 def test_garden_init_raises_if_metadata_entrypoints_dont_match(
     garden_nested_metadata_json,
 ):
+    data = deepcopy(garden_nested_metadata_json)
     entrypoints = []
-    garden_meta = GardenMetadata(**garden_nested_metadata_json)
+    modal_functions = []
+    del data["modal_function_ids"]
+    garden_meta = GardenMetadata(**data)
 
     with pytest.raises(ValueError):
-        # Giving an empty list of entrypoing should cause an error
+        # Giving an empty list of entrypoint should cause an error
         # garden_meta has an entrypoint_id so there is a mismatch
-        garden = Garden(garden_meta, entrypoints)  # noqa: F841
+        garden = Garden(garden_meta, entrypoints, modal_functions)  # noqa: F841
+
+    # ditto for modal functions
+    data = deepcopy(garden_nested_metadata_json)
+    del data["entrypoint_ids"]
+    garden_meta = GardenMetadata(**data)
+    with pytest.raises(ValueError):
+        garden = Garden(garden_meta, entrypoints, modal_functions)  # noqa: F841
 
 
 def test_garden_init(
     garden_nested_metadata_json,
     entrypoint_metadata_json,
+    modal_function_metadata_json,
+    garden_client,
 ):
     garden_meta = GardenMetadata(**garden_nested_metadata_json)
     entrypoint_meta = RegisteredEntrypointMetadata(**entrypoint_metadata_json)
     entrypoint = Entrypoint(entrypoint_meta)
+    modal_function_meta = ModalFunctionMetadata(**modal_function_metadata_json)
+    modal_function = ModalFunction(modal_function_meta, garden_client)
 
-    garden = Garden(garden_meta, [entrypoint])
+    garden = Garden(garden_meta, [entrypoint], [modal_function])
     assert isinstance(garden, Garden)
     assert garden.metadata == garden_meta
     assert garden.entrypoints == [entrypoint]
+    assert garden.modal_functions == [modal_function]
 
 
 def test_can_call_entrypoints_like_methods(
@@ -36,7 +53,9 @@ def test_can_call_entrypoints_like_methods(
     entrypoint_metadata_json,
     mocker,
 ):
-    garden_meta = GardenMetadata(**garden_nested_metadata_json)
+    data = deepcopy(garden_nested_metadata_json)
+    del data["modal_function_ids"]
+    garden_meta = GardenMetadata(**data)
     entrypoint_meta = RegisteredEntrypointMetadata(**entrypoint_metadata_json)
     entrypoint = Entrypoint(entrypoint_meta)
 
@@ -52,11 +71,37 @@ def test_can_call_entrypoints_like_methods(
         garden.some_entrypoint_that_does_not_exist()
 
 
+def test_can_call_modal_functions_like_methods(
+    garden_nested_metadata_json,
+    modal_function_metadata_json,
+    garden_client,
+    mocker,
+):
+    data = deepcopy(garden_nested_metadata_json)
+    del data["entrypoint_ids"]
+    garden_meta = GardenMetadata(**data)
+    modal_function_meta = ModalFunctionMetadata(**modal_function_metadata_json)
+    modal_function = ModalFunction(modal_function_meta, garden_client)
+
+    mock_call = mocker.patch.object(ModalFunction, "__call__")
+
+    garden = Garden(garden_meta, [], [modal_function])
+    # Call the entrypoint like a method
+    garden.test_function_name()
+    mock_call.assert_called()
+
+    with pytest.raises(AttributeError):
+        # but calling some other attribute should still fail
+        garden.does_not_exist()
+
+
 def test_repr_html_contains_garden_doi_and_entrypoint_dois(
     garden_nested_metadata_json,
     entrypoint_metadata_json,
 ):
-    garden_meta = GardenMetadata(**garden_nested_metadata_json)
+    data = deepcopy(garden_nested_metadata_json)
+    del data["modal_function_ids"]
+    garden_meta = GardenMetadata(**data)
     entrypoint_meta = RegisteredEntrypointMetadata(**entrypoint_metadata_json)
     entrypoint = Entrypoint(entrypoint_meta)
 
@@ -72,7 +117,9 @@ def test_entrypoint_names_in_dir(
     garden_nested_metadata_json,
     entrypoint_metadata_json,
 ):
-    garden_meta = GardenMetadata(**garden_nested_metadata_json)
+    data = deepcopy(garden_nested_metadata_json)
+    del data["modal_function_ids"]
+    garden_meta = GardenMetadata(**data)
     entrypoint_meta = RegisteredEntrypointMetadata(**entrypoint_metadata_json)
     entrypoint = Entrypoint(entrypoint_meta)
 


### PR DESCRIPTION
closes #537 

## Overview

Follow up to #536, this gives `Garden` objects a `modal_functions` attribute as well as the ability to call those functions by name, so the interface is the same as calling normal entrypoints. 

## Discussion

The implementation is almost identical to the way that Garden objects look up and call their entrypoints, but note that there are a few TODOs sprinkled here and there for future PRs. 

Specific point of divergence: gardens refer to entrypoints by DOI, but we don't have DOIs for modal functions (and probably won't for a while). I decided to go with the `function_name` in lieu of a doi for now, but depending on when we get the backend side of this feature (https://github.com/Garden-AI/garden-backend/pull/165) merged it's probably easier to just use the id from the database or something. 

Also, bad news: there is a circular import that I'm not sure we can easily fix without compromising the callable interface (`client` -> `backend_client` -> `gardens` -> `modal.functions` -> `client`). 

Good news is that ol' reliable (lazy importing `GardenClient` in `ModalFunction.__init__`) works fine as a short term fix, but we should keep in mind that every time we use this technique to dodge a circular dependency, we're actually dealing 2d6 psychic damage to our future selves. Life is all about tradeoffs. 

## Testing

I have an [updated version of last week's demo](https://gist.github.com/OwenPriceSkelly/b42dcfc308e87fc30c16273e279b7457) working (🥳) 

Also added a couple new tests / some fixture data, but mostly just modified existing tests to cover the new attributes `Garden`s have now. 

## Documentation

No docs! 

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--539.org.readthedocs.build/en/539/

<!-- readthedocs-preview garden-ai end -->