### PR TITLE
Send hpc invocation logs to the backend

### DIFF
--- a/garden_ai/backend_client.py
+++ b/garden_ai/backend_client.py
@@ -7,6 +7,7 @@ import requests
 from garden_ai.constants import GardenConstants
 from garden_ai.gardens import Garden
 from garden_ai.schemas.garden import GardenMetadata
+from garden_ai.schemas.hpc import HpcInvocationCreateRequest
 from garden_ai.schemas.modal import (
     ModalBlobUploadURLRequest,
     ModalBlobUploadURLResponse,
@@ -152,3 +153,7 @@ class BackendClient:
         result = self._post("/gardens/search", payload=payload)
 
         return result
+
+    def create_hpc_invocation(self, payload: HpcInvocationCreateRequest) -> dict:
+        response = self._post("/hpc/invocations", payload.model_dump(mode="json"))
+        return response

--- a/garden_ai/gardens.py
+++ b/garden_ai/gardens.py
@@ -204,7 +204,7 @@ class Garden:
         for hpc_function_data in data.get("hpc_functions", []):
             hpc_fn_metadata = HpcFunctionMetadata(**hpc_function_data)
             metadata.hpc_function_ids += [hpc_fn_metadata.id]
-            hpc_functions.append(HpcFunction(hpc_fn_metadata))
+            hpc_functions.append(HpcFunction(hpc_fn_metadata, client))
 
         return cls(metadata, modal_functions, modal_classes, hpc_functions)
 

--- a/garden_ai/schemas/hpc.py
+++ b/garden_ai/schemas/hpc.py
@@ -29,3 +29,12 @@ class HpcFunctionMetadata(BaseModel):
     year: str | None = None
     authors: list[str] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list)
+
+
+class HpcInvocationCreateRequest(BaseModel):
+    """Request schema for creating an HPC invocation log."""
+
+    function_id: int
+    endpoint_gcmu_id: str
+    globus_task_id: str
+    user_endpoint_config: dict = Field(default_factory=dict)


### PR DESCRIPTION
Resolves: #638 

## Overview

This PR adds a request schema and logic to send invocation logs to the backend's `POST /hpc/invocations` route when user call `submit` on an HPC function
