### PR TITLE
fix: update edith config

### DIFF
--- a/garden_ai/hpc/executor.py
+++ b/garden_ai/hpc/executor.py
@@ -12,9 +12,10 @@ from garden_ai.hpc.utils import subproc_wrapper  # noqa:
 EDITH_EP_ID = "a01b9350-e57d-4c8e-ad95-b4cb3c4cd1bb"
 
 DEFAULT_CONFIG = {
-    "worker_init": """
-module load openmpi
-export PATH=$PATH:/usr/sbin
+    "worker_init": """true;
+module load openmpi;
+export PATH=/usr/mpi/gcc/openmpi-4.1.7rc1/bin:$PATH;
+export PATH=$PATH:/usr/sbin;
 """,
 }
 
@@ -74,17 +75,6 @@ class HpcExecutor(Executor):
         """
         # submit the function the to gcmu exector
         func_source = inspect.getsource(func)
-
-        # Determine conda environment based on model parameter (3rd positional arg)
-        model = args[2] if len(args) >= 3 else ""
-        conda_env = (
-            "torch-sim-edith-mace"
-            if str(model).startswith("mace")
-            else "torch-sim-edith"
-        )
-
-        # Add conda_env to kwargs for subproc_wrapper
-        kwargs["conda_env"] = conda_env
 
         fut = super().submit(subproc_wrapper, func_source, *args, **kwargs)
         return fut

--- a/garden_ai/hpc/gardens/mlip_garden.py
+++ b/garden_ai/hpc/gardens/mlip_garden.py
@@ -222,6 +222,15 @@ class MLIPGarden(Garden):
         if validation_error:
             raise ValueError(f"Invalid relaxation parameters: {validation_error}")
 
+        # Determine conda environment based on model
+        conda_env = (
+            "torch-sim-edith-mace"
+            if str(model).startswith("mace")
+            else "torch-sim-edith"
+        )
+
+        env_path = "/home/hholb/.conda/envs/" + conda_env
+
         # Pass file content and filename directly to the batch relaxation function
         with EdithExecutor(endpoint_id=cluster_id) as ex:
             future = ex.submit(
@@ -232,6 +241,7 @@ class MLIPGarden(Garden):
                 max_batch_size,
                 "relaxation",
                 validated_params,
+                conda_env_path=env_path,
             )
         task_id = wait_for_task_id(future, task_id_timeout)
         return task_id


### PR DESCRIPTION
This PR fixes an issue we started to see on Edith where we would get the "no non-PBS mpiexec" error.

Something changed on Edith that caused `module load openmpi` to no longer add the openmpi mpiexec binary to the PATH, so we need to do that manually in the worker init script. A key detail here is that we need to *prepend* the path to the openpi mpiexec, otherwise the worker finds the PBS mpiexec first and raises the error.

I also moved the conda env path building logic out of the executor and into the mlip garden since that seemed like a more sensible place for that logic to live.

Tested manually running some batch relaxations:
<img width="850" height="506" alt="image" src="https://github.com/user-attachments/assets/f57eebdf-d5ea-4608-a6c4-d694526d0eee" />


<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--642.org.readthedocs.build/en/642/

<!-- readthedocs-preview garden-ai end -->