### PR TITLE
Search enhancements

### DIFF
--- a/garden_ai/backend_client.py
+++ b/garden_ai/backend_client.py
@@ -147,3 +147,8 @@ class BackendClient:
             "/modal-invocations/blob-uploads", payload.model_dump(mode="json")
         )
         return ModalBlobUploadURLResponse(**response)
+
+    def get_valid_tags(self) -> list[str]:
+        result = self._get("/gardens/tags")
+
+        return result

--- a/garden_ai/backend_client.py
+++ b/garden_ai/backend_client.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Callable
+from typing import Callable, Any
 
 import requests
 
@@ -148,7 +148,7 @@ class BackendClient:
         )
         return ModalBlobUploadURLResponse(**response)
 
-    def get_valid_tags(self) -> list[str]:
+    def get_valid_tags(self) -> dict[str, Any]:
         result = self._get("/gardens/tags")
 
         return result

--- a/garden_ai/mcp/server.py
+++ b/garden_ai/mcp/server.py
@@ -144,9 +144,9 @@ def search_gardens(
         )
 
         if tags and not response:
-            response = GardenClient().backend_client.get_valid_tags()
+            valid_tags = GardenClient().backend_client.get_valid_tags()
             raise ToolError(
-                f"Using invalid tags. These are all the valid tags: {response}",
+                f"Using invalid tags. These are all the valid tags: {valid_tags}",
                 "Retry again with valid tags.",
             )
 

--- a/garden_ai/mcp/server.py
+++ b/garden_ai/mcp/server.py
@@ -133,7 +133,6 @@ def search_gardens(
 ) -> str:
     """
     Search for gardens based on doi, tags, contributors, returns at most limit gardens.
-    Instructions for mcp client: If you are going to use tags to search first use get_valid_tags tool.
     """
     try:
         response = GardenClient().backend_client.get_gardens(
@@ -174,14 +173,6 @@ def search_gardens(
         return json.dumps(result)
     except Exception as e:
         raise ToolError(f"Error searching for garden: {e}")
-
-
-@mcp.tool(
-    description="Resource to obtain list of valid tag values for the search_gardens tool"
-)
-def get_valid_tags() -> dict[str, Any]:
-    response = GardenClient().backend_client.get_valid_tags()
-    return {"valid_tags": response}
 
 
 @mcp.tool()


### PR DESCRIPTION
#599 
Dependent on Garden-AI/garden-backend#358

## Overview

This PR makes two enhancements to the search tool. The first is removing unnecessary search parameters that mcp clients are unlikely to be able to utilize such as `year` or `draft`. The second enhancement aims to make the `tags` search parameter more useful by supplying all the valid possible values for a tag. This is done by making a call to the backend at a new route (Garden-AI/garden-backend#358) if invalid tag(s) are used and an empty response is returned because of it.

## Testing

Testing manually with Claude



<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--619.org.readthedocs.build/en/619/

<!-- readthedocs-preview garden-ai end -->