### PR TITLE
Integrate cloud relaxation logic with HPC relaxation flow

### DIFF
--- a/garden_ai/hpc_gardens/mlip_garden.py
+++ b/garden_ai/hpc_gardens/mlip_garden.py
@@ -263,25 +263,29 @@ def _run_batch_computation(
     model,
     max_batch_size,
     computation_type,
+    optimizer_str: str = "frechet_cell_fire",
+    dtype_str: str = "float64",
 ):
     """
     Generic function to run batch computations (relaxation or MD) on multiple
-    structures, saving results incrementally.
+    structures, saving results incrementally with intelligent batching.
 
     Args:
         xyz_content: String content of XYZ file.
         xyz_filename: Original filename for output naming.
         model: Model for the computation.
-        max_batch_size: Number of structures per batch.
+        max_batch_size: Maximum number of structures per batch (used as fallback).
         computation_type: 'relaxation' or 'md'.
+        optimizer_str: Optimizer to use for relaxation ('frechet_cell_fire' or 'fire').
+        dtype_str: Data type string ('float64' or 'float32').
 
     Returns:
         The content of the results XYZ file.
     """
     import os
-    import tempfile
     import uuid
     from pathlib import Path
+    from io import StringIO
 
     # Fix NUMEXPR threading issue early, before any imports that might use it
     os.environ["NUMEXPR_MAX_THREADS"] = "256"
@@ -291,16 +295,11 @@ def _run_batch_computation(
     import torch
     import torch_sim as ts
     from ase.io import read, write  # type: ignore[import-not-found]
+    from torch_sim.runners import generate_force_convergence_fn
 
-    # Write XYZ content to a temporary file on remote endpoint
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".xyz", delete=False
-    ) as temp_file:
-        temp_file.write(xyz_content)
-        temp_xyz_path = temp_file.name
-
-    # Read structures from temporary xyz file
-    all_atoms = read(temp_xyz_path, index=":")
+    # Parse xyz content using StringIO to match _perform_batch_relaxation pattern
+    string_file = StringIO(xyz_content)
+    all_atoms = read(string_file, index=":", format="extxyz")
     num_structures = len(all_atoms)
 
     # Create results file path
@@ -310,13 +309,29 @@ def _run_batch_computation(
     results_path = input_path.parent / results_filename
 
     print(f"📝 Results will be saved to: {results_path}")
-    print(
-        f"🚀 Starting batch {computation_type} of {num_structures} structures in batches of {max_batch_size}..."
-    )
+    print(f"🚀 Starting batch {computation_type} of {num_structures} structures...")
 
-    # Set up device and model
+    # Set up device and resolve dtype
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    dtype = torch.float64
+    if dtype_str == "float64":
+        torch_dtype = torch.float64
+    elif dtype_str == "float32":
+        torch_dtype = torch.float32
+    else:
+        raise ValueError(f"Unsupported dtype string: {dtype_str}")
+
+    # Resolve optimizer for relaxation
+    if computation_type == "relaxation":
+        if optimizer_str == "frechet_cell_fire":
+            optimizer_builder = ts.frechet_cell_fire
+            optimize_kwargs = {
+                "convergence_fn": generate_force_convergence_fn(force_tol=0.05)
+            }
+        elif optimizer_str == "fire":
+            optimizer_builder = ts.optimizers.fire
+            optimize_kwargs = {}
+        else:
+            raise ValueError(f"Unsupported optimizer string: {optimizer_str}")
 
     def load_torch_sim_model(model_name: str, device: str = "cpu", dtype=None):
         """Load a torch-sim model by name."""
@@ -377,55 +392,164 @@ def _run_batch_computation(
         else:
             raise ValueError(f"Unknown model: {model_name}")
 
-    torch_sim_model = load_torch_sim_model(model, device, dtype)
+    torch_sim_model = load_torch_sim_model(model, device, torch_dtype)
 
+    # Extract material IDs (create if not present) and atom counts
+    mat_ids = []
+    for idx, atoms in enumerate(all_atoms):
+        if "material_id" in atoms.info:
+            mat_ids.append(atoms.info["material_id"])
+        else:
+            mat_id = f"material_{idx}"
+            atoms.info["material_id"] = mat_id
+            mat_ids.append(mat_id)
+
+    atom_counts = [len(atoms) for atoms in all_atoms]
+
+    print(f"  - Found {len(all_atoms)} materials")
+    print(f"  - Atom count range: {min(atom_counts)} - {max(atom_counts)}")
+
+    # Create lists for each size category with (index, atoms, mat_id) tuples
+    small_materials = []  # <10 atoms
+    medium_materials = []  # 10-19 atoms
+    large_materials = []  # 20+ atoms
+
+    for idx, (atoms, mat_id, n_atoms) in enumerate(
+        zip(all_atoms, mat_ids, atom_counts)
+    ):
+        material_data = (idx, atoms, mat_id)
+        if n_atoms < 10:
+            small_materials.append(material_data)
+        elif n_atoms < 20:
+            medium_materials.append(material_data)
+        else:
+            large_materials.append(material_data)
+
+    print("\n📊 Size distribution:")
+    print(f"  - Small (<10 atoms): {len(small_materials)} materials")
+    print(f"  - Medium (10-19 atoms): {len(medium_materials)} materials")
+    print(f"  - Large (20+ atoms): {len(large_materials)} materials")
+
+    # Define batch sizes for each category
+    batch_sizes = {"small": 80, "medium": 40, "large": 16}
+
+    # Track results for proper ordering
+    all_results = []
     has_written = False
-    for i in range(0, num_structures, max_batch_size):
-        batch_atoms = all_atoms[i : i + max_batch_size]
+
+    def process_category(materials, category_name, batch_size):
+        """Process all materials in a size category."""
+        nonlocal has_written
+
+        if not materials:
+            print("nothing in " + category_name)
+            return
+
+        n_batches = (len(materials) + batch_size - 1) // batch_size
         print(
-            f"⚙️ Processing batch {i//max_batch_size + 1}/{(num_structures + max_batch_size - 1)//max_batch_size}..."
+            f"\n🔄 Processing {category_name} materials: {len(materials)} materials in {n_batches} batches"
         )
 
-        initial_state = ts.initialize_state(batch_atoms, device=device, dtype=dtype)
+        for batch_idx in range(n_batches):
+            start_idx = batch_idx * batch_size
+            end_idx = min((batch_idx + 1) * batch_size, len(materials))
+            batch_materials = materials[start_idx:end_idx]
 
-        if computation_type == "relaxation":
-            result_state = ts.optimize(
-                system=initial_state,
-                model=torch_sim_model,
-                optimizer=ts.frechet_cell_fire,
-                max_steps=200,
-                autobatcher=True,
-                convergence_fn=ts.runners.generate_force_convergence_fn(
-                    force_tol=0.05, include_cell_forces=False
-                ),
+            batch_atoms = [item[1] for item in batch_materials]
+            batch_mat_ids = [item[2] for item in batch_materials]
+            batch_original_indices = [item[0] for item in batch_materials]
+
+            print(
+                f"  - Batch {batch_idx + 1}/{n_batches}: {len(batch_atoms)} materials"
             )
-        elif computation_type == "md":
-            result_state = ts.integrate(
-                system=initial_state,
-                model=torch_sim_model,
-                integrator=ts.integrators.nvt_langevin,
-                n_steps=50,
-                timestep=0.002,
-                temperature=1000,
-                autobatcher=True,
+
+            # Initialize state
+            initial_state = ts.initialize_state(
+                batch_atoms, device=device, dtype=torch_dtype
             )
-        else:
-            raise ValueError(f"Unknown computation_type: {computation_type}")
 
-        result_atoms_list = result_state.to_atoms()
-        final_energies = result_state.energy.cpu().tolist()
-
-        print(f"💾 Saving {len(result_atoms_list)} structures to {results_path}...")
-        for atoms, energy in zip(result_atoms_list, final_energies):
-            atoms.info["energy"] = energy
-            atoms.info["model"] = model
+            # Run computation
             if computation_type == "relaxation":
-                atoms.info["relaxed"] = True
-            write(results_path, atoms, append=has_written)
-            if not has_written:
-                has_written = True
 
+                def optimizer_callable(model, **_kwargs):
+                    return optimizer_builder(model, md_flavor="ase_fire")
+
+                result_state = ts.optimize(
+                    system=initial_state,
+                    model=torch_sim_model,
+                    optimizer=optimizer_callable,
+                    max_steps=500,
+                    **optimize_kwargs,
+                )
+            elif computation_type == "md":
+                result_state = ts.integrate(
+                    system=initial_state,
+                    model=torch_sim_model,
+                    integrator=ts.integrators.nvt_langevin,
+                    n_steps=50,
+                    timestep=0.002,
+                    temperature=1000,
+                    autobatcher=True,
+                )
+            else:
+                raise ValueError(f"Unknown computation_type: {computation_type}")
+
+            result_atoms_list = result_state.to_atoms()
+            energies_tensor = result_state.energy
+
+            # Ensure energies are always in a list
+            if energies_tensor.dim() == 0:
+                # This is a 0-d tensor, so convert to a list with one item
+                final_energies = [energies_tensor.item()]
+            else:
+                # This is a 1-d or higher tensor, tolist() works correctly
+                final_energies = energies_tensor.cpu().tolist()
+
+            # Also ensure the atoms list is always a list for consistency
+            if not isinstance(result_atoms_list, list):
+                result_atoms_list = [result_atoms_list]
+
+            batch_results = [
+                {
+                    "material_id": mat_id,
+                    "final_energy": energy,
+                    "relaxed_atoms": atoms,
+                    "original_index": orig_idx,
+                }
+                for mat_id, atoms, energy, orig_idx in zip(
+                    batch_mat_ids,
+                    result_atoms_list,
+                    final_energies,
+                    batch_original_indices,
+                )
+            ]
+            all_results.extend(batch_results)
+
+            # Write results incrementally in case job gets killed before it finishes
+            print(f"💾 Saving {len(result_atoms_list)} structures to {results_path}...")
+            for atoms, energy, mat_id in zip(
+                result_atoms_list, final_energies, batch_mat_ids
+            ):
+                atoms.info["energy"] = energy
+                atoms.info["final_energy"] = energy
+                atoms.info["material_id"] = mat_id
+                atoms.info["model"] = model
+                if computation_type == "relaxation":
+                    atoms.info["relaxed"] = True
+                write(results_path, atoms, append=has_written)
+                if not has_written:
+                    has_written = True
+
+    # Process each category
+    process_category(small_materials, "small", batch_sizes["small"])
+    process_category(medium_materials, "medium", batch_sizes["medium"])
+    process_category(large_materials, "large", batch_sizes["large"])
+
+    # Read final results content
     with open(results_path, "r") as f:
         results_content = f.read()
 
+    print(
+        f"\n✅ {computation_type.capitalize()} complete! Returning results for {num_structures} structures"
+    )
     return results_content


### PR DESCRIPTION
Part 2 of #616 -- shouldn't have closed it until now, but oh well.

## Overview

This PR combines the batching and relaxation logic from https://github.com/Garden-AI/uploadathon/blob/main/MLIPs/mlip_garden.py `_perform_batch_relaxation` with the model initialization and incremental output writing in the HPC relaxation flow.


## Testing

Manual testing with MatterSim, SevenNet, and MACE



<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--621.org.readthedocs.build/en/621/

<!-- readthedocs-preview garden-ai end -->