### PR TITLE
Modal class support

### DIFF
--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -256,11 +256,4 @@ class Garden:
             for class_name, methods in class_methods.items()
         ]
 
-        # if "modal_functions" in data:
-        #     for modal_fn_data in data["modal_functions"]:
-        #         modal_functions += [
-        #             ModalFunction(ModalFunctionMetadata(**modal_fn_data), client)
-        #         ]
-        #         metadata.modal_function_ids += [modal_fn_data["id"]]
-
         return cls(metadata, entrypoints, modal_functions, modal_classes)

--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -188,7 +188,7 @@ class Garden:
                         }
                     )
 
-            modal_classes = "<h3>Modal Classes</h3>" + tabulate(
+            modal_classes = "<h3>Modal Class Methods</h3>" + tabulate(
                 classes_data,
                 headers="keys",
                 tablefmt="html",

--- a/garden_ai/modal/classes.py
+++ b/garden_ai/modal/classes.py
@@ -34,6 +34,12 @@ class ModalClassWrapper:
             return self._methods[method_name]
         raise AttributeError(f"'{self.class_name}' has no method '{method_name}'")
 
+    def __dir__(self) -> list[str]:
+        """Return list of valid attributes for tab completion."""
+        return list(super().__dir__()) + list(  # Get standard attributes
+            self._methods.keys()
+        )  # Add all method names
+
     @classmethod
     def from_metadata(
         cls,

--- a/garden_ai/modal/classes.py
+++ b/garden_ai/modal/classes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, TypeVar, Any
 from garden_ai.modal.functions import ModalFunction
 
@@ -19,14 +21,12 @@ class ModalClassWrapper:
         self,
         class_name: str,
         methods: list[ModalFunction],
-        client: GardenClient | None = None,
     ):
         self.class_name = class_name
         # Create method lookup internally
         self._methods = {
             method.metadata.function_name.split(".")[-1]: method for method in methods
         }
-        self.client = client
 
     def __getattr__(self, method_name: str) -> Any:
         """Allow accessing methods as attributes of the class wrapper."""
@@ -46,7 +46,7 @@ class ModalClassWrapper:
         class_name: str,
         methods_metadata: list[ModalFunctionMetadata],
         client: GardenClient | None = None,
-    ) -> "ModalClassWrapper":
+    ) -> ModalClassWrapper:
         """Create a ModalClassWrapper from metadata"""
         methods = [ModalFunction(metadata, client) for metadata in methods_metadata]
         return cls(class_name, methods, client)

--- a/garden_ai/modal/classes.py
+++ b/garden_ai/modal/classes.py
@@ -1,0 +1,50 @@
+from typing import TYPE_CHECKING, TypeVar, Any
+from garden_ai.modal.functions import ModalFunction
+
+from ..schemas.modal import ModalFunctionMetadata
+
+
+if TYPE_CHECKING:
+    from garden_ai.client import GardenClient
+else:
+    GardenClient = TypeVar("GardenClient")
+
+
+class ModalClassWrapper:
+    """
+    A wrapper for Modal class objects that allows method access and invocation through Garden.
+    """
+
+    def __init__(
+        self,
+        class_name: str,
+        methods: list[ModalFunction],
+        client: GardenClient | None = None,
+    ):
+        self.class_name = class_name
+        # Create method lookup internally
+        self._methods = {
+            method.metadata.function_name.split(".")[-1]: method for method in methods
+        }
+        self.client = client
+
+    def __getattr__(self, method_name: str) -> Any:
+        """Allow accessing methods as attributes of the class wrapper."""
+        if method_name in self._methods:
+            return self._methods[method_name]
+        raise AttributeError(f"'{self.class_name}' has no method '{method_name}'")
+
+    @classmethod
+    def from_metadata(
+        cls,
+        class_name: str,
+        methods_metadata: list[ModalFunctionMetadata],
+        client: GardenClient | None = None,
+    ) -> "ModalClassWrapper":
+        """Create a ModalClassWrapper from metadata"""
+        methods = [ModalFunction(metadata, client) for metadata in methods_metadata]
+        return cls(class_name, methods, client)
+
+    def __repr__(self) -> str:
+        method_list = ", ".join(self._methods.keys())
+        return f"<ModalClass '{self.class_name}' with methods: {method_list}>"

--- a/garden_ai/modal/classes.py
+++ b/garden_ai/modal/classes.py
@@ -49,7 +49,7 @@ class ModalClassWrapper:
     ) -> ModalClassWrapper:
         """Create a ModalClassWrapper from metadata"""
         methods = [ModalFunction(metadata, client) for metadata in methods_metadata]
-        return cls(class_name, methods, client)
+        return cls(class_name, methods)
 
     def __repr__(self) -> str:
         method_list = ", ".join(self._methods.keys())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,6 +223,26 @@ def garden_nested_metadata_json(garden_nested_metadata_raw) -> dict:
 
 
 @pytest.fixture(scope="session")
+def garden_nested_metadata_raw_with_modal_class() -> dict:
+    """Return a dict with a valid GardenMetadata schema with nested entrypoints."""
+    f = (
+        pathlib.Path(__file__).parent
+        / "fixtures"
+        / "garden_nested_metadata_with_modal_class.json"
+    )
+    with open(f, "r") as f_in:
+        return json.load(f_in)
+
+
+@pytest.fixture
+def garden_nested_metadata_json_with_modal_class(
+    garden_nested_metadata_raw_with_modal_class,
+) -> dict:
+    """Return a dict with a valid GardenMetadata schema with nested entrypoints."""
+    return deepcopy(garden_nested_metadata_raw_with_modal_class)
+
+
+@pytest.fixture(scope="session")
 def modal_function_metadata_raw() -> dict:
     """Return a dict with a valid ModalFunctionMetadata schema."""
     f = pathlib.Path(__file__).parent / "fixtures" / "modal_function_metadata.json"
@@ -234,6 +254,21 @@ def modal_function_metadata_raw() -> dict:
 def modal_function_metadata_json(modal_function_metadata_raw) -> dict:
     """Return a dict with a valid ModalFunctionMetadata schema."""
     return deepcopy(modal_function_metadata_raw)
+
+
+@pytest.fixture(scope="session")
+def modal_method_metadata_raw() -> dict:
+    """Return a dict with a valid ModalFunctionMetadata schema,
+    where the function in question is a class method."""
+    f = pathlib.Path(__file__).parent / "fixtures" / "modal_class_metadata.json"
+    with open(f, "r") as f_in:
+        return json.load(f_in)
+
+
+@pytest.fixture
+def modal_method_metadata_json(modal_method_metadata_raw) -> dict:
+    """Return a dict with a valid ModalFunctionMetadata schema."""
+    return deepcopy(modal_method_metadata_raw)
 
 
 @pytest.fixture(scope="session")

--- a/tests/fixtures/garden_nested_metadata_with_modal_class.json
+++ b/tests/fixtures/garden_nested_metadata_with_modal_class.json
@@ -1,0 +1,79 @@
+{
+    "title": "Semiconductor property prediction models",
+    "authors": ["Will Engler"],
+    "contributors": [
+        "Ryan Jacobs",
+        "Dane Morgan",
+        "Arun Mannodi-Kanakkithodi",
+        "Maria Chan",
+        "Maciej Polak"
+    ],
+    "doi": "10.26311/bg7s-v305",
+    "doi_is_draft": true,
+    "description": "A collection of models for predicting properties of semiconductors",
+    "publisher": "Garden-AI",
+    "year": "2020",
+    "language": "en",
+    "tags": ["numpy", "semiconductor", "machine learning"],
+    "version": "0.0.1",
+    "entrypoint_aliases": {},
+    "is_archived": false,
+    "owner_identity_id": "76024960-c68b-4fec-8cb8-b65b096f18da",
+    "id": 1,
+    "entrypoints": [
+        {
+            "doi": "10.26311/3hz8-as26",
+            "doi_is_draft": true,
+            "title": "Semiconductor defect impurity levels",
+            "description": "Input: (Type: ndarray Shape: ['None', '15']) List of 15 elemental and one-hot encoded features to evaluate model. The list includes: M_3site, M_i_3site, M_i_neut_site, M_i_5site, M_5site, charge_from, charge_to, epsilon, CovalentRadius_max_value, ElectronAffinity_composition_average, NUnfilled_difference, phi_arithmetic_average, Site1_AtomicRadii_arithmetic_average, Site1_BCCvolume_padiff_differenc, Site1_HHIr_composition_average. Output: (Type: ndarray, Shape: 'None') Predictions of semiconductor defect level energies (in eV)",
+            "year": "2020",
+            "func_uuid": "b04ac190-f692-4138-94ca-e6717a77f1e1",
+            "container_uuid": "580c7757-9449-4f46-ac3e-03fb3a86b82f",
+            "base_image_uri": "n/a - dlhub",
+            "full_image_uri": "n/a - dlhub",
+            "notebook_url": "https://www.dlhub.org/",
+            "is_archived": false,
+            "short_name": "predict_defect_level_energies",
+            "function_text": "N/A",
+            "authors": [
+                "Maciej Polak",
+                "Ryan Jacobs",
+                "Arun Mannodi-Kanakkithodi",
+                "Maria Chan",
+                "Dane Morgan"
+            ],
+            "tags": ["Materials Science"],
+            "test_functions": [
+                "def test_model():\n    import numpy as np\n    # The input shape is n rows of 15 attributes - replace with real data\n    input = np.zeros((1, 15))\n    return predict_defect_level_energies(input)\n"
+            ],
+            "requirements": [],
+            "models": [],
+            "repositories": [],
+            "papers": [],
+            "datasets": [],
+            "owner_identity_id": "76024960-c68b-4fec-8cb8-b65b096f18da",
+            "id": 1
+        }
+    ],
+    "entrypoint_ids": ["10.26311/3hz8-as26"],
+    "modal_functions": [
+        {
+            "id": 44,
+            "doi": null,
+            "title": "Test method",
+            "description": "This is a method on a class",
+            "year": "2024",
+            "is_archived": false,
+            "function_name": "ClassName.method_name",
+            "function_text": "foo bar",
+            "authors": ["Will ;)"],
+            "tags": ["you're", "it"],
+            "test_functions": [],
+            "models": [],
+            "repositories": [],
+            "papers": [],
+            "datasets": []
+        }
+    ],
+    "modal_function_ids": [44]
+}

--- a/tests/fixtures/modal_class_metadata.json
+++ b/tests/fixtures/modal_class_metadata.json
@@ -1,0 +1,17 @@
+{
+    "id": 44,
+    "doi": null,
+    "title": "Test method",
+    "description": "This is a method on a class",
+    "year": "2024",
+    "is_archived": false,
+    "function_name": "ClassName.method_name",
+    "function_text": "foo bar",
+    "authors": ["Will ;)"],
+    "tags": ["you're", "it"],
+    "test_functions": [],
+    "models": [],
+    "repositories": [],
+    "papers": [],
+    "datasets": []
+}


### PR DESCRIPTION
Second part of #198. Closes #198

## Overview

This PR accommodates Modal class methods. They come over as metadata just as normal functions do - they just have dots in their names, like "MyClass.my_method". The SDK will construct wrappers on the fly so that users can invoke class methods like my_garden.MyClass.my_method

## Discussion

## Testing

Added a new unit test to exercise the chain of `__getattr__`s. Also did manual testing to check tab completion and HTML rendering.

Manual testing was limited as I mostly used fixture data.

## Documentation

Not yet, but this will definitely merit some mention in the docs


<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--554.org.readthedocs.build/en/554/

<!-- readthedocs-preview garden-ai end -->