### PR TITLE
Disallow fetching archived gardens

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -23,7 +23,7 @@ security: # configuration for the `safety check` command
       reason: the CVE-2024-35195 vulnerability affects the use of "verify=False" in requests, but our project does not use this parameter in any API calls, so this risk can be ignored. If this version fixes our bug, we will find another solution.
     73725:
       reason: We aren't using starlette directly. It is pulled in as a transitive dependency from the Modal SDK
-    71064:
+    75976:
       reason: the vulnerability only affects dynamic jinja2 templates, which we don't use
 
   continue-on-vulnerability-error: False # Suppress non-zero exit codes when vulnerabilities are found. Enable this in pipelines and CI/CD processes if you want to pass builds that have vulnerabilities. We recommend you set this to False.

--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -23,6 +23,8 @@ security: # configuration for the `safety check` command
       reason: the CVE-2024-35195 vulnerability affects the use of "verify=False" in requests, but our project does not use this parameter in any API calls, so this risk can be ignored. If this version fixes our bug, we will find another solution.
     73725:
       reason: We aren't using starlette directly. It is pulled in as a transitive dependency from the Modal SDK
+    71064:
+      reason: the vulnerability only affects dynamic jinja2 templates, which we don't use
 
   continue-on-vulnerability-error: False # Suppress non-zero exit codes when vulnerabilities are found. Enable this in pipelines and CI/CD processes if you want to pass builds that have vulnerabilities. We recommend you set this to False.
 alert: # configuration for the `safety alert` command

--- a/garden_ai/backend_client.py
+++ b/garden_ai/backend_client.py
@@ -105,6 +105,8 @@ class BackendClient:
 
     def get_garden(self, doi: str) -> Garden:
         response = self._get(f"/gardens/{doi}")
+        if response.get("is_archived", True):
+            raise Exception(f"Garden with DOI {doi} is archived.")
         return Garden._from_nested_metadata(response)
 
     def get_garden_metadata(self, doi: str) -> GardenMetadata:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ maintainers = [
   "Globus Labs <labs@globus.org>",
   "Owen Price Skelly",
   "Will Engler",
+  "Hayden Holbrook",
   "Ben Blaiszik",
   "Ben Galewsky",
   "Eric Blau",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,11 +123,9 @@ def patch_backend_client_requests(mocker, garden_nested_metadata_json) -> None:
 @pytest.fixture
 def patch_garden_constants(mocker, tmp_path):
     """Patches fields in GardenConstants with temp values for tests."""
-    with mocker.patch.object(GardenConstants, "GARDEN_DIR", tmp_path):
-        with mocker.patch.object(
-            GardenConstants, "GARDEN_KEY_STORE", tmp_path / "tokens.json"
-        ):
-            yield
+    mocker.patch.object(GardenConstants, "GARDEN_DIR", tmp_path)
+    mocker.patch.object(GardenConstants, "GARDEN_KEY_STORE", tmp_path / "tokens.json")
+    yield
 
 
 @pytest.fixture

--- a/tests/test_backend_client.py
+++ b/tests/test_backend_client.py
@@ -383,3 +383,16 @@ def test_put_entrypoint_metadata_returns_entrypoint_metadata_on_success(
     )
 
     assert isinstance(entrypoint_meta, RegisteredEntrypointMetadata)
+
+
+def test_get_garden_raises_on_archived_garden(
+    mocker,
+    backend_client,
+):
+    mocker.patch(
+        "garden_ai.backend_client.BackendClient._get",
+        return_value={"is_archived": True},
+    )
+
+    with pytest.raises(Exception):
+        backend_client.get_garden("some/doi")


### PR DESCRIPTION
Resolves: #576 

## Overview

This PR disallows fetching archived gardens by raising an exception if the backend client gets a garden response with the `is_archived` field set to `True`.

## Testing
New unit test


<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--578.org.readthedocs.build/en/578/

<!-- readthedocs-preview garden-ai end -->