### PR TITLE
MCP search/summarize functionality

### DIFF
--- a/garden_ai/mcp/server.py
+++ b/garden_ai/mcp/server.py
@@ -109,7 +109,7 @@ def search_gardens(
     contributors: list[str] | None = None,
     year: str | None = None,
     owner_uuid: str | None = None,
-    limit: int = 1,
+    limit: int = 20,
 ) -> str:
     """
     Search for gardens by doi and/or tags, returns at most limit gardens.
@@ -125,7 +125,25 @@ def search_gardens(
             owner_uuid=owner_uuid,
             limit=limit,
         )
-        result = [garden.metadata.model_dump(mode="json") for garden in response]
+        result = [
+            garden.metadata.model_dump(
+                mode="json", include={"doi", "title", "description", "tags"}
+            )
+            for garden in response
+        ]
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        return f"error: {e}"
+
+
+@mcp.tool()
+def summarize_garden(doi: str) -> str:
+    """
+    Fully summarize garden by doi
+    """
+    try:
+        response = GardenClient().backend_client.get_garden(doi)
+        result = response.metadata.model_dump(mode="json")
         return json.dumps(result, indent=2)
     except Exception as e:
         return f"error: {e}"

--- a/garden_ai/mcp/server.py
+++ b/garden_ai/mcp/server.py
@@ -159,7 +159,7 @@ def get_garden_metadata(doi: str) -> str:
 
         if response.modal_functions:
             metadata["modal_functions"] = [
-                mf.metadata.function_name.model_dump()
+                mf.metadata.function_name
                 for mf in response.modal_functions
             ]
         elif response.modal_classes:

--- a/garden_ai/mcp/server.py
+++ b/garden_ai/mcp/server.py
@@ -159,13 +159,14 @@ def get_garden_metadata(doi: str) -> str:
 
         if response.modal_functions:
             metadata["modal_functions"] = [
-                mf.metadata.function_name for mf in response.modal_functions
+                mf.metadata.function_name.model_dump()
+                for mf in response.modal_functions
             ]
         elif response.modal_classes:
             metadata["modal_functions"] = []
             for modal_class in response.modal_classes:
                 for method in modal_class._methods.values():
-                    metadata["modal_functions"].append(method.metadata.model_dump())
+                    metadata["modal_functions"].append(method.metadata.function_name)
         else:
             metadata["modal_functions"] = []
 

--- a/garden_ai/mcp/server.py
+++ b/garden_ai/mcp/server.py
@@ -1,15 +1,16 @@
 import logging
+import requests
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
 
 from garden_ai import GardenClient
+from garden_ai.constants import GardenConstants
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 mcp = FastMCP("garden-mcp-server")
-
 
 @mcp.tool()
 def echo(message: str) -> str:
@@ -83,6 +84,28 @@ try:
 
 except ImportError:
     pass
+
+@mcp.tool()
+def search_gardens(
+    doi: str | None = None,
+    tags: list[str] | None = None,
+    limit: int = 1
+) -> str:
+    params = {}
+
+    if doi is not None:
+        params['doi'] = doi
+    if tags is not None:
+
+        params['tags'] = tags
+    params['limit'] = limit
+
+    try:
+        response = requests.get(GardenConstants.GARDEN_ENDPOINT, params=params)
+
+        return response.text
+    except Exception as e:
+        return f"error: {e}"
 
 
 def main():

--- a/garden_ai/mcp/server.py
+++ b/garden_ai/mcp/server.py
@@ -159,8 +159,7 @@ def get_garden_metadata(doi: str) -> str:
 
         if response.modal_functions:
             metadata["modal_functions"] = [
-                mf.metadata.function_name
-                for mf in response.modal_functions
+                mf.metadata.function_name for mf in response.modal_functions
             ]
         elif response.modal_classes:
             metadata["modal_functions"] = []

--- a/garden_ai/mcp/server.py
+++ b/garden_ai/mcp/server.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 mcp = FastMCP("garden-mcp-server")
 
+
 @mcp.tool()
 def echo(message: str) -> str:
     """
@@ -84,6 +85,7 @@ try:
 except ImportError:
     pass
 
+
 @mcp.tool()
 def search_gardens(
     dois: list[str] | None = None,
@@ -107,9 +109,9 @@ def search_gardens(
             contributors=contributors,
             year=year,
             owner_uuid=owner_uuid,
-            limit=limit
+            limit=limit,
         )
-        result = [garden.metadata.model_dump(mode='json') for garden in response]
+        result = [garden.metadata.model_dump(mode="json") for garden in response]
         return json.dumps(result, indent=2)
     except Exception as e:
         return f"error: {e}"

--- a/garden_ai/mcp/server.py
+++ b/garden_ai/mcp/server.py
@@ -133,7 +133,7 @@ def search_gardens(
 
             if garden.modal_functions:
                 data["modal_functions"] = [
-                    mf.metadata.funciton_name for mf in garden.modal_functions
+                    mf.metadata.function_name for mf in garden.modal_functions
                 ]
             elif garden.modal_classes:
                 data["modal_functions"] = []


### PR DESCRIPTION
#596 

## Overview
This PR adds three mcp tools to the stdio based mcp server (search_gardens, get_garden_metadata, search_functions). These three tools allow for mcp clients like Claude to search through gardens based on different query parameters. The search garden functionality is split up into two tools to avoid size limit issues I was seeing when Claude would pull all the metadata for a garden(s) all at once. The normal flow for this would be user asks Claude for garden based on some parameters -> search_gardens -> user wants to know more about garden that was found/what functions available -> get_garden_metadata/search_functions

## Testing
Tested manually with Claude

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--598.org.readthedocs.build/en/598/

<!-- readthedocs-preview garden-ai end -->