### PR TITLE
better modal tracebacks

### DIFF
--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -40,10 +40,11 @@ from garden_ai.gardens import Garden
 from garden_ai.schemas.entrypoint import RegisteredEntrypointMetadata
 from garden_ai.schemas.garden import GardenMetadata
 from garden_ai.utils._meta import make_function_to_register
+from modal.cli._traceback import setup_rich_traceback
 
 logger = logging.getLogger()
-
-rich.traceback.install()
+# modal helper replacement for rich.traceback.install
+setup_rich_traceback()
 
 
 class AuthException(Exception):

--- a/garden_ai/modal/functions.py
+++ b/garden_ai/modal/functions.py
@@ -17,8 +17,8 @@ from modal._utils.blob_utils import (
 )
 from modal._utils.hash_utils import get_upload_hashes
 from modal.exception import DeserializationError, ExecutionError, RemoteError
-from modal_proto import api_pb2
-from synchronicity.exceptions import UserCodeException
+from modal_proto import api_pb2  # type: ignore
+from synchronicity.exceptions import UserCodeException  # type: ignore
 
 if TYPE_CHECKING:
     from garden_ai.client import GardenClient

--- a/garden_ai/modal/functions.py
+++ b/garden_ai/modal/functions.py
@@ -1,7 +1,12 @@
 import io
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, TypeVar, Any
 
-from modal._serialization import serialize
+import modal
+import rich
+from modal.exception import DeserializationError, ExecutionError
+from synchronicity.exceptions import UserCodeException
+from modal._traceback import append_modal_tb
+from modal._serialization import serialize, deserialize, deserialize_data_format
 from modal._utils.async_utils import synchronize_api
 from modal._utils.blob_utils import (
     DEFAULT_SEGMENT_CHUNK_SIZE,
@@ -12,9 +17,8 @@ from modal._utils.blob_utils import (
     get_content_length,
     perform_multipart_upload,
 )
-from modal._utils.function_utils import _process_result
 from modal._utils.hash_utils import get_upload_hashes
-from modal_proto import api_pb2  # type: ignore
+from modal_proto import api_pb2
 
 if TYPE_CHECKING:
     from garden_ai.client import GardenClient
@@ -26,7 +30,56 @@ from ..schemas.modal import (
     ModalFunctionMetadata,
     ModalInvocationRequest,
     ModalInvocationResponse,
+    _ModalGenericResult,
 )
+
+
+def modal_deserialize(data: bytes, data_format: int | None = None) -> Any:
+    """Deserialize data using Modal's deserialization functions."""
+    if data_format:
+        return deserialize_data_format(data, data_format, None)
+    return deserialize(data, None)
+
+
+def clean_and_raise_remote_exception(modal_result: api_pb2.GenericResult) -> None:
+    """Handle remote exceptions from Modal, with proper traceback handling."""
+    if modal_result.traceback:
+        rich.print(f"[red]{modal_result.traceback}[/red]")
+
+    if modal_result.data:
+        try:
+            # In these cases the data field contains an exception, not a real result
+            exc = modal_deserialize(modal_result.data)
+        except DeserializationError as deser_exc:
+            raise ExecutionError(
+                "Could not deserialize remote exception due to local error:\n"
+                + f"{deser_exc}\n"
+                + "This can happen if your local environment does not have the remote exception definitions.\n"
+                + "Here is the remote traceback:\n"
+                + f"{modal_result.traceback}"
+            ) from deser_exc.__cause__
+        except Exception as deser_exc:
+            raise ExecutionError(
+                "Could not deserialize remote exception due to local error:\n"
+                + f"{deser_exc}\n"
+                + "Here is the remote traceback:\n"
+                + f"{modal_result.traceback}"
+            ) from deser_exc
+
+        if not isinstance(exc, BaseException):
+            raise ExecutionError(f"Got remote exception of incorrect type {type(exc)}")
+
+        if modal_result.serialized_tb:
+            try:
+                tb_info: dict = modal_deserialize(modal_result.serialized_tb)
+                line_cache = modal_deserialize(modal_result.tb_line_cache)
+                append_modal_tb(exc, tb_info, line_cache)
+            except:  # noqa
+                # deliberately suppress exceptions -- if we can't deserialize the traceback, we still raise the original exc
+                pass
+        raise UserCodeException(exc)
+    else:
+        raise modal.exception.RemoteError(modal_result.exception)
 
 
 class _ModalFunction:
@@ -36,9 +89,6 @@ class _ModalFunction:
         self._metadata = metadata
         self._client = client
 
-    # NOTE: read-only `@property` attributes had less surprising
-    # behavior on a synchronize_api-wrapped class than regular init attributes.
-    # No other reason for these to be properties.
     @property
     def metadata(self) -> ModalFunctionMetadata:
         return self._metadata
@@ -51,6 +101,23 @@ class _ModalFunction:
         from garden_ai import GardenClient
 
         return GardenClient()
+
+    async def __call__(self, *args, **kwargs) -> Any:
+        response: ModalInvocationResponse = await self._request_invocation(
+            *args, **kwargs
+        )
+        modal_result = api_pb2.GenericResult(
+            **response.result.model_dump(mode="python", exclude_defaults=True)
+        )
+
+        match modal_result.status:
+            case api_pb2.GenericResult.GENERIC_STATUS_SUCCESS:
+                return modal_deserialize(modal_result.data)
+            case api_pb2.GenericResult.GENERIC_STATUS_TIMEOUT:
+                raise modal.exception.FunctionTimeoutError(modal_result.exception)
+            case _:
+                # Not a timeout or success, but a secret third thing
+                clean_and_raise_remote_exception(modal_result)
 
     async def _upload_blob(self, data) -> str:
         """
@@ -96,7 +163,7 @@ class _ModalFunction:
             )
         return blob_id
 
-    async def __call__(self, *args, **kwargs):
+    async def _request_invocation(self, *args, **kwargs) -> ModalInvocationResponse:
         args_kwargs_serialized = serialize((args, kwargs))
 
         # Handle large arguments via blob storage if needed
@@ -111,6 +178,7 @@ class _ModalFunction:
                 function_id=self.metadata.id,
                 args_kwargs_serialized=args_kwargs_serialized,
             )
+
         # If we're in prod, track this invocation
         if self.client._mixpanel_track:
             event_properties = {
@@ -124,25 +192,18 @@ class _ModalFunction:
         response: ModalInvocationResponse = (
             self.client.backend_client.invoke_modal_function_async(request)
         )
-        result_data: dict = response.result.model_dump(
-            mode="python", exclude_defaults=True
-        )
-
-        if url := result_data.get("data_blob_url"):
+        if (url := response.result.data_blob_url) is not None:
             # hack: make large result data look like a regular modal payload.
-
-            # this lets us omit a modal client altogether in the
-            # `_process_result` helper (as opposed to needing an "anonymous
-            # client" just for deserializing)
             blob = await _download_from_url(url)  # type: ignore
-            result_data["data"] = blob
-            del result_data["data_blob_url"]
+            downloaded_result = _ModalGenericResult(
+                data=blob,
+                **response.result.model_dump(
+                    mode="python", exclude={"data", "data_blob_url"}
+                ),
+            )
+            response.result = downloaded_result
 
-        modal_result_struct = api_pb2.GenericResult(**result_data)
-
-        return await _process_result(
-            modal_result_struct, response.data_format, stub=None, client=None
-        )
+        return response
 
     def __eq__(self, other):
         return isinstance(other, type(self)) and self.metadata == other.metadata

--- a/garden_ai/schemas/modal.py
+++ b/garden_ai/schemas/modal.py
@@ -49,9 +49,6 @@ class _ModalGenericResult(BaseModel):
 
     @model_validator(mode="after")
     def one_of_data_or_blob_url(self):
-        assert (
-            self.data is not None or self.data_blob_url is not None
-        ), "At least one of data or data_blob_url should be set"
         assert not (
             self.data and self.data_blob_url
         ), "Only one of data or data_blob_url should be set."
@@ -65,9 +62,6 @@ class ModalInvocationRequest(BaseModel):
 
     @model_validator(mode="after")
     def one_of_args_or_blob(self):
-        assert (
-            self.args_kwargs_serialized or self.args_blob_id
-        ), "At least one of args_kwargs_serialized or args_blob_id should be set."
         assert not (
             self.args_kwargs_serialized and self.args_blob_id
         ), "Only one of args_kwargs_serialized or args_blob_id should be set."

--- a/tests/modal/test_functions.py
+++ b/tests/modal/test_functions.py
@@ -36,19 +36,19 @@ def test_modal_function_call_direct(modal_function):
     mock_result_deserialized = "what results! and *so* nicely processed"
 
     mock_serialize = Mock(return_value=mock_args_kwargs_serialized)
-    mock_deserialize = AsyncMock(return_value=mock_result_deserialized)
+    mock_deserialize = Mock(return_value=mock_result_deserialized)
 
     # Mock the backend client's invoke_modal_function_async method
     modal_function.client.backend_client.invoke_modal_function_async = Mock(
         return_value=ModalInvocationResponse(
-            result=_ModalGenericResult(status=0, data=mock_result_serialized),
+            result=_ModalGenericResult(status=1, data=mock_result_serialized),
             data_format=1,
         )
     )
 
     with (
         patch("garden_ai.modal.functions.serialize", mock_serialize),
-        patch("garden_ai.modal.functions._process_result", mock_deserialize),
+        patch("garden_ai.modal.functions._modal_deserialize", mock_deserialize),
     ):
         # call the modal function object
         result = modal_function("fake input data", hello="world")
@@ -96,7 +96,7 @@ def test_modal_function_call_large_args(modal_function):
     # Mock response from function invocation
     modal_function.client.backend_client.invoke_modal_function_async = Mock(
         return_value=ModalInvocationResponse(
-            result=_ModalGenericResult(status=0, data=mock_result_serialized),
+            result=_ModalGenericResult(status=1, data=mock_result_serialized),
             data_format=1,
         )
     )
@@ -109,8 +109,8 @@ def test_modal_function_call_large_args(modal_function):
         patch("garden_ai.modal.functions.get_content_length", mock_get_content_length),
         patch("garden_ai.modal.functions._upload_to_s3_url", mock_upload_to_s3),
         patch(
-            "garden_ai.modal.functions._process_result",
-            AsyncMock(return_value=mock_result_deserialized),
+            "garden_ai.modal.functions._modal_deserialize",
+            Mock(return_value=mock_result_deserialized),
         ),
     ):
         result = modal_function("large fake input data", hello="world")
@@ -157,7 +157,7 @@ def test_modal_function_call_large_args_multipart(modal_function):
     # Mock response from function invocation
     modal_function.client.backend_client.invoke_modal_function_async = Mock(
         return_value=ModalInvocationResponse(
-            result=_ModalGenericResult(status=0, data=mock_result_serialized),
+            result=_ModalGenericResult(status=1, data=mock_result_serialized),
             data_format=1,
         )
     )
@@ -172,8 +172,8 @@ def test_modal_function_call_large_args_multipart(modal_function):
             "garden_ai.modal.functions.perform_multipart_upload", mock_perform_multipart
         ),
         patch(
-            "garden_ai.modal.functions._process_result",
-            AsyncMock(return_value=mock_result_deserialized),
+            "garden_ai.modal.functions._modal_deserialize",
+            Mock(return_value=mock_result_deserialized),
         ),
     ):
         result = modal_function("very large fake input data", hello="world")
@@ -206,7 +206,7 @@ def test_modal_function_call_blob_response(modal_function):
     modal_function.client.backend_client.invoke_modal_function_async = Mock(
         return_value=ModalInvocationResponse(
             result=_ModalGenericResult(
-                status=0,
+                status=1,
                 data_blob_url=mock_download_url,
             ),
             data_format=1,
@@ -220,8 +220,8 @@ def test_modal_function_call_blob_response(modal_function):
         ),
         patch("garden_ai.modal.functions._download_from_url", mock_download),
         patch(
-            "garden_ai.modal.functions._process_result",
-            AsyncMock(return_value=mock_result_deserialized),
+            "garden_ai.modal.functions._modal_deserialize",
+            Mock(return_value=mock_result_deserialized),
         ),
     ):
         result = modal_function("input data")


### PR DESCRIPTION
fixes #564 

## Overview

This PR incorporates modal's remote exception handling/display logic for invocations from garden. 

Where possible, we do this by just calling the relevant helper function from their codebase outright; where it wasn't possible to do so I plagiarized their logic as best I could. 

Here's what it looks like (modal traceback on left/proxied traceback on the right): 

![image](https://github.com/user-attachments/assets/9dfcd025-55f8-4a18-96ca-84ca74802840)

## Discussion

The main reason we can't always just import and use modal helpers is that we can't instantiate a modal client on behalf of users who may not have modal credentials. To work around this (and clean up our `__call__` method), this PR has two new helpers (`_modal_deserialize` and `_clean_and_raise_remote_exception`) which together do essentially the same thing as the previously load-bearing `modal.function_utils._process_result`, but print tracebacks correctly on our end and do not need a client (no more kludgy anonymous client either). 


## Testing

yeeeehaw 🤠 

Tested manually, and we decided that writing good unit tests for this wasn't the best use of pre-hackathon time. Happy to revisit later

## Documentation

no docs 

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--565.org.readthedocs.build/en/565/

<!-- readthedocs-preview garden-ai end -->