### PR TITLE
Add bespoke AlphaFold2 Garden

### DIFF
--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -394,10 +394,14 @@ class GardenClient:
         if doi.lower() == "alphafold2":
             # Custom endpoint for AlphaFold2
             endpoint_id = "b1be97db-6d56-4ba7-8ef3-d5f77581e87c"
-            function_id = "2a84ee6a-ab11-433c-95f5-37c583704605"  # You'll need to specify the correct function name
+            # fn_id = "2a84ee6a-ab11-433c-95f5-37c583704605"  # Hello sayer
+            # fn_id = "8125a4c9-b55b-4fd4-aac4-f834066b0df2"  # AlphaFold2
+            # fn_id = "66d9c324-af8b-4f9c-8d16-b88605e895a2" # error reporter
+            # fn_id = "c4d363e7-e746-4d97-980d-7275c57326b5" # all context
+            fn_id = "0b692898-5da9-4fdd-b4e4-a8415fa9b0f4"  # diagnostics
 
             return CustomEndpointGarden(
-                client=self, doi=doi, endpoint_id=endpoint_id, function_id=function_id
+                client=self, doi=doi, endpoint_id=endpoint_id, function_id=fn_id
             )
 
         garden = self.backend_client.get_garden(doi)

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -384,13 +384,12 @@ class GardenClient:
             )
 
     def get_garden(self, doi: str) -> Garden:
-        """Get a Garden instance for a specific model.
-
-        Args:
-            doi: The DOI or special identifier for the model
-
+        """
+        Return the published Garden associated with the given DOI.
+        Parameters:
+            doi: The DOI of the garden. Raises an exception if not found.
         Returns:
-            Garden: A Garden instance configured for the specified model
+            The published Garden object. Any [entrypoints][garden_ai.Entrypoint] in the garden can be called like methods on this object.
         """
         if doi.lower() == "alphafold2":
             return AlphaFoldGarden(client=self, doi=doi)

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -36,7 +36,7 @@ from garden_ai.backend_client import BackendClient
 from garden_ai.constants import GardenConstants
 from garden_ai.entrypoints import Entrypoint
 from garden_ai.garden_file_adapter import GardenFileAdapter
-from garden_ai.gardens import Garden, CustomEndpointGarden
+from garden_ai.gardens import Garden, AlphaFoldGarden
 from garden_ai.schemas.entrypoint import RegisteredEntrypointMetadata
 from garden_ai.schemas.garden import GardenMetadata
 from garden_ai.utils._meta import make_function_to_register
@@ -392,16 +392,17 @@ class GardenClient:
             Garden: A Garden instance configured for the specified model
         """
         if doi.lower() == "alphafold2":
-            # Custom endpoint for AlphaFold2
+            # TODO: just consolidate this into the AlphaFoldGarden class
             endpoint_id = "b1be97db-6d56-4ba7-8ef3-d5f77581e87c"
-            # fn_id = "2a84ee6a-ab11-433c-95f5-37c583704605"  # Hello sayer
-            # fn_id = "8125a4c9-b55b-4fd4-aac4-f834066b0df2"  # AlphaFold2
-            # fn_id = "66d9c324-af8b-4f9c-8d16-b88605e895a2" # error reporter
-            # fn_id = "c4d363e7-e746-4d97-980d-7275c57326b5" # all context
-            fn_id = "0b692898-5da9-4fdd-b4e4-a8415fa9b0f4"  # diagnostics
-
-            return CustomEndpointGarden(
-                client=self, doi=doi, endpoint_id=endpoint_id, function_id=fn_id
+            return AlphaFoldGarden(
+                client=self,
+                doi=doi,
+                endpoint_id=endpoint_id,
+                function_ids=[
+                    "e7f4fb4a-9b4c-4479-8431-f01f0860fc3b",
+                    "156cba39-441d-45eb-b1bd-b4cb8858153c",
+                    "4230fbd4-f918-49f0-b948-4b408dbfd3de",
+                ],
             )
 
         garden = self.backend_client.get_garden(doi)

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -36,9 +36,10 @@ from garden_ai.backend_client import BackendClient
 from garden_ai.constants import GardenConstants
 from garden_ai.entrypoints import Entrypoint
 from garden_ai.garden_file_adapter import GardenFileAdapter
-from garden_ai.gardens import Garden, AlphaFoldGarden
+from garden_ai.gardens import Garden
 from garden_ai.schemas.entrypoint import RegisteredEntrypointMetadata
 from garden_ai.schemas.garden import GardenMetadata
+from garden_ai.hpc_gardens.alpha_fold import AlphaFoldGarden
 from garden_ai.utils._meta import make_function_to_register
 from modal.cli._traceback import setup_rich_traceback
 
@@ -392,18 +393,7 @@ class GardenClient:
             Garden: A Garden instance configured for the specified model
         """
         if doi.lower() == "alphafold2":
-            # TODO: just consolidate this into the AlphaFoldGarden class
-            endpoint_id = "b1be97db-6d56-4ba7-8ef3-d5f77581e87c"
-            return AlphaFoldGarden(
-                client=self,
-                doi=doi,
-                endpoint_id=endpoint_id,
-                function_ids=[
-                    "e7f4fb4a-9b4c-4479-8431-f01f0860fc3b",
-                    "156cba39-441d-45eb-b1bd-b4cb8858153c",
-                    "4230fbd4-f918-49f0-b948-4b408dbfd3de",
-                ],
-            )
+            return AlphaFoldGarden(client=self, doi=doi)
 
         garden = self.backend_client.get_garden(doi)
         return garden

--- a/garden_ai/client.py
+++ b/garden_ai/client.py
@@ -36,7 +36,7 @@ from garden_ai.backend_client import BackendClient
 from garden_ai.constants import GardenConstants
 from garden_ai.entrypoints import Entrypoint
 from garden_ai.garden_file_adapter import GardenFileAdapter
-from garden_ai.gardens import Garden
+from garden_ai.gardens import Garden, CustomEndpointGarden
 from garden_ai.schemas.entrypoint import RegisteredEntrypointMetadata
 from garden_ai.schemas.garden import GardenMetadata
 from garden_ai.utils._meta import make_function_to_register
@@ -383,15 +383,23 @@ class GardenClient:
             )
 
     def get_garden(self, doi: str) -> Garden:
-        """
-        Return the published Garden associated with the given DOI.
+        """Get a Garden instance for a specific model.
 
-        Parameters:
-            doi: The DOI of the garden. Raises an exception if not found.
+        Args:
+            doi: The DOI or special identifier for the model
 
         Returns:
-            The published Garden object. Any [entrypoints][garden_ai.Entrypoint] in the garden can be called like methods on this object.
+            Garden: A Garden instance configured for the specified model
         """
+        if doi.lower() == "alphafold2":
+            # Custom endpoint for AlphaFold2
+            endpoint_id = "b1be97db-6d56-4ba7-8ef3-d5f77581e87c"
+            function_id = "2a84ee6a-ab11-433c-95f5-37c583704605"  # You'll need to specify the correct function name
+
+            return CustomEndpointGarden(
+                client=self, doi=doi, endpoint_id=endpoint_id, function_id=function_id
+            )
+
         garden = self.backend_client.get_garden(doi)
         return garden
 

--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -303,7 +303,7 @@ class AlphaFoldGarden(Garden):
     def submit(self, fasta_string: str):
         """Main prediction method that invokes the custom endpoint."""
         print(f"Submitting HPC job to predict structure of {fasta_string}")
-        resp = self.entrypoints[0](endpoint=self.endpoint_id)
+        resp = self.entrypoints[0](fasta_string, endpoint=self.endpoint_id)
         if type(resp) is dict:
             return resp
         raise ValueError(resp)

--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, TypeVar
-from uuid import UUID
 from tabulate import tabulate
 
 from garden_ai.modal.functions import ModalFunction
@@ -257,61 +256,3 @@ class Garden:
         ]
 
         return cls(metadata, entrypoints, modal_functions, modal_classes)
-
-
-class AlphaFoldGarden(Garden):
-    """A Garden that uses a specific endpoint and function."""
-
-    def __init__(self, client, doi: str, endpoint_id: str, function_ids: list[str]):
-        self.client = client
-
-        # function_ids = ['bfc5557c-a1ff-4503-b276-8a8f6a4a4df1', '320aa08a-114e-4181-a393-98e3fcd02b0d']
-        function_names = ["predict", "check_prediction_status", "retrieve_results"]
-
-        stub_entrypoints = []
-        for function_id, function_name in zip(function_ids, function_names):
-            # Create the entrypoint first so we can use its DOI
-            entrypoint_metadata = RegisteredEntrypointMetadata(
-                doi=f"{doi}/{function_name}",
-                title="AlphaFold2 Prediction",
-                description="Predict protein structure using AlphaFold2",
-                short_name=function_name,
-                func_uuid=function_id,
-                container_uuid=UUID("00000000-0000-0000-0000-000000000000"),
-                base_image_uri="N/A",
-                full_image_uri="N/A",
-                notebook_url="https://thegardens.ai/",
-                function_text="",
-                entrypoint_ids=[],
-                doi_is_draft=False,
-            )
-            stub_entrypoints.append(Entrypoint(entrypoint_metadata))
-
-        metadata = GardenMetadata(
-            doi=doi,
-            title="AlphaFold2",
-            description="AlphaFold2 protein structure prediction",
-            entrypoint_ids=[ep.metadata.doi for ep in stub_entrypoints],
-            entrypoint_aliases={},
-            doi_is_draft=False,
-        )
-
-        super().__init__(metadata=metadata, entrypoints=stub_entrypoints)
-        self.endpoint_id = endpoint_id
-
-    # We'll call this 'submit' instead
-    def submit(self, fasta_string: str):
-        """Main prediction method that invokes the custom endpoint."""
-        print(f"Submitting HPC job to predict structure of {fasta_string}")
-        resp = self.entrypoints[0](fasta_string, endpoint=self.endpoint_id)
-        if type(resp) is dict:
-            return resp
-        raise ValueError(resp)
-
-    def check_prediction_status(self, task_id: str):
-        """Check the status of a submitted task."""
-        return self.entrypoints[1](task_id, endpoint=self.endpoint_id)
-
-    def retrieve_results(self, pdb_id: str):
-        """Retrieve the results of a submitted task."""
-        return self.entrypoints[2](pdb_id, endpoint=self.endpoint_id)

--- a/garden_ai/hpc_gardens/alpha_fold.py
+++ b/garden_ai/hpc_gardens/alpha_fold.py
@@ -24,6 +24,7 @@ class AlphaFoldGarden(Garden):
         for function_id, function_name in zip(function_ids, function_names):
             entrypoint_metadata = RegisteredEntrypointMetadata(
                 doi=f"{doi}/{function_name}",
+                authors=["DeepMind"],
                 title="AlphaFold2 Prediction",
                 description="Predict protein structure using AlphaFold2",
                 short_name=function_name,
@@ -40,6 +41,7 @@ class AlphaFoldGarden(Garden):
 
         metadata = GardenMetadata(
             doi=doi,
+            authors=["DeepMind"],
             title="AlphaFold2",
             description="AlphaFold2 protein structure prediction",
             entrypoint_ids=[ep.metadata.doi for ep in stub_entrypoints],

--- a/garden_ai/hpc_gardens/alpha_fold.py
+++ b/garden_ai/hpc_gardens/alpha_fold.py
@@ -1,10 +1,9 @@
 from uuid import UUID
 
-from gardens import Garden
+from ..gardens import Garden
+from ..entrypoints import Entrypoint
 from garden_ai.schemas.entrypoint import RegisteredEntrypointMetadata
 from garden_ai.schemas.garden import GardenMetadata
-
-from ..entrypoints import Entrypoint
 
 
 class AlphaFoldGarden(Garden):

--- a/garden_ai/hpc_gardens/alpha_fold.py
+++ b/garden_ai/hpc_gardens/alpha_fold.py
@@ -22,7 +22,6 @@ class AlphaFoldGarden(Garden):
 
         stub_entrypoints = []
         for function_id, function_name in zip(function_ids, function_names):
-            # Create the entrypoint first so we can use its DOI
             entrypoint_metadata = RegisteredEntrypointMetadata(
                 doi=f"{doi}/{function_name}",
                 title="AlphaFold2 Prediction",
@@ -51,7 +50,6 @@ class AlphaFoldGarden(Garden):
         super().__init__(metadata=metadata, entrypoints=stub_entrypoints)
         self.endpoint_id = endpoint_id
 
-    # We'll call this 'submit' instead
     def submit(self, fasta_string: str):
         """Main prediction method that invokes the custom endpoint."""
         print(f"Submitting HPC job to predict structure of {fasta_string}")

--- a/garden_ai/hpc_gardens/alpha_fold.py
+++ b/garden_ai/hpc_gardens/alpha_fold.py
@@ -1,0 +1,70 @@
+from uuid import UUID
+
+from gardens import Garden
+from garden_ai.schemas.entrypoint import RegisteredEntrypointMetadata
+from garden_ai.schemas.garden import GardenMetadata
+
+from ..entrypoints import Entrypoint
+
+
+class AlphaFoldGarden(Garden):
+    """A Garden that uses a specific endpoint and function."""
+
+    def __init__(self, client, doi: str):
+        self.client = client
+
+        function_ids = [
+            "b3b3ffba-6fbb-46c9-8631-c8d3c7d6033b",
+            "d6558962-2877-4ba7-a193-c1ab43cdde6d",
+            "49f01f32-2574-47a7-b536-44008d15c58e",
+        ]
+        function_names = ["predict", "check_prediction_status", "retrieve_results"]
+        endpoint_id = "b1be97db-6d56-4ba7-8ef3-d5f77581e87c"
+
+        stub_entrypoints = []
+        for function_id, function_name in zip(function_ids, function_names):
+            # Create the entrypoint first so we can use its DOI
+            entrypoint_metadata = RegisteredEntrypointMetadata(
+                doi=f"{doi}/{function_name}",
+                title="AlphaFold2 Prediction",
+                description="Predict protein structure using AlphaFold2",
+                short_name=function_name,
+                func_uuid=function_id,
+                container_uuid=UUID("00000000-0000-0000-0000-000000000000"),
+                base_image_uri="N/A",
+                full_image_uri="N/A",
+                notebook_url="https://thegardens.ai/",
+                function_text="",
+                entrypoint_ids=[],
+                doi_is_draft=False,
+            )
+            stub_entrypoints.append(Entrypoint(entrypoint_metadata))
+
+        metadata = GardenMetadata(
+            doi=doi,
+            title="AlphaFold2",
+            description="AlphaFold2 protein structure prediction",
+            entrypoint_ids=[ep.metadata.doi for ep in stub_entrypoints],
+            entrypoint_aliases={},
+            doi_is_draft=False,
+        )
+
+        super().__init__(metadata=metadata, entrypoints=stub_entrypoints)
+        self.endpoint_id = endpoint_id
+
+    # We'll call this 'submit' instead
+    def submit(self, fasta_string: str):
+        """Main prediction method that invokes the custom endpoint."""
+        print(f"Submitting HPC job to predict structure of {fasta_string}")
+        resp = self.entrypoints[0](fasta_string, endpoint=self.endpoint_id)
+        if type(resp) is dict:
+            return resp
+        raise ValueError(resp)
+
+    def check_prediction_status(self, task_id: str):
+        """Check the status of a submitted task."""
+        return self.entrypoints[1](task_id, endpoint=self.endpoint_id)
+
+    def retrieve_results(self, pdb_id: str):
+        """Retrieve the results of a submitted task."""
+        return self.entrypoints[2](pdb_id, endpoint=self.endpoint_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,4 +117,4 @@ addopts = "--random-order"
 
 [tool.coverage.run]
 source = ["garden_ai/"]
-omit = ["garden_ai/notebook_templates/*", "tests/*", "scripts/*"]
+omit = ["garden_ai/notebook_templates/*", "tests/*", "scripts/*", "garden_ai/hpc_gardens/*"]


### PR DESCRIPTION
Closes https://github.com/Garden-AI/uploadathon/issues/7

## Overview

This PR adds a special hidden garden. If you say `garden_client.get_garden('AlphaFold2')` you get a Garden with functions for submitting, checking on, and retrieving AlphaFold2 runs on Delta.

## Discussion

This is a deliberately cheeky and hacky way of getting this in to the SDK. There is no backend component and everything is hardcoded. While we are in such an experimental phase with the HPC work I think it's good to have a light touch and one clear "cutoff" point to include/exclude.

## Testing

I tested this end-to-end on Delta with [this notebook](https://colab.research.google.com/drive/1BIxNq1xlWRkxGFACS8t8SxWofXYZ1HUr?usp=sharing). Unfortunately nobody but me can run this with the current Globus Compute endpoint on Delta, but we will try to change that next. 

<img width="702" alt="Screenshot 2025-02-27 at 4 22 42 PM" src="https://github.com/user-attachments/assets/ca54a3f2-7ce1-47e8-8335-94adc191588d" />


## Documentation

This is deliberately not included in the docs because it is a proof of concept that only I can operate

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--571.org.readthedocs.build/en/571/

<!-- readthedocs-preview garden-ai end -->