### PR TITLE
Enable entrypoint lookups by DOI with dict-like syntax

### DIFF
--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -42,6 +42,13 @@ class Garden:
         garden = client.get_garden("my_garden_doi")
         result = garden.my_entrypoint(data, endpoint="endpoint_uuid")
         ```
+
+        Entrypoints can also be accessed like dict values where the DOI of the entrypoint is the key:
+        ```
+        garden = client.get_garden("my_garden_doi")
+        ep_func = garden["my_entrypoint_doi"]
+        result = ep_func(data)
+        ```
     """  # noqa: E501
 
     def __init__(

--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -156,6 +156,12 @@ class Garden:
         )
         return style + title + details + entrypoints + modal_functions + optional
 
+    def __getitem__(self, doi: str):
+        for ep in self.entrypoints:
+            if ep.metadata.doi == doi:
+                return ep
+        raise KeyError(f"Garden does not have an entrypoint with doi: {doi}.")
+
     @classmethod
     def _from_nested_metadata(cls, data: dict, client: GardenClient | None = None):
         """helper: instantiate from search index-style payload with nested entrypoint metadata.

--- a/tests/test_gardens.py
+++ b/tests/test_gardens.py
@@ -95,6 +95,45 @@ def test_can_call_modal_functions_like_methods(
         garden.does_not_exist()
 
 
+def test_can_access_entrypoints_like_dict_by_doi(
+    garden_nested_metadata_json,
+    entrypoint_metadata_json,
+    mocker,
+):
+    data = deepcopy(garden_nested_metadata_json)
+    del data["modal_function_ids"]
+    garden_meta = GardenMetadata(**data)
+    entrypoint_meta = RegisteredEntrypointMetadata(**entrypoint_metadata_json)
+    entrypoint = Entrypoint(entrypoint_meta)
+
+    mock_call = mocker.patch.object(Entrypoint, "__call__")
+
+    garden = Garden(garden_meta, [entrypoint])
+
+    ep = garden[f"{entrypoint.metadata.doi}"]
+    assert ep == entrypoint
+
+    ep()
+    mock_call.assert_called()
+
+
+def test_accessing_entrypoint_like_dict_raises_if_bad_doi(
+    garden_nested_metadata_json,
+    entrypoint_metadata_json,
+    mocker,
+):
+    data = deepcopy(garden_nested_metadata_json)
+    del data["modal_function_ids"]
+    garden_meta = GardenMetadata(**data)
+    entrypoint_meta = RegisteredEntrypointMetadata(**entrypoint_metadata_json)
+    entrypoint = Entrypoint(entrypoint_meta)
+
+    garden = Garden(garden_meta, [entrypoint])
+
+    with pytest.raises(KeyError):
+        garden["some-bad-doi"]
+
+
 def test_repr_html_contains_garden_doi_and_entrypoint_dois(
     garden_nested_metadata_json,
     entrypoint_metadata_json,


### PR DESCRIPTION
Resolves: #532 

## Overview

This PR defines `Garden.__getitem__` so entrypoints can be accessed like:

```
garden = client.get_garden("some-doi")

ep_func = garden["some-ep-doi"]

ep_func()
```

## Testing

New unit tests

## Documentation


<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--550.org.readthedocs.build/en/550/

<!-- readthedocs-preview garden-ai end -->