### PR TITLE
docs: fix CLI typo

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -98,7 +98,7 @@ $ garden-ai mcp setup [OPTIONS]
 **Options**:
 
 * `--client TEXT`: &#x27;claude&#x27;, &#x27;claude code&#x27;, &#x27;gemini&#x27;, &#x27;cursor&#x27;, &#x27;windsurf&#x27;
-* `--path TEXT`: Path to initalize config file for any other mcp client
+* `--path TEXT`: Path to initialize config file for any other mcp client
 * `--help`: Show this message and exit.
 
 ### `garden-ai mcp serve`


### PR DESCRIPTION
## Problem
The generated CLI docs for the MCP config path option contain a typo: "initalize".

## Solution
Changed it to "initialize".

## Validation
- `git diff --check`
- `git grep -n -i 'initalize' -- docs/CLI.md` returned no matches\n\n## Confidence\nScore: 80/100\nCategory: docs/typo\n

<!-- readthedocs-preview garden-ai start -->
----
📚 Documentation preview 📚: https://garden-ai--660.org.readthedocs.build/en/660/

<!-- readthedocs-preview garden-ai end -->