### PR TITLE
Update the Modal publish docs based on user experiance

### DIFF
--- a/docs/user_guide/publishing/modal-publishing.md
+++ b/docs/user_guide/publishing/modal-publishing.md
@@ -4,7 +4,7 @@
     Use of this feature requires that your Globus account is authorized by the Garden Team. Please [contact](mailto:thegardens@uchicago.edu) us if you are interested in using this feature.
     For another publishing flow that doesn't require special authorization, see: [Publishing with Docker](tutorial_docker.md).
 
-## Introduction
+## 1. Introduction
 
 This guide will walk you through the process of publishing a Garden from a Modal App.
 
@@ -23,15 +23,30 @@ Create a free Modal account by linking your GitHub: [signup](https://modal.com/s
 !!! Note
     You'll get $30/month of free compute credit for your personal Modal account. It's totally safe to spend those credits developing and debugging your modal functions before you publish them with garden -- modal functions published through garden won't charge your personal account.
 
-## 1. Author the Modal App
 
+### Install the Modal CLI
+Create a python virtual env and install the current modal CLI and SDK along
+with the Garden CLI and SDK:
+    
+    ```bash
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip install modal
+    pip install garden-ai
+    ```
+
+You need to log in into modal using your GitHub account and create a token:
+```bash
+modal setup
+```
+## 2. Author a Modal App
 !!! Tip
     Skip the details and see the [complete modal file](#the-complete-modal-file).
 
-
 ### Create a python file for your Modal App
 
-Modal files are regular python scripts. Create a new python file in your project:
+Modal files are regular python scripts that define a modal app and decorate one 
+or more functions. Create a new python file in your project:
 
 ```bash
 $ touch my_app.py
@@ -133,9 +148,80 @@ def my_other_cool_function(data):
   return result
 ```
 
-See the [Modal docs](https://modal.com/docs/guide) for more details on defining Modal Apps and functions.
+## 3. Testing and Debugging
+Garden provides a citable, findable, wrapper around the modal function. Before we
+register the function with Garden it can be useful to test it with the raw modal 
+runtime tools. This makes for a faster feedback loop when developing and debugging.
 
-## 2. Upload your App to Garden
+To enable this, we have to add a `local_entrypoint` to our python script. This is only
+used by the modal CLI and will be ignored by Garden.
+
+Add this to your python script:
+
+```python
+@app.local_entrypoint()
+def main():
+    # run the function on the modal servers
+    print(my_awesome_function.remote([1, 2, 3, 4, 5]))
+```
+
+Ask modal to run this with:
+    
+```bash
+modal run my_app.py
+```
+
+## 4. Specify Dependencies and Cache Model
+Modal allows you to define an _image_ in which the function will run. See the modal 
+docs on [images](https://modal.com/docs/guide/images) for full information. Here's
+an example of how to define an image that includes some pip dependencies, installs
+wget into the debian image, and downloads a model from figshare:
+
+```python
+image = modal.Image.debian_slim(python_version="3.12").apt_install("wget") \
+.pip_install(
+    "pandas==2.2.3",
+    "torch==2.2.2",
+    "torchvision==0.17.2",
+    "requests==2.32.3",
+) \
+    .run_commands("wget -O model.pth https://figshare.com/ndownloader/files/51767333", "pwd", "ls -lht")
+```
+
+In this example, the model will be available to the function in the container at `/model.pth`.
+
+### Caching Hugging Face Models
+If you are using one of HuggingFace's published transformers, you can take advantage 
+of the library's caching strategy. You need to call the python functions to load the models
+during the `run_commands` phase of the image build. Here is an example of how to cache
+the `distilbert-base-uncased` model:
+
+
+```python
+image = modal.Image.debian_slim(python_version="3.12") \
+.pip_install(
+    "transformers",
+    "sentencepiece",
+    "torch",
+    "datasets") \
+    .run_commands('python -c "from transformers import T5Tokenizer, T5ForConditionalGeneration; model_name = \'t5-small\'; T5Tokenizer.from_pretrained(model_name); T5ForConditionalGeneration.from_pretrained(model_name) "')
+```
+
+For models that have been published to the HuggingFace model hub, you can use the
+a `git clone` to download the model and cache it in the image. Here is an example
+```python
+image = modal.Image.debian_slim(python_version="3.12").apt_install("wget") \
+.apt_install("git") \
+.pip_install(
+    "torch",
+    "datasets") \
+    .run_commands('git clone https://huggingface.co/Arigadam/img2float', 'pwd', 'ls -lht')
+
+```
+
+
+## 5. Upload your App to Garden
+Now that you have a python file defining your Modal App, you can upload it to Garden.
 
 ### Create a new Garden
 
@@ -175,7 +261,7 @@ It may take a few minutes for the deployment process to finish.
 
 Check the 'My Gardens' tab on your [Profile](https://thegardens.ai/#/user) page for the new Garden. Note the DOI for the next step.
 
-## 3. Invoke your published functions using Garden
+## 6. Invoke your published functions using Garden
 
 After uploading your Modal App to Garden, you should have a new DOI referencing the Garden you created.
 


### PR DESCRIPTION
# Summary:
1. Added more info on installing modal and logging into the service
2. Created section on testing and debugging your function before uploading to garden
3. Section on images along with some hints on caching model weights


<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--568.org.readthedocs.build/en/568/

<!-- readthedocs-preview garden-ai end -->