### PR TITLE
update schemas to use function IDs

### DIFF
--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -58,9 +58,8 @@ class Garden:
                 "Expected `entrypoints` DOIs to match `metadata.entrypoint_ids`. "
                 f"Got: {[ep.metadata.doi for ep in entrypoints]} != {metadata.entrypoint_ids}"
             )
-        # TODO: update to use DOIs when modal functions have them
         if set(metadata.modal_function_ids) ^ set(
-            [mf.metadata.function_name for mf in modal_functions]
+            [mf.metadata.id for mf in modal_functions]
         ):
             raise ValueError(
                 "Expected `modal_functions` to match `metadata.modal_function_ids`. "
@@ -175,7 +174,6 @@ class Garden:
                 modal_functions += [
                     ModalFunction(ModalFunctionMetadata(**modal_fn_data), client)
                 ]
-                # TODO: use DOIs once modal functions have them
-                metadata.modal_function_ids += [modal_fn_data["function_name"]]
+                metadata.modal_function_ids += [modal_fn_data["id"]]
 
         return cls(metadata, entrypoints, modal_functions)

--- a/garden_ai/modal/functions.py
+++ b/garden_ai/modal/functions.py
@@ -43,8 +43,7 @@ class ModalFunction:
                 "Garden's modal integration does not yet support input arguments greater than 2MiB."
             )
         request = ModalInvocationRequest(
-            app_name=self.metadata.app_name,
-            function_name=self.metadata.function_name,
+            function_id=self.metadata.id,
             args_kwargs_serialized=args_kwargs_serialized,
         )
         response: ModalInvocationResponse = (

--- a/garden_ai/schemas/garden.py
+++ b/garden_ai/schemas/garden.py
@@ -55,9 +55,8 @@ class GardenMetadata(BaseModel):
     entrypoint_aliases: dict[str, str] = Field(default_factory=dict)
     entrypoint_ids: UniqueList[str] = Field(default_factory=list)
 
-    # TODO: for now a modal function ID is just the function's name, but once modal
-    # functions have DOIs this should be updated for consistency with entrypoints.
-    modal_function_ids: UniqueList[str] = Field(default_factory=list)
+    # these are DB ids (unlike entrypoint_ids which are dois)
+    modal_function_ids: UniqueList[int] = Field(default_factory=list)
 
     owner_identity_id: UUID | None = None
     id: int | None = None

--- a/garden_ai/schemas/modal.py
+++ b/garden_ai/schemas/modal.py
@@ -1,11 +1,37 @@
-from .schema_utils import B64Bytes
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from .entrypoint import (
+    DatasetMetadata,
+    ModelMetadata,
+    PaperMetadata,
+    RepositoryMetadata,
+)
+from .schema_utils import B64Bytes, UniqueList
 
 
 class ModalFunctionMetadata(BaseModel):
-    app_name: str
+    # Identifiers
+    id: int
+    doi: str | None = None
+
+    # DataCite Metadata
+    title: str
+    description: str | None = ""
+    year: str
+
+    # Function Metadata
+    is_archived: bool = False
     function_name: str
-    # TODO other fields we'll want to persist
+    function_text: str
+
+    authors: UniqueList[str] = Field(default_factory=list)
+    tags: UniqueList[str] = Field(default_factory=list)
+    test_functions: list[str] = Field(default_factory=list)
+
+    models: list[ModelMetadata] = Field(default_factory=list)
+    repositories: list[RepositoryMetadata] = Field(default_factory=list)
+    papers: list[PaperMetadata] = Field(default_factory=list)
+    datasets: list[DatasetMetadata] = Field(default_factory=list)
 
 
 class _ModalGenericResult(BaseModel):
@@ -21,8 +47,7 @@ class _ModalGenericResult(BaseModel):
 
 
 class ModalInvocationRequest(BaseModel):
-    app_name: str
-    function_name: str
+    function_id: int
     args_kwargs_serialized: B64Bytes
 
 

--- a/garden_ai/schemas/schema_utils.py
+++ b/garden_ai/schemas/schema_utils.py
@@ -17,10 +17,9 @@ JsonStr: TypeAlias = str
 
 
 # see: https://github.com/pydantic/pydantic-core/pull/820#issuecomment-1670475909
-def _validate_unique_list(v: list[T]) -> list[T]:
-    if len(v) != len(set(v)):
-        raise PydanticCustomError("unique_list", "List must be unique")
-    return v
+def _parse_unique_list(v: list[T]) -> list[T]:
+    assert isinstance(v, list)
+    return list(set(v))
 
 
 def const_item_validator(cls, v: T, info: ValidationInfo) -> T:
@@ -34,7 +33,7 @@ def const_item_validator(cls, v: T, info: ValidationInfo) -> T:
 # Types
 UniqueList = Annotated[
     list[T],
-    AfterValidator(_validate_unique_list),
+    AfterValidator(_parse_unique_list),
     Field(json_schema_extra={"uniqueItems": True}, default_factory=list),
 ]
 Url = Annotated[HttpUrl, PlainSerializer(lambda url: str(url), return_type=type(""))]

--- a/tests/fixtures/garden_nested_metadata_response.json
+++ b/tests/fixtures/garden_nested_metadata_response.json
@@ -58,9 +58,22 @@
     "entrypoint_ids": ["10.26311/3hz8-as26"],
     "modal_functions": [
         {
-            "app_name": "00000000-0000-0000-0000-000000000000-test-modal-app",
-            "function_name": "test_function_name"
+            "id": 42,
+            "doi": null,
+            "title": "Test Function",
+            "description": "",
+            "year": "2024",
+            "is_archived": false,
+            "function_name": "test_function_name",
+            "function_text": "@app.function(image=iris_image)\ndef predict_iris_type(input_array):\n    import joblib\n    from garden_ai.model_connectors import create_connector\n\n    hf_iris_connector = create_connector(\n        \"https://huggingface.co/Garden-AI/sklearn-iris\"\n    )\n    download_path = hf_iris_connector.stage()\n    model = joblib.load(f\"{download_path}/model.joblib\")\n\n    predictions = model.predict(input_array)\n    as_strings = [\n        [\"setosa\", \"versicolor\", \"virginica\"][prediction] for prediction in predictions\n    ]\n\n    return as_strings\n\n\n",
+            "authors": ["owen :)"],
+            "tags": ["you're", "it"],
+            "test_functions": [],
+            "models": [],
+            "repositories": [],
+            "papers": [],
+            "datasets": []
         }
     ],
-    "modal_function_ids": ["test_function_name"]
+    "modal_function_ids": [42]
 }

--- a/tests/fixtures/modal_function_metadata.json
+++ b/tests/fixtures/modal_function_metadata.json
@@ -1,4 +1,17 @@
 {
-    "app_name": "00000000-0000-0000-0000-000000000000-test-modal-app",
-    "function_name": "test_function_name"
+    "id": 42,
+    "doi": null,
+    "title": "Test Function",
+    "description": "",
+    "year": "2024",
+    "is_archived": false,
+    "function_name": "test_function_name",
+    "function_text": "@app.function(image=iris_image)\ndef predict_iris_type(input_array):\n    import joblib\n    from garden_ai.model_connectors import create_connector\n\n    hf_iris_connector = create_connector(\n        \"https://huggingface.co/Garden-AI/sklearn-iris\"\n    )\n    download_path = hf_iris_connector.stage()\n    model = joblib.load(f\"{download_path}/model.joblib\")\n\n    predictions = model.predict(input_array)\n    as_strings = [\n        [\"setosa\", \"versicolor\", \"virginica\"][prediction] for prediction in predictions\n    ]\n\n    return as_strings\n\n\n",
+    "authors": ["owen :)"],
+    "tags": ["you're", "it"],
+    "test_functions": [],
+    "models": [],
+    "repositories": [],
+    "papers": [],
+    "datasets": []
 }

--- a/tests/modal/test_functions.py
+++ b/tests/modal/test_functions.py
@@ -1,10 +1,9 @@
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-
-from garden_ai.client import GardenClient
 from garden_ai.backend_client import BackendClient
-from garden_ai.modal.functions import ModalFunction, MaximumArgumentSizeError
+from garden_ai.client import GardenClient
+from garden_ai.modal.functions import MaximumArgumentSizeError, ModalFunction
 from garden_ai.schemas.modal import (
     ModalFunctionMetadata,
     ModalInvocationRequest,
@@ -13,8 +12,8 @@ from garden_ai.schemas.modal import (
 
 
 @pytest.fixture
-def modal_function_meta():
-    return ModalFunctionMetadata(app_name="test_app", function_name="test_function")
+def modal_function_meta(modal_function_metadata_json):
+    return ModalFunctionMetadata(**modal_function_metadata_json)
 
 
 @pytest.fixture
@@ -65,8 +64,7 @@ def test_modal_function_call(modal_function):
     # Check that the backend client's method was called with the correct request payload
     modal_function.client.backend_client.invoke_modal_function.assert_called_once_with(
         ModalInvocationRequest(
-            app_name="test_app",
-            function_name="test_function",
+            function_id=42,
             args_kwargs_serialized=mock_args_kwargs_serialized,
         )
     )


### PR DESCRIPTION
## Overview
This is a small second pass PR which closes #540 and is basically just limited to schema tweaks on the sdk side. Nothing is functionally new vs #539. 

see also: the [corresponding backend PR](https://github.com/Garden-AI/garden-backend/pull/177) which expects the client to refer to functions by ID instead of function and app name.

~If you have this branch checked out for the sdk and `owen/post-modal-fns-uses-ids` checked out for a local instance of the backend, [this](https://gist.github.com/OwenPriceSkelly/57fa0abbddb6f63aaf4a42da205cd06a) script should reproduce the bug causing modal's containers to crash~

## Discussion

I decided I didn't like our custom UniqueList type throwing errors when it could just ignore repeat values and ensure the list was unique itself. This is more in line with pydantic's general philosophy of "parse don't validate even though we call it validate". 

This change wasn't prompted by anything in particular; just felt like being a good boyscout 

## Testing

I had to tweak a couple of unit tests but mostly just updating the fixture data was enough for everything to pass again. Also tested pretty extensively with my end-to-end script I originally linked. 
## Documentation

No docs 

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--542.org.readthedocs.build/en/542/

<!-- readthedocs-preview garden-ai end -->