### PR TITLE
avoid event loop conflicts calling from jupyter

### DIFF
--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
-from typing import TypeVar, TYPE_CHECKING
 
 import logging
+from typing import TYPE_CHECKING, TypeVar
 
 from tabulate import tabulate
 
+from garden_ai.modal.functions import ModalFunction
 from garden_ai.schemas.entrypoint import RegisteredEntrypointMetadata
 from garden_ai.schemas.garden import GardenMetadata
 from garden_ai.schemas.modal import ModalFunctionMetadata
-from garden_ai.modal.functions import ModalFunction
 
 from .entrypoints import Entrypoint
 
@@ -137,7 +137,7 @@ class Garden:
             [
                 {
                     key.title(): str(entrypoint[key])
-                    for key in ("short_name", "title", "authors", "doi")
+                    for key in ("function_name", "title", "authors", "doi")
                 }
                 for entrypoint in data["modal_functions"]
             ],


### PR DESCRIPTION
fixes #543 

## Overview

This handles the bug Ben surfaced when he tried running his modal function from a notebook. 

Turns out the original strategy of just naively creating a new event loop to run the modal `_process_result` helper would break when there was already an event loop running, as is the case in jupyter/colab notebooks. 

The workaround I landed on is basically the same strategy, except it runs the new event loop in its own thread for better isolation. 

## Discussion

An alternative approach I eventually punted on involved trying to infer the execution context and to see if an event loop already existed to which it could submit the helper task. Punted on this because it was looking like much lower-level asyncio plumbing just for the notebook case. It felt a little silly to start up an entire new thread just to call a single helper function, but the upshot is that this is the same logic whether or not we're running in a notebook or regular execution context. 

## Testing

Manually from a notebook and repl using the garden ben made to try out the new modal publishing flow. No unit tests 

## Documentation

No docs

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--544.org.readthedocs.build/en/544/

<!-- readthedocs-preview garden-ai end -->