### PR TITLE
first pass at invoke_function tool

### DIFF
--- a/garden_ai/mcp/README.md
+++ b/garden_ai/mcp/README.md
@@ -66,11 +66,15 @@ To include the bespoke `submit_relaxation_job`, `check_job_status` and `get_job_
       "command": "uv",
       "args": [
         "run",
+        "--no-cache",
         "--with",
         "/path/to/local/repo/garden[mcp]",
         "garden-ai",
         "mcp"
-      ]
+      ],
+      "env": {
+        "GARDEN_ENV":"dev"
+      }
     }
   }
 }


### PR DESCRIPTION
## Overview

This is a first pass at one of the two ways we're thinking about enabling function invocation.

## Discussion

**The problem**: An LLM is only able to send str arguments to a tool, which makes it tricky for the LLM to invoke a function that expects e.g. an `Atoms` object or a `dict`. 

Two approaches to the problem:
  - (less clever) only worry about functions which accept plain str data (or dicts we read with `json.loads`). When attempting to invoke e.g. functions needing `Atoms`, just respond with a helpful error message
  - (more "clever") have the LLM generate "preprocessing code" for the str data and `exec` it to build the complex argument types the function expects

This is the less clever approach. If we can get the code generation tool to reliably come up with sane code we can try the second approach (or some combination of the two) but this is a safer bet to get something demo-worthy.

Another design question for this is how we want to handle inputs which are file paths and not raw input data -- I have a feeling that the fewer tools we expose the better, so the first pass tries to read from a file first, then tries to parse as json, then falls back to raw str inputs. 

This also doesn't (yet?) worry about invocations with more than one arg/kwargs. 

## Testing
TBD 
## Documentation
no docs 

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--600.org.readthedocs.build/en/600/

<!-- readthedocs-preview garden-ai end -->