### PR TITLE
Edith fix: trick globus compute into creating new endpoints for each job

### DIFF
--- a/garden_ai/hpc_executors/edith_executor.py
+++ b/garden_ai/hpc_executors/edith_executor.py
@@ -11,7 +11,7 @@ from garden_ai.hpc_gardens.utils import subproc_wrapper  # noqa:
 EDITH_EP_ID = "a01b9350-e57d-4c8e-ad95-b4cb3c4cd1bb"
 
 DEFAULT_CONFIG = {
-    "worker_init": """true;
+    "worker_init": """
 module load openmpi
 export PATH=$PATH:/usr/sbin
 """,
@@ -26,6 +26,16 @@ class EdithExecutor(Executor):
         user_endpoint_config=DEFAULT_CONFIG,
         **kwargs,
     ):
+        # vary the user_endpoint_config to try to force separate PBS jobs
+        if "user_endpoint_config" in kwargs and kwargs["user_endpoint_config"]:
+            import time
+
+            config = kwargs["user_endpoint_config"].copy()
+            # Add a unique comment to make each job "different"
+            if "worker_init" in config:
+                config["worker_init"] += f"\n# Job timestamp: {time.time()}"
+            kwargs["user_endpoint_config"] = config
+
         super().__init__(
             *args,
             endpoint_id=endpoint_id,

--- a/garden_ai/hpc_gardens/mlip_garden.py
+++ b/garden_ai/hpc_gardens/mlip_garden.py
@@ -217,8 +217,6 @@ class MLIPGarden(Garden):
         except (FileNotFoundError, ValueError) as e:
             raise RuntimeError(f"Failed to read XYZ file: {e}")
 
-        ex = EdithExecutor(endpoint_id=cluster_id)
-
         validated_params, validation_error = self.validate_relaxation_params(
             relaxation_options
         )
@@ -226,15 +224,16 @@ class MLIPGarden(Garden):
             raise ValueError(f"Invalid relaxation parameters: {validation_error}")
 
         # Pass file content and filename directly to the batch relaxation function
-        future = ex.submit(
-            _run_batch_computation,
-            file_content,
-            xyz_path.name,
-            model,
-            max_batch_size,
-            "relaxation",
-            validated_params,
-        )
+        with EdithExecutor(endpoint_id=cluster_id) as ex:
+            future = ex.submit(
+                _run_batch_computation,
+                file_content,
+                xyz_path.name,
+                model,
+                max_batch_size,
+                "relaxation",
+                validated_params,
+            )
         task_id = wait_for_task_id(future, task_id_timeout)
         return task_id
 
@@ -574,7 +573,7 @@ def _run_batch_computation(
     print(f"  - Large (20+ atoms): {len(large_materials)} materials")
 
     # Define batch sizes for each category
-    batch_sizes = {"small": 400, "medium": 250, "large": 50}
+    batch_sizes = {"small": 200, "medium": 100, "large": 25}
 
     # Track results for proper ordering
     all_results = []


### PR DESCRIPTION
## Overview

This PR fixes an issue we uncovered last week where subsequent batch relaxation jobs failed with confusing errors about missing files on the remote compute node.

This also bumps the batch sizes down a little to avoid out of memory errors SevenNet was hitting on large structures.

A quick summary of what this PR is meant to do.

## Discussion

So this was a bit tricky to solve. The bug we were seeing was triggered when calling `batch_relax` more than once in quick succession in the same python session. The first call would run fine, but subsequent calls would fail with errors like `Error: FileNotFound /var/PBS/<job-id>/generated_script.py` where the PBS job id would be the job id from the first job. Turns out this was as subtle behavior of globus-compute seeing that the PBS job from the first call was still alive and reusing it for subsequent calls. I think this is an optimization that makes sense when running short-lived functions to avoid scheduler queue times. But for our patterns we want subsequent calls to start new PBS jobs. The "fix" is to trick globus-compute to think each request has a "different" `worker_init` script which causes the multi-user endpoint to start a new user endpoint for each request, which in turn starts a new PBS job for each invocation. I do this by adding a comment string to the worker init script with a timestamp that doesn't do anything, but does make globus-compute think its a different endpoint config.

## Testing

Manual testing of multiple `batch_relax` calls on different models in the same python session while watching the PBS queue on Edith. I saw three separate jobs that all succeeded!
