### PR TITLE
Add cloud functions to MLIP garden

### DIFF
--- a/garden_ai/hpc_gardens/mlip_garden.py
+++ b/garden_ai/hpc_gardens/mlip_garden.py
@@ -40,11 +40,25 @@ class MLIPGarden(Garden):
         super().__init__(metadata=metadata)
 
     def relax(
+        self,
         xyz_file_path: str | Path | None = None,
         xyz_string: str | None = None,
-        model: str = "mace-mp-0",
+        model: str = "mace",
         options: dict = {},
     ):
+        cloud_mlip_garden = self.client.get_garden("10.26311/qs92-3t67")
+        models_to_class_name = {
+            "mace": "MACE",
+            "orb": "ORB",
+            "fairchem": "FAIRCHEM",
+            "mattersim": "MATTERSIM",
+            "sevennet": "SEVENNET",
+        }
+        class_name = models_to_class_name.get(model, None)
+        cls = getattr(cloud_mlip_garden, class_name, None)
+        if cls is None:
+            raise ValueError(f"Model {model} not found")
+        cls.relax(xyz_file_path, xyz_string, options)
         pass
 
     def run_relaxation(

--- a/garden_ai/hpc_gardens/mlip_garden.py
+++ b/garden_ai/hpc_gardens/mlip_garden.py
@@ -39,6 +39,14 @@ class MLIPGarden(Garden):
         )
         super().__init__(metadata=metadata)
 
+    def relax(
+        xyz_file_path: str | Path | None = None,
+        xyz_string: str | None = None,
+        model: str = "mace-mp-0",
+        options: dict = {},
+    ):
+        pass
+
     def run_relaxation(
         self, atoms, model: str = "mace-mp-0", cluster_id: str | None = None
     ):

--- a/garden_ai/hpc_gardens/mlip_garden.py
+++ b/garden_ai/hpc_gardens/mlip_garden.py
@@ -58,8 +58,20 @@ class MLIPGarden(Garden):
         cls = getattr(cloud_mlip_garden, class_name, None)
         if cls is None:
             raise ValueError(f"Model {model} not found")
-        cls.relax(xyz_file_path, xyz_string, options)
-        pass
+        # If we're given a file path, read the file into a string
+        if xyz_string is not None:
+            raw_input = xyz_string
+        elif xyz_file_path is not None:
+            try:
+                with open(xyz_file_path, "r") as f:
+                    raw_input = f.read()
+            except Exception as e:
+                raise ValueError(f"Could not read {xyz_file_path}: {e}")
+        else:
+            raise ValueError("No input provided")
+
+        raw_output = cls.relax(raw_input)
+        return raw_output
 
     def run_relaxation(
         self, atoms, model: str = "mace-mp-0", cluster_id: str | None = None


### PR DESCRIPTION
Closes #591. This PR adds the ability to run relaxation with 5 different MLIPs (Versions of MACE, Orb, Mattersim, Sevennet, and FairChem) on demand. 

This is an MVP of the interface. I need to add optional parameters, be more specific about the exact checkpoints being used and much more. But this is a start!

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--613.org.readthedocs.build/en/613/

<!-- readthedocs-preview garden-ai end -->