### PR TITLE
Handle modal invocations asynchronously

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -4,89 +4,91 @@
 # Otherwise, you can use the flag `safety check --policy-file <path-to-this-file>` to specify a custom location and name for the file.
 # To validate and review your policy file, run the validate command: `safety validate policy_file --path <path-to-this-file>`
 security: # configuration for the `safety check` command
-    ignore-cvss-severity-below: 4 # A severity number between 0 and 10. Some helpful reference points: 9=ignore all vulnerabilities except CRITICAL severity. 7=ignore all vulnerabilities except CRITICAL & HIGH severity. 4=ignore all vulnerabilities except CRITICAL, HIGH & MEDIUM severity.
-    ignore-cvss-unknown-severity: False # True or False. We recommend you set this to False.
-    ignore-vulnerabilities: # Here you can list multiple specific vulnerabilities you want to ignore (optionally for a time period)
-        # We recommend making use of the optional `reason` and `expires` keys for each vulnerability that you ignore.
-        59399: # Vulnerability ID
-            reason: the scipy developers identified its CVE classification as unwarranted # optional, for internal note purposes to communicate with your team. This reason will be reported in the Safety reports
-            # this exception can be removed when Python 3.8 is not supported
-            # expires: '2022-10-21' # datetime string - date this ignore will expire, best practice to use this variable
-        65212: # Vulnerability ID
-            reason: this is for a crypto error that is not relevant to us functionally, and only happens on PowerPCs.
+  ignore-cvss-severity-below: 4 # A severity number between 0 and 10. Some helpful reference points: 9=ignore all vulnerabilities except CRITICAL severity. 7=ignore all vulnerabilities except CRITICAL & HIGH severity. 4=ignore all vulnerabilities except CRITICAL, HIGH & MEDIUM severity.
+  ignore-cvss-unknown-severity: False # True or False. We recommend you set this to False.
+  ignore-vulnerabilities: # Here you can list multiple specific vulnerabilities you want to ignore (optionally for a time period)
+    # We recommend making use of the optional `reason` and `expires` keys for each vulnerability that you ignore.
+    59399: # Vulnerability ID
+      reason: the scipy developers identified its CVE classification as unwarranted # optional, for internal note purposes to communicate with your team. This reason will be reported in the Safety reports
+      # this exception can be removed when Python 3.8 is not supported
+      # expires: '2022-10-21' # datetime string - date this ignore will expire, best practice to use this variable
+    65212: # Vulnerability ID
+      reason: this is for a crypto error that is not relevant to us functionally, and only happens on PowerPCs.
 
-        67599:
-            reason: this only affects the --extra-index-url option in pip which we don't currently use. It is also intended behavior and is up to the user to operate --extra-index-url safely.
-        70612:
-            reason: we're only using jinja on the client side to template notebooks
-        71064:
-            reason: the CVE-2024-35195 vulnerability affects the use of "verify=False" in requests, but our project does not use this parameter in any API calls, so this risk can be ignored. If this version fixes our bug, we will find another solution.
+    67599:
+      reason: this only affects the --extra-index-url option in pip which we don't currently use. It is also intended behavior and is up to the user to operate --extra-index-url safely.
+    70612:
+      reason: we're only using jinja on the client side to template notebooks
+    71064:
+      reason: the CVE-2024-35195 vulnerability affects the use of "verify=False" in requests, but our project does not use this parameter in any API calls, so this risk can be ignored. If this version fixes our bug, we will find another solution.
+    73725:
+      reason: We aren't using starlette directly. It is pulled in as a transitive dependency from the Modal SDK
 
-    continue-on-vulnerability-error: False # Suppress non-zero exit codes when vulnerabilities are found. Enable this in pipelines and CI/CD processes if you want to pass builds that have vulnerabilities. We recommend you set this to False.
+  continue-on-vulnerability-error: False # Suppress non-zero exit codes when vulnerabilities are found. Enable this in pipelines and CI/CD processes if you want to pass builds that have vulnerabilities. We recommend you set this to False.
 alert: # configuration for the `safety alert` command
-    security:
-        # Configuration specific to Safety's GitHub Issue alerting
-        github-issue:
-            # Same as for security - these allow controlling if this alert will fire based
-            # on severity information.
-            # default: not set
-            # ignore-cvss-severity-below: 6
-            # ignore-cvss-unknown-severity: False
+  security:
+    # Configuration specific to Safety's GitHub Issue alerting
+    github-issue:
+      # Same as for security - these allow controlling if this alert will fire based
+      # on severity information.
+      # default: not set
+      # ignore-cvss-severity-below: 6
+      # ignore-cvss-unknown-severity: False
 
-            # Add a label to pull requests with the cvss severity, if available
-            # default: true
-            # label-severity: True
+      # Add a label to pull requests with the cvss severity, if available
+      # default: true
+      # label-severity: True
 
-            # Add a label to pull requests, default is 'security'
-            # requires private repo permissions, even on public repos
-            # default: security
-            # labels:
-            #  - security
+      # Add a label to pull requests, default is 'security'
+      # requires private repo permissions, even on public repos
+      # default: security
+      # labels:
+      #  - security
 
-            # Assign users to pull requests, default is not set
-            # requires private repo permissions, even on public repos
-            # default: empty
-            # assignees:
-            #  - example-user
+      # Assign users to pull requests, default is not set
+      # requires private repo permissions, even on public repos
+      # default: empty
+      # assignees:
+      #  - example-user
 
-            # Prefix to give issues when creating them. Note that changing
-            # this might cause duplicate issues to be created.
-            # default: "[PyUp] "
-            # issue-prefix: "[PyUp] "
+      # Prefix to give issues when creating them. Note that changing
+      # this might cause duplicate issues to be created.
+      # default: "[PyUp] "
+      # issue-prefix: "[PyUp] "
 
-        # Configuration specific to Safety's GitHub PR alerting
-        github-pr:
-            # Same as for security - these allow controlling if this alert will fire based
-            # on severity information.
-            # default: not set
-            # ignore-cvss-severity-below: 6
-            # ignore-cvss-unknown-severity: False
+    # Configuration specific to Safety's GitHub PR alerting
+    github-pr:
+      # Same as for security - these allow controlling if this alert will fire based
+      # on severity information.
+      # default: not set
+      # ignore-cvss-severity-below: 6
+      # ignore-cvss-unknown-severity: False
 
-            # Set the default branch (ie, main, master)
-            # default: empty, the default branch on GitHub
-            branch: ""
+      # Set the default branch (ie, main, master)
+      # default: empty, the default branch on GitHub
+      branch: ""
 
-            # Add a label to pull requests with the cvss severity, if available
-            # default: true
-            # label-severity: True
+      # Add a label to pull requests with the cvss severity, if available
+      # default: true
+      # label-severity: True
 
-            # Add a label to pull requests, default is 'security'
-            # requires private repo permissions, even on public repos
-            # default: security
-            # labels:
-            #  - security
+      # Add a label to pull requests, default is 'security'
+      # requires private repo permissions, even on public repos
+      # default: security
+      # labels:
+      #  - security
 
-            # Assign users to pull requests, default is not set
-            # requires private repo permissions, even on public repos
-            # default: empty
-            # assignees:
-            #  - example-user
+      # Assign users to pull requests, default is not set
+      # requires private repo permissions, even on public repos
+      # default: empty
+      # assignees:
+      #  - example-user
 
-            # Configure the branch prefix for PRs created by this alert.
-            # NB: Changing this will likely cause duplicate PRs.
-            # default: pyup/
-            branch-prefix: pyup/
+      # Configure the branch prefix for PRs created by this alert.
+      # NB: Changing this will likely cause duplicate PRs.
+      # default: pyup/
+      branch-prefix: pyup/
 
-            # Set a global prefix for PRs
-            # default: "[PyUp] "
-            pr-prefix: "[PyUp] "
+      # Set a global prefix for PRs
+      # default: "[PyUp] "
+      pr-prefix: "[PyUp] "

--- a/garden_ai/backend_client.py
+++ b/garden_ai/backend_client.py
@@ -227,4 +227,8 @@ class BackendClient:
                     data_format=1, result=output_response["result"]
                 )
             case _:
-                raise ValueError(f"Something went wrong: {output_response['error']}")
+                raise Exception(
+                    f"Error invoking Modal function with id: {invocation_response['id']}:\n\t"
+                    f"Invocation Status: {output_response['status']}\n\t"
+                    f"Error: {output_response['error']}"
+                )

--- a/garden_ai/constants.py
+++ b/garden_ai/constants.py
@@ -36,6 +36,10 @@ class GardenConstants:
     DEFAULT_JUPYTER_PORT = 9188
     MAX_JUPYTER_PORTS_TO_ATTEMPT = 10
 
+    BACKEND_POLL_INTERVAL_SECONDS: float = float(
+        os.environ.get("BACKEND_POLL_INTERVAL_SECONDS", 0.1)
+    )
+
     # The DOIs of entrypoints migrated from DLHub.
     DLHUB_DOIS = set(
         [

--- a/garden_ai/modal/functions.py
+++ b/garden_ai/modal/functions.py
@@ -49,7 +49,7 @@ class ModalFunction:
             args_kwargs_serialized=args_kwargs_serialized,
         )
         response: ModalInvocationResponse = (
-            self.client.backend_client.invoke_modal_function(request)
+            self.client.backend_client.invoke_modal_function_async(request)
         )
         result_data: dict = response.result.model_dump(
             mode="python", exclude_defaults=True

--- a/garden_ai/schemas/modal.py
+++ b/garden_ai/schemas/modal.py
@@ -54,3 +54,8 @@ class ModalInvocationRequest(BaseModel):
 class ModalInvocationResponse(BaseModel):
     result: _ModalGenericResult
     data_format: int
+
+
+class AsyncModalInvocationResponse(BaseModel):
+    id: int
+    status: str

--- a/tests/modal/test_functions.py
+++ b/tests/modal/test_functions.py
@@ -42,7 +42,7 @@ def test_modal_function_call(modal_function):
     )
 
     # Mock the backend client's invoke_modal_function method
-    modal_function.client.backend_client.invoke_modal_function.return_value = (
+    modal_function.client.backend_client.invoke_modal_function_async.return_value = (
         ModalInvocationResponse(
             result=dict(status=0, data=b"mock unprocessed data"), data_format=1
         )
@@ -62,7 +62,7 @@ def test_modal_function_call(modal_function):
     # Check that serialize was called with the correct arguments
     mock_serialize.assert_called_once_with(mock_args_kwargs)
     # Check that the backend client's method was called with the correct request payload
-    modal_function.client.backend_client.invoke_modal_function.assert_called_once_with(
+    modal_function.client.backend_client.invoke_modal_function_async.assert_called_once_with(
         ModalInvocationRequest(
             function_id=42,
             args_kwargs_serialized=mock_args_kwargs_serialized,


### PR DESCRIPTION
Resolves: #552 

## Overview

This PR updates the backend client to hit the new async modal invocation routes. The invocations are still synchronous from the user's perspective, but this allows for long-running invocations without hitting the gateway timeout for a single request to the backend.

 There are no major changes in logic other than a polling loop to check the status of the invocation. There is a new environment variable "BACKEND_POLL_INTERVAL_SECONDS" to configure how often we poll for the invocation status. The default is set for 0.1 seconds, or 100ms.

## Discussion

We may want some sort of back-off logic in the poll interval so really long running jobs don't ping the server so much, but this probably won't be an issue until we have hundreds of invocations in-progress simultaneously. I'll leave that for an issue in the future.

## Testing
Updated existing tests.
Manual testing.

## Documentation
Nothing changes from the users perspective.


<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--553.org.readthedocs.build/en/553/

<!-- readthedocs-preview garden-ai end -->