### PR TITLE
bugfix empty requirements data

### DIFF
--- a/garden_ai/notebook_metadata.py
+++ b/garden_ai/notebook_metadata.py
@@ -102,7 +102,6 @@ def get_notebook_metadata(notebook_path: Path) -> NotebookMetadata:
             global_notebook_doi=None,
             notebook_image_name=None,
             notebook_image_uri=None,
-            notebook_requirements=None,
         )
 
     try:
@@ -114,7 +113,6 @@ def get_notebook_metadata(notebook_path: Path) -> NotebookMetadata:
             global_notebook_doi=None,
             notebook_image_name=None,
             notebook_image_uri=None,
-            notebook_requirements=None,
         )
 
 

--- a/garden_ai/notebook_metadata.py
+++ b/garden_ai/notebook_metadata.py
@@ -237,11 +237,12 @@ def _build_base_image_widget(nb_meta: NotebookMetadata) -> widgets.Dropdown:
 
 
 def _build_reqs_widget(nb_meta: NotebookMetadata) -> widgets.Textarea:
-    if nb_meta.notebook_requirements.file_format == "pip":  # type: ignore
-        reqs_string = "\n".join([req for req in nb_meta.notebook_requirements.contents])  # type: ignore
-    else:
-        # ignoring conda requirements, since we are planning to remove support for them anyways
-        reqs_string = ""
+    reqs_string = ""
+    if nb_meta.notebook_requirements is not None:
+        if nb_meta.notebook_requirements.file_format == "pip":  # type: ignore
+            reqs_string = "\n".join(
+                [req for req in nb_meta.notebook_requirements.contents]
+            )  # type: ignore
 
     return widgets.Textarea(
         value=reqs_string,

--- a/garden_ai/notebook_metadata.py
+++ b/garden_ai/notebook_metadata.py
@@ -1,22 +1,19 @@
-from pathlib import Path
-from typing import Optional, Union, Callable
-from pydantic import BaseModel, ValidationError
-import typer
 import json
 import os
-import sys
 import subprocess
+import sys
+from pathlib import Path
 from subprocess import SubprocessError
+from typing import Callable, Optional, Union
 
 import ipywidgets as widgets  # type: ignore
-from IPython.display import display
-
 import nbformat
-
+import typer
+from IPython.display import display
 from nbformat.notebooknode import NotebookNode  # type: ignore
+from pydantic import BaseModel, Field, ValidationError
 
 from garden_ai import GardenConstants
-
 
 NOTEBOOK_DISPLAY_METADATA_CELL = (
     '"""\n'
@@ -44,15 +41,15 @@ METADATA_CELL_TAG = "garden_display_metadata_cell"
 
 
 class RequirementsData(BaseModel):
-    file_format: str
-    contents: Union[dict, list]
+    file_format: str = "pip"
+    contents: Union[dict, list] = Field(default_factory=list)
 
 
 class NotebookMetadata(BaseModel):
     global_notebook_doi: Optional[str]
     notebook_image_name: Optional[str]
     notebook_image_uri: Optional[str]
-    notebook_requirements: Optional[RequirementsData]
+    notebook_requirements: RequirementsData = Field(default_factory=RequirementsData)
 
 
 def add_notebook_metadata(
@@ -238,11 +235,8 @@ def _build_base_image_widget(nb_meta: NotebookMetadata) -> widgets.Dropdown:
 
 def _build_reqs_widget(nb_meta: NotebookMetadata) -> widgets.Textarea:
     reqs_string = ""
-    if nb_meta.notebook_requirements is not None:
-        if nb_meta.notebook_requirements.file_format == "pip":  # type: ignore
-            reqs_string = "\n".join(
-                [req for req in nb_meta.notebook_requirements.contents]
-            )  # type: ignore
+    if nb_meta.notebook_requirements.file_format == "pip":
+        reqs_string = "\n".join([req for req in nb_meta.notebook_requirements.contents])
 
     return widgets.Textarea(
         value=reqs_string,
@@ -399,8 +393,9 @@ def update_reqs_observer(
     update_reqs_widget: widgets.Button,
     output: widgets.Output,
 ) -> Callable:
-    from garden_ai.app.console import console
     from rich.status import Status
+
+    from garden_ai.app.console import console
 
     def _update_reqs_observer(button):
         with output:

--- a/garden_ai/scripts/save_session_and_metadata.py
+++ b/garden_ai/scripts/save_session_and_metadata.py
@@ -9,8 +9,8 @@ def assert_compatible_dill_version():
     This is factored out into its own function because `sys.version_info` does
     something spooky that breaks dill if it picks up the reference.
     """
-    from importlib.metadata import version
     import sys
+    from importlib.metadata import version
 
     # this should be exactly the same as globus compute requirements
     python_version = sys.version_info
@@ -52,10 +52,10 @@ def get_requirements_data():
 
     path = get_requirements_file()
     if not path:
-        return None
+        return []
 
     reqs = read_requirements_data(path)
-    return reqs.contents if reqs else None
+    return reqs.contents if reqs else []
 
 
 if __name__ == "__main__":

--- a/tests/test_notebook_metadata.py
+++ b/tests/test_notebook_metadata.py
@@ -5,18 +5,17 @@ from pathlib import Path
 import ipywidgets as widgets  # type: ignore
 import nbformat
 import pytest
-
 from garden_ai.constants import GardenConstants
 from garden_ai.notebook_metadata import (
+    NOTEBOOK_DISPLAY_METADATA_CELL,
+    RequirementsData,
+    _has_metadata_cell_tag,
     add_notebook_metadata,
-    set_notebook_metadata,
+    display_metadata_widget,
     get_notebook_metadata,
     read_requirements_data,
     save_requirements_data,
-    RequirementsData,
-    NOTEBOOK_DISPLAY_METADATA_CELL,
-    _has_metadata_cell_tag,
-    display_metadata_widget,
+    set_notebook_metadata,
 )
 
 
@@ -119,14 +118,16 @@ def test_add_notebook_metadata_writes_metadata_cell_to_notebook(
     assert ntbk.cells[0].source == NOTEBOOK_DISPLAY_METADATA_CELL
 
 
-def test_get_metadata_returns_empty_metadata_if_garden_metadata_not_foune(
+def test_get_metadata_returns_empty_metadata_if_garden_metadata_not_found(
     tmp_notebook_empty,
 ):
     ntbk_meta = get_notebook_metadata(tmp_notebook_empty)
     assert ntbk_meta.global_notebook_doi is None
     assert ntbk_meta.notebook_image_name is None
     assert ntbk_meta.notebook_image_uri is None
-    assert ntbk_meta.notebook_requirements is None
+    assert ntbk_meta.notebook_requirements == RequirementsData(
+        file_format="pip", contents=[]
+    )
 
 
 def test_get_metadata_returns_empty_metadata_if_garden_metadata_is_bad(
@@ -142,7 +143,9 @@ def test_get_metadata_returns_empty_metadata_if_garden_metadata_is_bad(
     assert ntbk_meta.global_notebook_doi is None
     assert ntbk_meta.notebook_image_name is None
     assert ntbk_meta.notebook_image_uri is None
-    assert ntbk_meta.notebook_requirements is None
+    assert ntbk_meta.notebook_requirements == RequirementsData(
+        file_format="pip", contents=[]
+    )
 
 
 def test_get_metadata_returns_metadata_if_already_present(


### PR DESCRIPTION
Fixes #548 and friends (also fixes #520 and fixes #522)

## Overview

This squashes a handful of bugs related to the metadata objects being passed around by various notebook widget helper functions. Specifically, the `NotebookMetadata` schema had every field optional, and wasn't very consistent with `None` defaults. 

To fix this family of bugs I gave the nested `RequirementsData` schema object sane defaults (`"pip"` file format and an empty list for contents) so that we could make it non-optional in the `NotebookMetadata` schema. 

Until now, we'd been representing the no-requirements case with `requirements_data=None`; now we're representing that case with empty `requirements_data=RequirementsData()` objects. This means that we no longer have to worry about occasionally accessing e.g. a nonexistent `file_format` attribute on `None`s.


## Discussion

There was more I wanted to do to clean up the ad-hoc pydantic schemas for the widget but I think this called for as surgical of a bugfix as possible so we can focus on the other stuff on our plates. 

## Testing

Just manually -- I was able to reproduce the bugs in the various issues by starting up notebooks without any requirements and verified that we no longer hit those bugs. 

## Documentation

no docs 

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--549.org.readthedocs.build/en/549/

<!-- readthedocs-preview garden-ai end -->