### PR TITLE
Add module level get_garden, get_functions funcs

### DIFF
--- a/garden_ai/__init__.py
+++ b/garden_ai/__init__.py
@@ -26,3 +26,13 @@ __all__ = [
     "entrypoint_test",
     "create_connector",
 ]
+
+
+def get_garden(doi: str) -> Garden:
+    gc = GardenClient()
+    return gc.get_garden(doi)
+
+
+def get_function(doi: str) -> Entrypoint:
+    gc = GardenClient()
+    return gc.get_entrypoint(doi)


### PR DESCRIPTION
## Overview

This PR adds top-level `get_garden` and `get_function` functions to the SDK. This allows users to do this:

```python
import garden_ai

garden = garden_ai.get_garden("some/doi")
result = garden.run_some_function(inputs)
```

Instead of:
```python
import garden_ai
gc = GardenClient()
garden = gc.get_garden()
result = garden.run_some_function(inputs)
```

The functions are simple and just wrap the `gc = GardenClient()` up to remove that step. reducing the number of things our users need to type to invoke a Garden.


## Testing

Manually

## Documentation

If we like this, we should probably update the docs and examples to use these new functions.
