### PR TITLE
Remove uncallable MLIPs

### DIFF
--- a/garden_ai/hpc_gardens/mlip_garden.py
+++ b/garden_ai/hpc_gardens/mlip_garden.py
@@ -47,8 +47,6 @@ class MLIPGarden(Garden):
         cloud_mlip_garden = self.client.get_garden("10.26311/qs92-3t67")
         models_to_class_name = {
             "mace": "MACE",
-            "orb": "ORB",
-            "fairchem": "FAIRCHEM",
             "mattersim": "MATTERSIM",
             "sevennet": "SEVENNET",
         }


### PR DESCRIPTION
Small maintenance PR. We're not including ORB and FairChem in the initial rollout, so removing from the MLIP garden.


<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--617.org.readthedocs.build/en/617/

<!-- readthedocs-preview garden-ai end -->