### PR TITLE
naively include tools from mlip demo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           pip install --upgrade pip && \
           poetry config virtualenvs.create false && \
-          poetry install --no-interaction --no-ansi --with=test --extras=mcp
+          poetry install --no-interaction --no-ansi --with=test --extras=mcp --extras=mlip
       - name: black lint
         uses: psf/black@stable
         with:

--- a/garden_ai/hpc_gardens/mlip_garden.py
+++ b/garden_ai/hpc_gardens/mlip_garden.py
@@ -470,7 +470,7 @@ def _run_single_relaxation(atoms_dict, model: str = "mace-mp-0"):
         # MACE models
         if model_name.startswith("mace"):
             from mace.calculators.foundations_models import mace_mp, mace_off
-            from torch_sim.models.mace import MaceModel, MaceUrls  # noqa:
+            from torch_sim.models.mace import MaceModel  # noqa:
 
             if "off" in model_name:
                 # MACE-OFF models for organic molecules
@@ -607,7 +607,7 @@ def _run_batch_relaxation(atoms_dicts, model="mace-mp-0", max_batch_size=10):
         # MACE models
         if model_name.startswith("mace"):
             from mace.calculators.foundations_models import mace_mp, mace_off
-            from torch_sim.models.mace import MaceModel, MaceUrls  # noqa:
+            from torch_sim.models.mace import MaceModel  # noqa:
 
             if "off" in model_name:
                 # MACE-OFF models for organic molecules

--- a/garden_ai/mcp/README.md
+++ b/garden_ai/mcp/README.md
@@ -1,15 +1,13 @@
 # Garden MCP server
 
-This is a prototype implementation of a local (stdio) MCP server to enable MCP
-clients like claude desktop to interact with the garden service via the sdk
-(instead of via a hosted MCP server)
+This is a prototype implementation of a local (stdio) MCP server to enable MCP clients like claude desktop to interact with the garden service via the sdk (instead of via a hosted MCP server)
 
 It exposes the following tools (TODO):
 
 - [ ] search_gardens
 - [ ] search_functions
 - [ ] call_function
-- [ ] MLIP-demo-related tools
+- [ ] MLIP-demo-related tools (see below)
 
 ## Prerequisites
 
@@ -26,13 +24,37 @@ It exposes the following tools (TODO):
       "args": [
         "run",
         "--with",
-        "garden[mcp]",
+        "garden-ai[mcp]",
         "garden-ai",
         "mcp"
       ]
     }
   }
 }
+```
+
+### including MLIP tools
+
+To include the bespoke `submit_relaxation_job`, `check_job_status` and `get_job_results` tools, add an additional `--with garden-ai[mlip]` to the uv command, like so:
+
+```
+{
+  "mcpServers": {
+    "garden": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--with",
+        "garden-ai[mcp]",
+        "--with",
+        "garden-ai[mlip]",
+        "garden-ai",
+        "mcp"
+      ]
+    }
+  }
+}
+
 ```
 
 ## local dev claude config

--- a/garden_ai/mcp/mlip.py
+++ b/garden_ai/mcp/mlip.py
@@ -76,7 +76,7 @@ def check_job_status(job_id: str):
         raise ToolError(f"Failed to check job status for {job_id}: {e}")
 
 
-def get_job_results(job_id: str, output_file_path: str = None):
+def get_job_results(job_id: str, output_file_path: str | None = None):
     """
     Retrieve the results of a completed relaxation job and optionally save to file.
 

--- a/garden_ai/mcp/mlip.py
+++ b/garden_ai/mcp/mlip.py
@@ -1,0 +1,116 @@
+import json
+from pathlib import Path
+
+from mcp.server.fastmcp.exceptions import ToolError
+
+# Global singleton for MLIP Garden to maintain job context across tool calls
+_mlip_garden = None
+
+
+def get_mlip_garden():
+    """
+    Lazy initialization of MLIP Garden singleton to maintain job context.
+    """
+    global _mlip_garden
+    if _mlip_garden is None:
+        import garden_ai
+
+        _mlip_garden = garden_ai.get_garden("mlip-garden")
+    return _mlip_garden
+
+
+def submit_relaxation_job(xyz_file_path: str, model: str = "mace-mp-0"):
+    """
+    Submit an XYZ structure file for relaxation on the Edith HPC cluster using the MLIP Garden.
+
+    Args:
+        xyz_file_path: Path to the XYZ file containing structures to relax
+        model: The ML interatomic potential model to use (default: "mace-mp-0")
+
+    Returns:
+        job_id: The job ID for tracking the submitted job
+    """
+    try:
+        xyz_file = Path(xyz_file_path)
+        if not xyz_file.exists():
+            raise ToolError(f"XYZ file not found: {xyz_file_path}")
+
+        # Edith HPC cluster endpoint ID
+        edith_ep_id = "a01b9350-e57d-4c8e-ad95-b4cb3c4cd1bb"
+
+        # Use singleton MLIP garden to maintain job context
+        mlip_garden = get_mlip_garden()
+        job_id = mlip_garden.batch_relax(xyz_file, model=model, cluster_id=edith_ep_id)
+
+        return {
+            "job_id": job_id,
+            "message": f"Successfully submitted relaxation job for {xyz_file_path}",
+            "model": model,
+            "cluster": "Edith",
+        }
+    except Exception as e:
+        raise ToolError(f"Failed to submit relaxation job: {e}")
+
+
+def check_job_status(job_id: str):
+    """
+    Check the status of a previously submitted relaxation job.
+
+    Args:
+        job_id: The job ID returned from submit_relaxation_job
+
+    Returns:
+        Status information for the job
+    """
+    try:
+        # Use singleton MLIP garden to access job context
+        mlip_garden = get_mlip_garden()
+        status = mlip_garden.get_job_status(job_id)
+
+        return {
+            "job_id": job_id,
+            "status": status,
+            "message": f"Job {job_id} status: {status}",
+        }
+    except Exception as e:
+        raise ToolError(f"Failed to check job status for {job_id}: {e}")
+
+
+def get_job_results(job_id: str, output_file_path: str = None):
+    """
+    Retrieve the results of a completed relaxation job and optionally save to file.
+
+    Args:
+        job_id: The job ID returned from submit_relaxation_job
+        output_file_path: Optional path to save the results to a file
+
+    Returns:
+        The job results, and confirmation if saved to file
+    """
+    try:
+        # Use singleton MLIP garden to access job context
+        mlip_garden = get_mlip_garden()
+        results = mlip_garden.get_results(job_id)
+
+        response = {"job_id": job_id, "results": results}
+
+        # Optionally save results to file
+        if output_file_path:
+            output_path = Path(output_file_path)
+
+            # Create parent directories if they don't exist
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+
+            # Save results as JSON
+            with open(output_path, "w") as f:
+                json.dump(results, f, indent=2, default=str)
+
+            response["saved_to"] = str(output_path)
+            response["message"] = f"Results retrieved and saved to {output_path}"
+        else:
+            response["message"] = f"Results retrieved for job {job_id}"
+
+        return response
+
+    except Exception as e:
+        raise ToolError(f"Failed to get results for job {job_id}: {e}")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,10 +1,8 @@
 # flake8: noqa: F841
 import os
-from unittest.mock import Mock, patch
 
 import pytest
 from globus_compute_sdk import Client  # type: ignore
-from globus_compute_sdk.sdk.login_manager.manager import LoginManager  # type: ignore
 from globus_sdk import (
     AuthAPIError,
     AuthLoginClient,


### PR DESCRIPTION
part of #596 and #591

## Overview

this is a quick copy/paste of the tools from [globus-labs/science-mcps](https://github.com/globus-labs/science-mcps/tree/main/mcps/garden) that got claude to successfully submit batch relaxation on edith. 


I haven't tested this yet, because I do not currently have an allocation on edith 

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--597.org.readthedocs.build/en/597/

<!-- readthedocs-preview garden-ai end -->