### PR TITLE
Add mattersim, sevennet, mace to Edith MLIP garden

### DIFF
--- a/garden_ai/hpc_executors/edith_executor.py
+++ b/garden_ai/hpc_executors/edith_executor.py
@@ -11,10 +11,10 @@ from garden_ai.hpc_gardens.utils import subproc_wrapper  # noqa:
 EDITH_EP_ID = "a01b9350-e57d-4c8e-ad95-b4cb3c4cd1bb"
 
 DEFAULT_CONFIG = {
-    "worker_init": """
+    "worker_init": """true;
 module load openmpi
 export PATH=$PATH:/usr/sbin
-    """,
+""",
 }
 
 
@@ -48,6 +48,18 @@ class EdithExecutor(Executor):
         """
         # submit the function the to gcmu exector
         func_source = inspect.getsource(func)
+
+        # Determine conda environment based on model parameter (3rd positional arg)
+        model = args[2] if len(args) >= 3 else ""
+        conda_env = (
+            "torch-sim-edith-mace"
+            if str(model).startswith("mace")
+            else "torch-sim-edith"
+        )
+
+        # Add conda_env to kwargs for subproc_wrapper
+        kwargs["conda_env"] = conda_env
+
         fut = super().submit(subproc_wrapper, func_source, *args, **kwargs)
         return fut
 

--- a/garden_ai/hpc_gardens/utils.py
+++ b/garden_ai/hpc_gardens/utils.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+import time
+
+from globus_compute_sdk.sdk.asynchronous.compute_future import ComputeFuture
 
 
 FIVE_MB = 5 * 1000 * 1000
@@ -53,6 +56,8 @@ def subproc_wrapper(func_source, *args, **kwargs):
         return {"error": "Could not extract function name from source"}
 
     func_name = func_name_match.group(1)
+    conda_env = kwargs.pop("conda_env", "torch-sim-edith")
+    env_path_str = f"/home/hholb/.conda/envs/{conda_env}"
 
     # Function data to execute
     func_data = {
@@ -95,7 +100,7 @@ print("RESULT_DATA:", result_data)
             "conda",
             "run",
             "-p",
-            "/home/hholb/.conda/envs/torch-sim-edith",
+            env_path_str,
             "python",
             script_path,
         ]
@@ -127,3 +132,16 @@ print("RESULT_DATA:", result_data)
         "stdout": result.stdout,
         "stderr": result.stderr,
     }
+
+
+def wait_for_task_id(future: ComputeFuture, timeout: int = 60) -> str:
+    """Waits for a globus-compute task ID to become available, with a timeout."""
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        task_id = future.task_id
+        if task_id:
+            return task_id
+        time.sleep(0.5)
+    raise TimeoutError(
+        f"Could not get task ID from globus-compute within {timeout} seconds."
+    )

--- a/garden_ai/hpc_gardens/utils.py
+++ b/garden_ai/hpc_gardens/utils.py
@@ -56,7 +56,7 @@ def subproc_wrapper(func_source, *args, **kwargs):
         return {"error": "Could not extract function name from source"}
 
     func_name = func_name_match.group(1)
-    conda_env = kwargs.pop("conda_env", "torch-sim-edith")
+    conda_env = kwargs.pop("conda_env", "torch-sim-edith-mace")
     env_path_str = f"/home/hholb/.conda/envs/{conda_env}"
 
     # Function data to execute


### PR DESCRIPTION
Resolves #616 

## Overview

This PR adds model initialization logic for mattersim, sevennet, and mace to the MLIPs running on Edith. Now users can pass these model names to the `batch_relax` function:
```
import garden_ai

edith_ep_id = "<edith_id>"
my_atoms  = "./path_to_atoms.xyz"

g = garden_ai.get_garden("mlip-garden")

job_id = g.batch_relax(my_atoms, model="mace", cluster_id=edith_ep_id)
job_id = g.batch_relax(my_atoms, model="sevennet", cluster_id=edith_ep_id)
job_id = g.batch_relax(my_atoms, model="mattersim", cluster_id=edith_ep_id)

# poll for status, fetch results...
```

## Discussion

Pulled the model initialization code from: https://github.com/Garden-AI/uploadathon/blob/main/MLIPs/mlip_garden.py

Ineeded to create a separate conda env for MACE on Edith called 'torch-sim-edith-mace'. The `EdithExecutor` handles choosing the correct conda env based on the model parameter to `batch_relax`, so users don't need to know there is a difference.

I also added a `wait_for_task_id` helper function that fixes a potential infinite loop waiting for a task_id from globus-compute.

### Next Steps
- Revisit the actual relaxation script to better match what is in https://github.com/Garden-AI/uploadathon/blob/main/MLIPs/mlip_garden.py

## Testing

Manually tested each of the new models on a test xyz file.



<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--620.org.readthedocs.build/en/620/

<!-- readthedocs-preview garden-ai end -->