### PR TITLE
Remove search command and references to the search index

### DIFF
--- a/docs/garden-ai.md
+++ b/docs/garden-ai.md
@@ -229,7 +229,6 @@ $ garden-ai garden [OPTIONS] COMMAND [ARGS]...
 * `list`: Lists all local Gardens.
 * `publish`: Push data about a Garden stored to Globus...
 * `register-doi`: Moves a Garden's DOI out of draft state.
-* `search`: Queries the Garden search index and prints...
 * `show`: Shows all info for some Gardens
 
 ### `garden-ai garden add-entrypoint`
@@ -353,30 +352,6 @@ $ garden-ai garden register-doi [OPTIONS] DOI
 
 **Options**:
 
-* `--help`: Show this message and exit.
-
-### `garden-ai garden search`
-
-Queries the Garden search index and prints matching results. All query components are ANDed together.
-So if you say `garden-ai garden search --description "foo" --title "bar"` you will get results
-for gardens that have "foo" in their description and "bar" in their title.
-
-**Usage**:
-
-```console
-$ garden-ai garden search [OPTIONS]
-```
-
-**Options**:
-
-* `-t, --title TEXT`: Title of a Garden
-* `-a, --author TEXT`: an author of the Garden
-* `-y, --year TEXT`: year the Garden was published
-* `-c, --contributor TEXT`: a contributor to the Garden
-* `-d, --description TEXT`: text in the description of the Garden you are searching for
-* `--tag TEXT`: A tag of the Garden
-* `--verbose / --no-verbose`: If true, print the query being passed to Globus Search.  [default: no-verbose]
-* `--raw-query TEXT`: Form your own Globus Search query directly. It will be passed to Search in advanced mode.Overrides all the other query options.See https://docs.globus.org/api/search/reference/get_query for more details.
 * `--help`: Show this message and exit.
 
 ### `garden-ai garden show`

--- a/garden_ai/app/garden.py
+++ b/garden_ai/app/garden.py
@@ -4,13 +4,11 @@ from typing import List, Optional
 
 import rich
 import typer
-from globus_sdk import SearchAPIError
 from rich.prompt import Prompt
 
 from garden_ai.app.completion import complete_entrypoint, complete_garden
 from garden_ai.app.console import console, get_owned_gardens_rich_table
 from garden_ai.client import GardenClient
-from garden_ai.constants import GardenConstants
 from garden_ai.gardens import Garden
 from garden_ai.schemas.garden import GardenMetadata
 from garden_ai.utils.interactive_cli import gui_edit_garden_entity
@@ -149,77 +147,6 @@ def create(
         f"Garden '{garden.metadata.title}' created with DOI: {garden.metadata.doi}"
     )
     return
-
-
-@garden_app.command(no_args_is_help=True)
-def search(
-    title: Optional[str] = typer.Option(
-        None, "-t", "--title", help="Title of a Garden"
-    ),
-    authors: Optional[List[str]] = typer.Option(
-        None, "-a", "--author", help="an author of the Garden"
-    ),
-    year: Optional[str] = typer.Option(
-        None, "-y", "--year", help="year the Garden was published"
-    ),
-    contributors: List[str] = typer.Option(
-        None,
-        "-c",
-        "--contributor",
-        help="a contributor to the Garden",
-    ),
-    description: Optional[str] = typer.Option(
-        None,
-        "-d",
-        "--description",
-        help="text in the description of the Garden you are searching for",
-    ),
-    tags: List[str] = typer.Option(
-        None,
-        "--tag",
-        help="A tag of the Garden",
-    ),
-    verbose: bool = typer.Option(
-        False, help="If true, print the query being passed to Globus Search."
-    ),
-    raw_query: Optional[str] = typer.Option(
-        None,
-        help=(
-            "Form your own Globus Search query directly. It will be passed to Search in advanced mode."
-            "Overrides all the other query options."
-            "See https://docs.globus.org/api/search/reference/get_query for more details."
-        ),
-    ),
-):
-    """Queries the Garden search index and prints matching results. All query components are ANDed together.
-    So if you say `garden-ai garden search --description "foo" --title "bar"` you will get results
-    for gardens that have "foo" in their description and "bar" in their title.
-    """
-    client = GardenClient()
-    if raw_query:
-        query = raw_query
-    else:
-        query = create_query(
-            title=title,
-            authors=authors,
-            year=year,
-            contributors=contributors,
-            description=description,
-            tags=tags,
-        )
-    if verbose:
-        logger.info(query)
-
-    try:
-        results = client.search(query)
-    except SearchAPIError as e:
-        logger.fatal(
-            f"Could not query search index {GardenConstants.GARDEN_INDEX_UUID}"
-        )
-        logger.fatal(e.error_data)
-        raise typer.Exit(code=1) from e
-
-    rich.print_json(results)
 
 
 @garden_app.command(no_args_is_help=True)
@@ -364,36 +291,3 @@ def edit(
     edited_garden_meta = gui_edit_garden_entity(garden_meta, string_fields, list_fields)
     client.backend_client.put_garden(edited_garden_meta)
     console.print(f"Updated garden {doi}.")
-
-
-def create_query(
-    title: Optional[str] = None,
-    authors: Optional[List[str]] = None,
-    year: Optional[str] = None,
-    contributors: Optional[List[str]] = None,
-    description: Optional[str] = None,
-    tags: Optional[List[str]] = None,
-) -> str:
-    query_parts = []
-    if title:
-        query_parts.append(f'(title: "{title}")')
-
-    if authors:
-        for author in authors:
-            query_parts.append(f'(authors: "{author}")')
-
-    if year:
-        query_parts.append(f'(year: "{year}")')
-
-    if contributors:
-        for contributor in contributors:
-            query_parts.append(f'(contributors: "{contributor}")')
-
-    if description:
-        query_parts.append(f'(description: "{description}")')
-
-    if tags:
-        for tag in tags:
-            query_parts.append(f'(tags: "{tag}")')
-
-    return " AND ".join(query_parts)

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -36,7 +36,6 @@ from garden_ai.constants import GardenConstants
 from garden_ai.entrypoints import Entrypoint
 from garden_ai.garden_file_adapter import GardenFileAdapter
 from garden_ai.gardens import Garden
-from garden_ai.globus_search import garden_search
 from garden_ai.schemas.entrypoint import RegisteredEntrypointMetadata
 from garden_ai.schemas.garden import GardenMetadata
 from garden_ai.utils._meta import make_function_to_register
@@ -67,7 +66,6 @@ class GardenClient:
     def __init__(
         self,
         auth_client: Optional[Union[AuthLoginClient, ConfidentialAppAuthClient]] = None,
-        search_client: Optional[SearchClient] = None,
     ):
         key_store_path = Path(GardenConstants.GARDEN_DIR)
         key_store_path.mkdir(exist_ok=True)
@@ -98,16 +96,8 @@ class GardenClient:
             self.groups_authorizer = self._create_authorizer(
                 GroupsClient.scopes.resource_server
             )
-            self.search_authorizer = self._create_authorizer(
-                SearchClient.scopes.resource_server
-            )
             self.compute_authorizer = self._create_authorizer(
                 ComputeScopes.resource_server
-            )
-            self.search_client = (
-                SearchClient(authorizer=self.search_authorizer)
-                if not search_client
-                else search_client
             )
             self.garden_authorizer = self._create_authorizer(
                 GardenClient.scopes.resource_server
@@ -121,13 +111,9 @@ class GardenClient:
             self.groups_authorizer = ClientCredentialsAuthorizer(
                 self.auth_client, GroupsClient.scopes.view_my_groups_and_memberships
             )
-            self.search_authorizer = ClientCredentialsAuthorizer(
-                self.auth_client, SearchClient.scopes.all
-            )
             self.compute_authorizer = ClientCredentialsAuthorizer(
                 self.auth_client, Client.FUNCX_SCOPE
             )
-            self.search_client = SearchClient(authorizer=self.search_authorizer)
             self.garden_authorizer = ClientCredentialsAuthorizer(
                 self.auth_client,
                 GardenClient.scopes.test_scope,
@@ -354,12 +340,6 @@ class GardenClient:
             raise Exception(
                 f"Request to Garden backend to publish notebook failed with error: {str(e)}"
             )
-
-    def search(self, query: str) -> str:
-        """
-        Given a Globus Search advanced query, returns JSON Globus Search result string with gardens as entries.
-        """
-        return garden_search.search_gardens(query, self.search_client)
 
     def get_garden(self, doi: str) -> Garden:
         """

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -24,7 +24,6 @@ from globus_sdk import (
     GroupsClient,
     NativeAppAuthClient,
     RefreshTokenAuthorizer,
-    SearchClient,
 )
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.scopes import ScopeBuilder
@@ -148,7 +147,6 @@ class GardenClient:
                 AuthLoginClient.scopes.email,
                 AuthLoginClient.scopes.manage_projects,
                 GroupsClient.scopes.all,
-                SearchClient.scopes.all,
                 GardenClient.scopes.test_scope,
                 GardenClient.scopes.action_all,
                 ComputeScopes.all,

--- a/garden_ai/constants.py
+++ b/garden_ai/constants.py
@@ -10,9 +10,6 @@ _PROD_ENDPOINT = "https://api.thegardens.ai"
 _DEV_ENDPOINT = "https://api-dev.thegardens.ai"
 _LOCAL_ENDPOINT = "http://localhost:5500"
 
-_DEV_SEARCH_INDEX = "58e4df29-4492-4e7d-9317-b27eba62a911"
-_PROD_SEARCH_INDEX = "813d4556-cbd4-4ba9-97f2-a7155f70682f"
-
 _PROD_ECR_REPO = "public.ecr.aws/x2v7f8j4/garden-containers-prod"
 _DEV_ECR_REPO = "public.ecr.aws/x2v7f8j4/garden-containers-dev"
 
@@ -26,11 +23,6 @@ class GardenConstants:
         _LOCAL_ENDPOINT
         if os.environ.get("GARDEN_ENV") == "local"
         else _DEV_ENDPOINT if os.environ.get("GARDEN_ENV") == "dev" else _PROD_ENDPOINT
-    )
-    GARDEN_INDEX_UUID = (
-        _DEV_SEARCH_INDEX
-        if os.environ.get("GARDEN_ENV") in ("dev", "local")
-        else _PROD_SEARCH_INDEX
     )
     GARDEN_ECR_REPO = (
         _DEV_ECR_REPO

--- a/garden_ai/globus_search/garden_search.py
+++ b/garden_ai/globus_search/garden_search.py
@@ -1,9 +1,0 @@
-from globus_sdk import SearchClient
-
-from garden_ai.constants import GardenConstants
-
-
-def search_gardens(query: str, search_client: SearchClient) -> str:
-    index_uuid = GardenConstants.GARDEN_INDEX_UUID
-    res = search_client.search(index_uuid, query, advanced=True)
-    return res.text

--- a/tests/app/test_garden.py
+++ b/tests/app/test_garden.py
@@ -189,58 +189,6 @@ def test_garden_create_prompts_for_missing_description(
 
 
 @pytest.mark.cli
-def test_search_easy_query(cli_runner, app, mocker):
-    mock_client = mocker.MagicMock(GardenClient)
-    mocker.patch("garden_ai.app.garden.GardenClient").return_value = mock_client
-    mock_rich = mocker.MagicMock(rich)
-    mocker.patch("garden_ai.app.garden.rich", new=mock_rich)
-    command = [
-        "garden",
-        "search",
-        "-d",
-        "foo",
-        "-t",
-        "bar",
-    ]
-    result = cli_runner.invoke(app, command)
-    assert result.exit_code == 0
-
-    mock_client.search.assert_called_once()
-    mock_rich.print_json.assert_called_once()
-
-    args = mock_client.search.call_args.args
-    query = args[0]
-    assert '(title: "bar")' in query
-    assert '(description: "foo")' in query
-    assert " AND " in query
-
-
-@pytest.mark.cli
-def test_search_raw_query(cli_runner, app, mocker):
-    mock_client = mocker.MagicMock(GardenClient)
-    mocker.patch("garden_ai.app.garden.GardenClient").return_value = mock_client
-    mock_rich = mocker.MagicMock(rich)
-    mocker.patch("garden_ai.app.garden.rich", new=mock_rich)
-    command = [
-        "garden",
-        "search",
-        "-d",
-        "foo",
-        "--raw-query",
-        "lalalala",
-    ]
-    result = cli_runner.invoke(app, command)
-    assert result.exit_code == 0
-
-    mock_client.search.assert_called_once()
-    mock_rich.print_json.assert_called_once()
-
-    args = mock_client.search.call_args.args
-    query = args[0]
-    assert query == "lalalala"
-
-
-@pytest.mark.cli
 def test_add_entrypoint_valid_args(
     cli_runner,
     app,

--- a/tests/app/test_garden.py
+++ b/tests/app/test_garden.py
@@ -6,7 +6,6 @@ import rich
 
 from garden_ai.client import GardenClient
 from garden_ai.gardens import Garden
-from garden_ai.app.garden import create_query
 
 
 @pytest.mark.cli
@@ -397,39 +396,3 @@ def test_edit_returns_failure_status_if_no_garden(
     )
     result = cli_runner.invoke(app, cli_args)
     assert result.exit_code == 1
-
-
-def test_create_query_returns_empty_string_if_no_args():
-    q = create_query()
-    assert q == ""
-
-
-def test_create_query_ANDS_multiple_args(faker):
-    title = faker.job()
-    authors = [faker.name() for _ in range(3)]
-    year = "2024"
-    contributors = [faker.name() for _ in range(3)]
-    description = faker.text()
-    tags = [faker.word() for _ in range(5)]
-
-    q = create_query(
-        title=title,
-        authors=authors,
-        year=year,
-        contributors=contributors,
-        description=description,
-        tags=tags,
-    )
-
-    assert f'(title: "{title}")' in q
-    assert f'AND (year: "{year}")' in q
-    assert f'AND (description: "{description}")' in q
-
-    for author in authors:
-        assert f'AND (authors: "{author}")' in q
-
-    for contributor in contributors:
-        assert f'AND (contributors: "{contributor}")' in q
-
-    for tag in tags:
-        assert f'AND (tags: "{tag}")' in q

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pathlib  # noqa
 from unittest.mock import patch
 
 from globus_compute_sdk.sdk.login_manager.manager import LoginManager  # type: ignore
-from globus_sdk import AuthLoginClient, OAuthTokenResponse, SearchClient
+from globus_sdk import AuthLoginClient, OAuthTokenResponse
 import nbformat
 import pytest
 from typer.testing import CliRunner
@@ -159,13 +159,11 @@ def garden_client(
     # mocker.patch("garden_ai.client.input").return_value = "my token"
     mocker.patch("garden_ai.client.Prompt.ask").return_value = "my token"
     mocker.patch("garden_ai.client.typer.launch")
-    mock_search_client = mocker.MagicMock(SearchClient)
 
     mock_token_response = mocker.MagicMock(OAuthTokenResponse)
     mock_token_response.data = {"id_token": identity_jwt}
     mock_token_response.by_resource_server = {
         "groups.api.globus.org": token,
-        "search.api.globus.org": token,
         "0948a6b0-a622-4078-b0a4-bfd6d77d65cf": token,
         "funcx_service": token,
         "auth.globus.org": token,
@@ -186,7 +184,7 @@ def garden_client(
     )
 
     # Call the Garden constructor
-    gc = GardenClient(auth_client=mock_auth_client, search_client=mock_search_client)
+    gc = GardenClient(auth_client=mock_auth_client)
     return gc
 
 

--- a/tests/ete/conftest.py
+++ b/tests/ete/conftest.py
@@ -86,7 +86,6 @@ def authed(garden_client_authed):
             globus_sdk.AuthLoginClient.scopes.openid,
             globus_sdk.AuthLoginClient.scopes.email,
             globus_sdk.GroupsClient.scopes.view_my_groups_and_memberships,
-            globus_sdk.SearchClient.scopes.all,
             globus_compute_sdk.Client.FUNCX_SCOPE,
             GardenClient.scopes.action_all,
         ],


### PR DESCRIPTION
Closes #538

## Overview

This PR removes the `garden-ai garden search` command and all references to the search index in the CLI. (With the exception of the search index migration script)

## Discussion

At first I was going to convert to the new search endpoint but ... I don't think we really need this feature in the CLI. It was one of the very first things we added to the CLI and it was largely showing that we had it hooked up to the search index. It just prints JSON. I think users can and should just use the website.

## Testing

I ran `garden-ai garden` and confirmed that the `search` subcommand was gone.

## Documentation

I removed the command from the docs


<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--541.org.readthedocs.build/en/541/

<!-- readthedocs-preview garden-ai end -->